### PR TITLE
fix bad logger calls

### DIFF
--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -50,14 +50,14 @@ func New(db *database.DB) *Config {
 
 	if ds := os.Getenv("CONFIG_REFRESH_DURATION"); ds != "" {
 		if d, err := time.ParseDuration(ds); err != nil {
-			logger.Info("CONFIG_REFRESH_DURATION parse error: %v", defaultRefreshPeriod)
+			logger.Infof("CONFIG_REFRESH_DURATION parse error: %v", defaultRefreshPeriod)
 		} else {
 			cfg.refreshPeriod = d
 		}
 	}
 
 	if cfg.refreshPeriod > time.Minute*5 {
-		logger.Warn("config refresh duration is > 5 minutes: %v", cfg.refreshPeriod)
+		logger.Warnf("config refresh duration is > 5 minutes: %v", cfg.refreshPeriod)
 	}
 
 	return cfg

--- a/internal/serverenv/env.go
+++ b/internal/serverenv/env.go
@@ -41,7 +41,7 @@ func New(ctx context.Context) *ServerEnv {
 	if override := os.Getenv(portEnvVar); override != "" {
 		env.port = override
 	}
-	logger.Info("using port %v (override with $%v)", env.port, portEnvVar)
+	logger.Infof("using port %v (override with $%v)", env.port, portEnvVar)
 
 	return env
 }


### PR DESCRIPTION
Add 'f' to logger calls that needed it