### PR TITLE
putting the export worker db ops in a transaction

### DIFF
--- a/internal/api/export.go
+++ b/internal/api/export.go
@@ -22,10 +22,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/googlepartners/exposure-notifications/internal/database"
-	"github.com/googlepartners/exposure-notifications/internal/logging"
-	"github.com/googlepartners/exposure-notifications/internal/model"
-	"github.com/googlepartners/exposure-notifications/internal/storage"
+	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/logging"
+	"github.com/google/exposure-notifications-server/internal/model"
+	"github.com/google/exposure-notifications-server/internal/storage"
 )
 
 const (

--- a/internal/database/export.go
+++ b/internal/database/export.go
@@ -22,9 +22,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/googlepartners/exposure-notifications/internal/logging"
-	"github.com/googlepartners/exposure-notifications/internal/model"
-	"github.com/googlepartners/exposure-notifications/internal/storage"
+	"github.com/google/exposure-notifications-server/internal/logging"
+	"github.com/google/exposure-notifications-server/internal/model"
+	"github.com/google/exposure-notifications-server/internal/storage"
 
 	pgx "github.com/jackc/pgx/v4"
 )
@@ -436,7 +436,7 @@ func (db *DB) CompleteFileAndBatch(ctx context.Context, files []string, batchID 
 
 type joinedExportBatchFile struct {
 	filename    string
-	batchID     int
+	batchID     int64
 	count       int
 	fileStatus  string
 	batchStatus string
@@ -470,7 +470,7 @@ func (db *DB) DeleteFilesBefore(ctx context.Context, before time.Time) (count in
 	defer rows.Close()
 
 	bucket := os.Getenv(bucketEnvVar)
-	batchFileDeleteCounter := make(map[int]int)
+	batchFileDeleteCounter := make(map[int64]int)
 	for rows.Next() {
 		var f joinedExportBatchFile
 		err := rows.Scan(&f.batchID, &f.batchStatus, &f.filename, &f.count, &f.fileStatus)


### PR DESCRIPTION
Putting the add to export file and complete batch calls in a transaction. We assume that the worker can fail after completing partial work, which will result in another worker redo-ing the work. This change prevents the redo step from failing because of a duplicate insert into the table. 

New flow is
Repeat until no more keys {
 read maxKeys
put in file }
add entries for all files in ExportFile
mark the batch as complete in Export Batch