### PR TITLE
migrations: add timezones to timestamps

### DIFF
--- a/migrations/000004_add_time_zone.down.sql
+++ b/migrations/000004_add_time_zone.down.sql
@@ -1,0 +1,36 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE FederationQuery
+	ALTER COLUMN last_timestamp type TIMESTAMP;
+
+ALTER TABLE FederationSync
+	ALTER COLUMN started type TIMESTAMP,
+	ALTER COLUMN completed type TIMESTAMP,
+	ALTER COLUMN max_timestamp type TIMESTAMP;
+
+ALTER TABLE Exposure
+	ALTER COLUMN created_at type TIMESTAMP;
+
+ALTER TABLE ExportConfig
+	ALTER COLUMN from_timestamp type TIMESTAMP,
+	ALTER COLUMN thru_timestamp type TIMESTAMP;
+
+ALTER TABLE ExportBatch
+	ALTER COLUMN start_timestamp type TIMESTAMP,
+	ALTER COLUMN end_timestamp type TIMESTAMP,
+	ALTER COLUMN lease_expires type TIMESTAMP;
+
+ALTER TABLE Lock
+	ALTER COLUMN expires type TIMESTAMP;

--- a/migrations/000004_add_time_zone.up.sql
+++ b/migrations/000004_add_time_zone.up.sql
@@ -1,0 +1,41 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Change every TIMESTAMP type to TIMESTAMPTZ, preserving data.
+
+-- This migration does not need to be run in a transaction.
+-- Each ALTER TABLE happens atomically, and is idempotent.
+
+ALTER TABLE FederationQuery
+	ALTER COLUMN last_timestamp type TIMESTAMPTZ USING last_timestamp AT TIME ZONE 'UTC';
+
+ALTER TABLE FederationSync
+	ALTER COLUMN started type TIMESTAMPTZ USING started AT TIME ZONE 'UTC',
+	ALTER COLUMN completed type TIMESTAMPTZ USING completed AT TIME ZONE 'UTC',
+	ALTER COLUMN max_timestamp type TIMESTAMPTZ USING max_timestamp AT TIME ZONE 'UTC';
+
+ALTER TABLE Exposure
+	ALTER COLUMN created_at type TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC';
+
+ALTER TABLE ExportConfig
+	ALTER COLUMN from_timestamp type TIMESTAMPTZ USING from_timestamp AT TIME ZONE 'UTC',
+	ALTER COLUMN thru_timestamp type TIMESTAMPTZ USING thru_timestamp AT TIME ZONE 'UTC';
+
+ALTER TABLE ExportBatch
+	ALTER COLUMN start_timestamp type TIMESTAMPTZ USING start_timestamp AT TIME ZONE 'UTC',
+	ALTER COLUMN end_timestamp type TIMESTAMPTZ USING end_timestamp AT TIME ZONE 'UTC',
+	ALTER COLUMN lease_expires type TIMESTAMPTZ USING lease_expires AT TIME ZONE 'UTC';
+
+ALTER TABLE Lock
+	ALTER COLUMN expires type TIMESTAMPTZ USING expires AT TIME ZONE 'UTC';


### PR DESCRIPTION
Change every TIMESTAMP type to TIMESTAMPTZ, preserving existing data.

Adding the time zone means these columns will accurately represent
a point in time, rather than just a calendar date-time.

See https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_timestamp_.28without_time_zone.29
for more.