### PR TITLE
Split Cloud Build into explicit build and deploy builds.

### DIFF
--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -12,14 +12,17 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
+  - -P
   - ./cmd/export
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
+  - -P
   - ./cmd/federation-pull
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
+  - -P
   - ./cmd/federation
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
@@ -29,18 +32,10 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
+  - -P
   - ./cmd/wipeout-export
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
+  - -P
   - ./cmd/wipeout-exposure
-# Deploy to Cloud Run.
-- name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: 'bash'
-  args:
-  - '-c'
-  # `--platform managed` and `--no-traffic` only works in `alpha`
-  - |
-    gcloud alpha run deploy exposure --image \
-      us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/exposure:latest --region us-central1 \
-      --platform managed --update-labels=env=staging --no-traffic

--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -1,0 +1,51 @@
+options:
+  env:
+  - 'KO_DOCKER_REPO=us.gcr.io/${PROJECT_ID}'
+  - 'DOCKER_REPO_OVERRIDE=us.gcr.io/${PROJECT_ID}'
+steps:
+# Tests
+- name: 'mirror.gcr.io/library/golang'
+  env:
+  - GO111MODULE=on
+  args: ['go', 'test', './...']
+# Build and publish containers`
+- name: 'gcr.io/$PROJECT_ID/ko'
+  args:
+  - publish
+  - -P
+  - ./cmd/export
+- name: 'gcr.io/$PROJECT_ID/ko'
+  args:
+  - publish
+  - -P
+  - ./cmd/federation-pull
+- name: 'gcr.io/$PROJECT_ID/ko'
+  args:
+  - publish
+  - -P
+  - ./cmd/federation
+- name: 'gcr.io/$PROJECT_ID/ko'
+  args:
+  - publish
+  - -P
+  - ./cmd/exposure
+- name: 'gcr.io/$PROJECT_ID/ko'
+  args:
+  - publish
+  - -P
+  - ./cmd/wipeout-export
+- name: 'gcr.io/$PROJECT_ID/ko'
+  args:
+  - publish
+  - -P
+  - ./cmd/wipeout-exposure
+# Deploy to Cloud Run.
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  # `--platform managed` and `--no-traffic` only works in `alpha`
+  - |
+    gcloud alpha run deploy exposure --image \
+      us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/exposure:latest --region us-central1 \
+      --platform managed --update-labels=env=staging --no-traffic


### PR DESCRIPTION
The build can be wired up to `master` while the deploy can be manually
triggered or wired up to a `release.*` branch pattern to support a
branch based release workflow.

Tested:
  * `gcloud builds submit --config builders/build.yaml`
  * `gcloud builds submit --config builders/deploy.yaml`
