### PR TITLE
Write an index file to GCS at the end of an export batch

### DIFF
--- a/internal/api/federation/federation.go
+++ b/internal/api/federation/federation.go
@@ -140,6 +140,7 @@ func (s *federationServer) fetch(ctx context.Context, req *pb.FederationFetchReq
 			// Reached the end of the result set.
 			break
 		}
+		// Iterator may go one past before returning done==true.
 		if inf == nil {
 			continue
 		}

--- a/internal/database/export.go
+++ b/internal/database/export.go
@@ -51,14 +51,14 @@ func (db *DB) AddExportConfig(ctx context.Context, ec *model.ExportConfig) error
 		row := tx.QueryRow(ctx, `
 			INSERT INTO
 				ExportConfig
-				(filename_root, period_seconds, include_regions, exclude_regions, from_timestamp, thru_timestamp)
+				(filename_root, period_seconds, region, from_timestamp, thru_timestamp)
 			VALUES
-				($1, $2, $3, $4, $5, $6)
+				($1, $2, $3, $4, $5)
 			RETURNING config_id
-		`, ec.FilenameRoot, int(ec.Period.Seconds()), ec.IncludeRegions, ec.ExcludeRegions, ec.From, thru)
+		`, ec.FilenameRoot, int(ec.Period.Seconds()), ec.Region, ec.From, thru)
 
 		if err := row.Scan(&ec.ConfigID); err != nil {
-			return fmt.Errorf("fetching config_id: %v", err)
+			return fmt.Errorf("fetching config_id: %w", err)
 		}
 		return nil
 	})
@@ -76,13 +76,13 @@ type ExportConfigIterator interface {
 func (db *DB) IterateExportConfigs(ctx context.Context, now time.Time) (ExportConfigIterator, error) {
 	conn, err := db.pool.Acquire(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("acquiring connection: %v", err)
+		return nil, fmt.Errorf("acquiring connection: %w", err)
 	}
 	// We don't defer Release() here because the iterator's Close() method will do it.
 
 	rows, err := conn.Query(ctx, `
 		SELECT
-			config_id, filename_root, period_seconds, include_regions, exclude_regions, from_timestamp, thru_timestamp
+			config_id, filename_root, period_seconds, region, from_timestamp, thru_timestamp
 		FROM
 			ExportConfig
 		WHERE
@@ -109,7 +109,7 @@ func (i *postgresExportConfigIterator) Next() (*model.ExportConfig, bool, error)
 	var m model.ExportConfig
 	var periodSeconds int
 	var thru *time.Time
-	if err := i.iter.rows.Scan(&m.ConfigID, &m.FilenameRoot, &periodSeconds, &m.IncludeRegions, &m.ExcludeRegions, &m.From, &thru); err != nil {
+	if err := i.iter.rows.Scan(&m.ConfigID, &m.FilenameRoot, &periodSeconds, &m.Region, &m.From, &thru); err != nil {
 		return nil, false, err
 	}
 	m.Period = time.Duration(periodSeconds) * time.Second
@@ -126,10 +126,11 @@ func (i *postgresExportConfigIterator) Close() error {
 // LatestExportBatchEnd returns the end time of the most recent ExportBatch for
 // a given ExportConfig. It returns the zero time if no previous ExportBatch
 // exists.
+// TODO(jasonco): This needs a
 func (db *DB) LatestExportBatchEnd(ctx context.Context, ec *model.ExportConfig) (time.Time, error) {
 	conn, err := db.pool.Acquire(ctx)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("acquiring connection: %v", err)
+		return time.Time{}, fmt.Errorf("acquiring connection: %w", err)
 	}
 	defer conn.Release()
 
@@ -149,7 +150,7 @@ func (db *DB) LatestExportBatchEnd(ctx context.Context, ec *model.ExportConfig) 
 		if err == pgx.ErrNoRows {
 			return time.Time{}, nil
 		}
-		return time.Time{}, fmt.Errorf("scanning result: %v", err)
+		return time.Time{}, fmt.Errorf("scanning result: %w", err)
 	}
 	return latestEnd, nil
 }
