### PR TITLE
use errors.Is

### DIFF
--- a/internal/api/export/export.go
+++ b/internal/api/export/export.go
@@ -17,6 +17,7 @@ package export
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -63,7 +64,7 @@ func (s *BatchServer) CreateBatchesHandler(w http.ResponseWriter, r *http.Reques
 	lock := "create_batches"
 	unlockFn, err := s.db.Lock(ctx, lock, s.bsc.CreateTimeout) // TODO(jasonco): double this?
 	if err != nil {
-		if err == database.ErrAlreadyLocked {
+		if errors.Is(err, database.ErrAlreadyLocked) {
 			msg := fmt.Sprintf("Lock %s already in use. No work will be performed.", lock)
 			logger.Infof(msg)
 			w.Write([]byte(msg)) // We return status 200 here so that Cloud Scheduler does not retry.

--- a/internal/database/federation.go
+++ b/internal/database/federation.go
@@ -73,7 +73,7 @@ func (db *DB) AddFederationQuery(ctx context.Context, q *model.FederationQuery) 
 	err := db.inTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
 		existing := true
 		if _, err := getFederationQuery(ctx, q.QueryID, tx.QueryRow); err != nil {
-			if err == ErrNotFound {
+			if errors.Is(err, ErrNotFound) {
 				existing = false
 			} else {
 				return fmt.Errorf("getting existing federation query %s: %v", q.QueryID, err)

--- a/internal/storage/objects.go
+++ b/internal/storage/objects.go
@@ -17,6 +17,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -56,7 +57,7 @@ func DeleteObject(ctx context.Context, bucket, objectName string) error {
 	defer cancel()
 
 	if err := client.Bucket(bucket).Object(objectName).Delete(ctx); err != nil {
-		if err == storage.ErrObjectNotExist {
+		if errors.Is(err, storage.ErrObjectNotExist) {
 			// Object doesn't exist; presumably already deleted.
 			return nil
 		}


### PR DESCRIPTION
Use errors.Is in place of equality comparisons with sentinel errors.

This will allow the sentinel errors to be wrapped. It is also best
practice.