@@ -161,9 +162,9 @@ func (db *DB) AddExportBatches(ctx context.Context, batches []*model.ExportBatch
 		_, err := tx.Prepare(ctx, stmtName, `
 			INSERT INTO
 				ExportBatch
-				(config_id, filename_root, start_timestamp, end_timestamp, include_regions, exclude_regions, status)
+				(config_id, filename_root, start_timestamp, end_timestamp, region, status)
 			VALUES
-				($1, $2, $3, $4, $5, $6, $7)
+				($1, $2, $3, $4, $5, $6)
 		`)
 		if err != nil {
 			return err
@@ -171,7 +172,7 @@ func (db *DB) AddExportBatches(ctx context.Context, batches []*model.ExportBatch
 
 		for _, eb := range batches {
 			if _, err := tx.Exec(ctx, stmtName,
-				eb.ConfigID, eb.FilenameRoot, eb.StartTimestamp, eb.EndTimestamp, eb.IncludeRegions, eb.ExcludeRegions, eb.Status); err != nil {
+				eb.ConfigID, eb.FilenameRoot, eb.StartTimestamp, eb.EndTimestamp, eb.Region, eb.Status); err != nil {
 				return err
 			}
 		}
@@ -186,7 +187,7 @@ func (db *DB) LeaseBatch(ctx context.Context, ttl time.Duration, now time.Time) 
 	err := func() error { // Use a func to allow defer conn.Release() to work.
 		conn, err := db.pool.Acquire(ctx)
 		if err != nil {
-			return fmt.Errorf("acquiring connection: %v", err)
+			return fmt.Errorf("acquiring connection: %w", err)
 		}
 		defer conn.Release()
 
@@ -213,7 +214,7 @@ func (db *DB) LeaseBatch(ctx context.Context, ttl time.Duration, now time.Time) 
 
 		for rows.Next() {
 			if err := rows.Err(); err != nil {
-				return fmt.Errorf("iterating rows: %v", err)
+				return fmt.Errorf("iterating rows: %w", err)
 			}
 
 			var id int64
@@ -291,7 +292,7 @@ func (db *DB) LeaseBatch(ctx context.Context, ttl time.Duration, now time.Time) 
 func (db *DB) LookupExportBatch(ctx context.Context, batchID int64) (*model.ExportBatch, error) {
 	conn, err := db.pool.Acquire(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("acquiring connection: %v", err)
+		return nil, fmt.Errorf("acquiring connection: %w", err)
 	}
 	defer conn.Release()
 
@@ -301,7 +302,7 @@ func (db *DB) LookupExportBatch(ctx context.Context, batchID int64) (*model.Expo
 func lookupExportBatch(ctx context.Context, batchID int64, queryRow queryRowFn) (*model.ExportBatch, error) {
 	row := queryRow(ctx, `
 		SELECT
-			batch_id, config_id, filename_root, start_timestamp, end_timestamp, include_regions, exclude_regions, status, lease_expires
+			batch_id, config_id, filename_root, start_timestamp, end_timestamp, region, status, lease_expires
 		FROM
 			ExportBatch
 		WHERE
@@ -310,7 +311,7 @@ func lookupExportBatch(ctx context.Context, batchID int64, queryRow queryRowFn) 
 
 	var expires *time.Time
 	eb := model.ExportBatch{}
-	if err := row.Scan(&eb.BatchID, &eb.ConfigID, &eb.FilenameRoot, &eb.StartTimestamp, &eb.EndTimestamp, &eb.IncludeRegions, &eb.ExcludeRegions, &eb.Status, &expires); err != nil {
+	if err := row.Scan(&eb.BatchID, &eb.ConfigID, &eb.FilenameRoot, &eb.StartTimestamp, &eb.EndTimestamp, &eb.Region, &eb.Status, &expires); err != nil {
 		if err == pgx.ErrNoRows {
 			return nil, ErrNotFound
 		}
@@ -322,28 +323,69 @@ func lookupExportBatch(ctx context.Context, batchID int64, queryRow queryRowFn) 
 	return &eb, nil
 }
 
-func (db *DB) CompleteFileAndBatch(ctx context.Context, files []string, batchID int64, batchCount int) error {
+// FinalizeBatch writes the ExportFile records and marks the ExportBatch as complete.
+func (db *DB) FinalizeBatch(ctx context.Context, eb *model.ExportBatch, files []string, batchSize int) error {
 	return db.inTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
 		// Update ExportFile for the files created.
-		for _, file := range files {
+		for i, file := range files {
 			ef := model.ExportFile{
-				Filename: file,
-				BatchID:  batchID,
-				Region:   "", // TODO(lmohanan) figure out where region comes from.
-				BatchNum: batchCount,
-				Status:   model.ExportBatchComplete,
+				Filename:  file,
+				BatchID:   eb.BatchID,
+				Region:    eb.Region,
+				BatchNum:  i + 1,
+				BatchSize: batchSize,
+				Status:    model.ExportBatchComplete,
 			}
 			if err := addExportFile(ctx, tx, &ef); err != nil {
-				return fmt.Errorf("adding export file entry: %v", err)
+				return fmt.Errorf("adding export file entry: %w", err)
 			}
 		}
 
 		// Update ExportFile for the batch to mark it complete.
-		if err := completeBatch(ctx, tx, batchID); err != nil {
-			return fmt.Errorf("marking batch %v complete: %v", batchID, err)
+		if err := completeBatch(ctx, tx, eb.BatchID); err != nil {
+			return fmt.Errorf("marking batch %v complete: %w", eb.BatchID, err)
 		}
 		return nil
 	})
+}
+
+// LookupExportFiles returns a list of export files for the given ExportConfig exportConfigID.
+func (db *DB) LookupExportFiles(ctx context.Context, exportConfigID int64) ([]string, error) {
+	conn, err := db.pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("acquiring connection: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, `
+		SELECT
+			ef.filename
+		FROM
+			ExportFile ef
+		INNER JOIN
+			ExportBatch eb ON (eb.batch_id = ef.batch_id)
+		WHERE
+			eb.config_id = $1
+		ORDER BY
+			ef.filename
+		`, exportConfigID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var filenames []string
+	for rows.Next() {
+		if rows.Err() != nil {
+			return nil, rows.Err()
+		}
+		var filename string
+		if err := rows.Scan(&filename); err != nil {
+			return nil, err
+		}
+		filenames = append(filenames, filename)
+	}
+	return filenames, nil
 }
 
 type joinedExportBatchFile struct {
@@ -363,34 +405,34 @@ func (db *DB) DeleteFilesBefore(ctx context.Context, before time.Time) (int, err
 	err := func() error { // Use a func to allow defer conn.Release() to work.
 		conn, err := db.pool.Acquire(ctx)
 		if err != nil {
-			return fmt.Errorf("acquiring connection: %v", err)
+			return fmt.Errorf("acquiring connection: %w", err)
 		}
 		defer conn.Release()
 
 		q := `
 			SELECT
-				ExportBatch.batch_id,
-				ExportBatch.status,
-				ExportFile.filename,
-				ExportFile.batch_size,
-				ExportFile.status
+				eb.batch_id,
+				eb.status,
+				ef.filename,
+				ef.batch_size,
+				ef.status
 			FROM 
-				ExportBatch 
+				ExportBatch eb
 			INNER JOIN
-				ExportFile ON (ExportBatch.batch_id = ExportFile.batch_id)
+				ExportFile ef ON (eb.batch_id = ef.batch_id)
 			WHERE
-				ExportBatch.end_timestamp < $1
-				AND ExportBatch.status != $2`
+				eb.end_timestamp < $1
+				AND eb.status != $2`
 		rows, err := conn.Query(ctx, q, before, model.ExportBatchDeleted)
 		if err != nil {
-			return fmt.Errorf("fetching filenames: %v", err)
+			return fmt.Errorf("fetching filenames: %w", err)
 		}
 		defer rows.Close()
 
 		for rows.Next() {
 			var f joinedExportBatchFile
 			if err := rows.Scan(&f.batchID, &f.batchStatus, &f.filename, &f.count, &f.fileStatus); err != nil {
-				return fmt.Errorf("fetching batch_id: %v", err)
+				return fmt.Errorf("fetching batch_id: %w", err)
 			}
 			files = append(files, f)
 		}
@@ -414,19 +456,19 @@ func (db *DB) DeleteFilesBefore(ctx context.Context, before time.Time) (int, err
 
 		// Delete stored file.
 		if err := storage.DeleteObject(ctx, bucket, f.filename); err != nil {
-			return 0, fmt.Errorf("delete object: %v", err)
+			return 0, fmt.Errorf("delete object: %w", err)
 		}
 
 		err := db.inTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
 			// Update Status in ExportFile.
 			if err := updateExportFileStatus(ctx, tx, f.filename, model.ExportBatchDeleted); err != nil {
-				return fmt.Errorf("updating ExportFile: %v", err)
+				return fmt.Errorf("updating ExportFile: %w", err)
 			}
 
 			// If batch completely deleted, update in ExportBatch.
 			if batchFileDeleteCounter[f.batchID] == f.count {
 				if err := updateExportBatchStatus(ctx, tx, f.batchID, model.ExportBatchDeleted); err != nil {
-					return fmt.Errorf("updating ExportBatch: %v", err)
+					return fmt.Errorf("updating ExportBatch: %w", err)
 				}
 			}
 			return nil
@@ -435,7 +477,7 @@ func (db *DB) DeleteFilesBefore(ctx context.Context, before time.Time) (int, err
 			return 0, err
 		}
 
-		logger.Infof("Deleted filename %v", f.filename)
+		logger.Infof("Deleted filename %s", f.filename)
 		count++
 	}
 
@@ -451,7 +493,7 @@ func addExportFile(ctx context.Context, tx pgx.Tx, ef *model.ExportFile) error {
 			($1, $2, $3, $4, $5, $6)
 		`, ef.Filename, ef.BatchID, ef.Region, ef.BatchNum, ef.BatchSize, ef.Status)
 	if err != nil {
-		return fmt.Errorf("inserting to ExportFile: %v", err)
+		return fmt.Errorf("inserting to ExportFile: %w", err)
 	}
 	return nil
 }
@@ -466,7 +508,7 @@ func updateExportFileStatus(ctx context.Context, tx pgx.Tx, filename, status str
 			filename = $2
 		`, status, filename)
 	if err != nil {
-		return fmt.Errorf("updating ExportFile: %v", err)
+		return fmt.Errorf("updating ExportFile: %w", err)
 	}
 	return nil
 }
@@ -481,7 +523,7 @@ func updateExportBatchStatus(ctx context.Context, tx pgx.Tx, batchID int64, stat
 			batch_id = $2
 		`, status, batchID)
 	if err != nil {
-		return fmt.Errorf("updating ExportBatch: %v", err)
+		return fmt.Errorf("updating ExportBatch: %w", err)
 	}
 	return nil
 }

--- a/internal/database/export_test.go
+++ b/internal/database/export_test.go
@@ -31,12 +31,11 @@ func TestAddExportConfig(t *testing.T) {
 	fromTime := time.Now().UTC()
 	thruTime := fromTime.Add(6 * time.Hour)
 	want := &model.ExportConfig{
-		FilenameRoot:   "root",
-		Period:         3 * time.Hour,
-		IncludeRegions: []string{"i1", "i2"},
-		ExcludeRegions: nil,
-		From:           fromTime,
-		Thru:           thruTime,
+		FilenameRoot: "root",
+		Period:       3 * time.Hour,
+		Region:       "i1",
+		From:         fromTime,
+		Thru:         thruTime,
 	}
 	if err := testDB.AddExportConfig(ctx, want); err != nil {
 		t.Fatal(err)
@@ -52,12 +51,12 @@ func TestAddExportConfig(t *testing.T) {
 	)
 	err = conn.QueryRow(ctx, `
 		SELECT
-			config_id, filename_root, period_seconds, include_regions, exclude_regions, from_timestamp, thru_timestamp
+			config_id, filename_root, period_seconds, region, from_timestamp, thru_timestamp
 		FROM
 			ExportConfig
 		WHERE
 			config_id = $1
-	`, want.ConfigID).Scan(&got.ConfigID, &got.FilenameRoot, &psecs, &got.IncludeRegions, &got.ExcludeRegions, &got.From, &got.Thru)
+	`, want.ConfigID).Scan(&got.ConfigID, &got.FilenameRoot, &psecs, &got.Region, &got.From, &got.Thru)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/model/export.go
+++ b/internal/model/export.go
@@ -26,13 +26,12 @@ var (
 )
 
 type ExportConfig struct {
-	ConfigID       int64         `db:"config_id"`
-	FilenameRoot   string        `db:"filename_root"`
-	Period         time.Duration `db:"period_seconds"`
-	IncludeRegions []string      `db:"include_regions"`
-	ExcludeRegions []string      `db:"exclude_regions"`
-	From           time.Time     `db:"from_timestamp"`
-	Thru           time.Time     `db:"thru_timestamp"`
+	ConfigID     int64         `db:"config_id"`
+	FilenameRoot string        `db:"filename_root"`
+	Period       time.Duration `db:"period_seconds"`
+	Region       string        `db:"region"`
+	From         time.Time     `db:"from_timestamp"`
+	Thru         time.Time     `db:"thru_timestamp"`
 }
 
 type ExportBatch struct {
@@ -41,8 +40,7 @@ type ExportBatch struct {
 	FilenameRoot   string    `db:"filename_root", json:"filenameRoot"`
 	StartTimestamp time.Time `db:"start_timestamp", json:"startTimestamp"`
 	EndTimestamp   time.Time `db:"end_timestamp", json:"endTimestamp"`
-	IncludeRegions []string  `db:"include_regions", json:"includeRegions"`
-	ExcludeRegions []string  `db:"exclude_regions", json:"excludeRegions"`
+	Region         string    `db:"region"`
 	Status         string    `db:"status", json:"status"`
 	LeaseExpires   time.Time `db:"lease_expires", json:"leaseExpires"`
 }

--- a/internal/pb/export/export.proto
+++ b/internal/pb/export/export.proto
@@ -66,4 +66,3 @@ message TemporaryExposureKey {
   optional int32 rolling_period = 4
       [default = 144];  // defaults to 10 min intervals
 }
-

--- a/migrations/000005_export_file_regions.down.sql
+++ b/migrations/000005_export_file_regions.down.sql
@@ -1,0 +1,25 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE ExportConfig DROP COLUMN region;
+ALTER TABLE ExportBatch DROP COLUMN region;
+
+ALTER TABLE ExportConfig ADD COLUMN include_regions VARCHAR(5) [];
+ALTER TABLE ExportConfig ADD COLUMN exclude_regions VARCHAR(5) [];
+ALTER TABLE ExportBatch ADD COLUMN include_regions VARCHAR(5) [];
+ALTER TABLE ExportBatch ADD COLUMN exclude_regions VARCHAR(5) [];
+
+END;

--- a/migrations/000005_export_file_regions.up.sql
+++ b/migrations/000005_export_file_regions.up.sql
@@ -1,0 +1,25 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE ExportConfig DROP COLUMN include_regions;
+ALTER TABLE ExportConfig DROP COLUMN exclude_regions;
+ALTER TABLE ExportBatch DROP COLUMN include_regions;
+ALTER TABLE ExportBatch DROP COLUMN exclude_regions;
+
+ALTER TABLE ExportConfig ADD COLUMN region VARCHAR(5);
+ALTER TABLE ExportBatch ADD COLUMN region VARCHAR(5);
+
+END;

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -60,8 +60,7 @@ CREATE TABLE ExportConfig (
 	config_id SERIAL PRIMARY KEY,
 	filename_root VARCHAR(100) NOT NULL,
 	period_seconds INT NOT NULL,
-	include_regions VARCHAR(5) [],
-	exclude_regions VARCHAR(5) [],
+	region VARCHAR(5) NOT NULL,
 	from_timestamp TIMESTAMP NOT NULL,
 	thru_timestamp TIMESTAMP
 );
@@ -73,8 +72,7 @@ CREATE TABLE ExportBatch (
 	filename_root VARCHAR(100) NOT NULL,
 	start_timestamp TIMESTAMP NOT NULL,
 	end_timestamp TIMESTAMP NOT NULL,
-	include_regions VARCHAR(5) [],
-	exclude_regions VARCHAR(5) [],
+	region VARCHAR(5) NOT NULL,
 	status ExportBatchStatus NOT NULL DEFAULT 'OPEN',
 	lease_expires TIMESTAMP
 );
@@ -82,7 +80,7 @@ CREATE TABLE ExportBatch (
 CREATE TABLE ExportFile (
 	filename VARCHAR(200) PRIMARY KEY,
 	batch_id INT REFERENCES ExportBatch(batch_id),
-	region VARCHAR(5),
+	region VARCHAR(5) NOT NULL,
 	batch_num INT,
 	batch_size INT,
 	status VARCHAR(10)


### PR DESCRIPTION
We have a region cardinality issue to figure out. On the publish (upload) side of the server API, each Exposure can have an array of Region. However, on the export side of the server API, the exported TemporaryExposureKey only has a single region per key.

This CL adjusts the TemporaryExposureKey to have multiple keys to solve this problem, but we could also do the opposite (reduce Publish and Exposure to only have a single region).

Thoughts?