### PR TITLE
use %w with fmt.Errorf

### DIFF
--- a/internal/android/safetynet.go
+++ b/internal/android/safetynet.go
@@ -49,7 +49,7 @@ func ValidateAttestation(ctx context.Context, attestation string, opts VerifyOpt
 
 	claims, err := parseAttestation(ctx, attestation)
 	if err != nil {
-		return fmt.Errorf("parseAttestation: %v", err)
+		return fmt.Errorf("parseAttestation: %w", err)
 	}
 
 	// Validate claims based on the options passed in.
@@ -60,7 +60,7 @@ func ValidateAttestation(ctx context.Context, attestation string, opts VerifyOpt
 		}
 		nonceClaimBytes, err := base64.StdEncoding.DecodeString(nonceClaimB64)
 		if err != nil {
-			return fmt.Errorf("unable to decode nonce claim data: %v", err)
+			return fmt.Errorf("unable to decode nonce claim data: %w", err)
 		}
 		nonceClaim := string(nonceClaimBytes)
 		nonceCalculated := opts.Nonce.Nonce()
@@ -134,11 +134,11 @@ func keyFunc(ctx context.Context, tok *jwt.Token) (interface{}, error) {
 		}
 		certData, err := base64.StdEncoding.DecodeString(certStr.(string))
 		if err != nil {
-			return nil, fmt.Errorf("invalid certificate encoding: %v", err)
+			return nil, fmt.Errorf("invalid certificate encoding: %w", err)
 		}
 		x509certs[i], err = x509.ParseCertificate(certData)
 		if err != nil {
-			return nil, fmt.Errorf("invalid certificate: %v", err)
+			return nil, fmt.Errorf("invalid certificate: %w", err)
 		}
 	}
 
@@ -154,7 +154,7 @@ func keyFunc(ctx context.Context, tok *jwt.Token) (interface{}, error) {
 	// Verify the first certificate, with all added as allowed intermediates.
 	_, err := x509certs[0].Verify(opts)
 	if err != nil {
-		return nil, fmt.Errorf("invalid certificate chain: %v", err)
+		return nil, fmt.Errorf("invalid certificate chain: %w", err)
 	}
 
 	// extract the public key for verification.
@@ -175,7 +175,7 @@ func parseAttestation(ctx context.Context, signedAttestation string) (jwt.MapCla
 		})
 
 	if err != nil {
-		return nil, fmt.Errorf("jwt.Parse: %v", err)
+		return nil, fmt.Errorf("jwt.Parse: %w", err)
 	}
 	if !token.Valid {
 		logger.Errorf("invalid JWS attestation passed.")

--- a/internal/api/export/export.go
+++ b/internal/api/export/export.go
@@ -383,7 +383,7 @@ func (h *testExportHandler) doExport(ctx context.Context, limit int) error {
 	until := time.Now().UTC()
 	exposureKeys, err := h.queryExposureKeys(ctx, since, until, limit)
 	if err != nil {
-		return fmt.Errorf("error getting exposures: %v", err)
+		return fmt.Errorf("error getting exposures: %w", err)
 	}
 	eb := &model.ExportBatch{
 		StartTimestamp: since,
@@ -392,11 +392,11 @@ func (h *testExportHandler) doExport(ctx context.Context, limit int) error {
 	}
 	data, err := MarshalExportFile(eb, exposureKeys, 1, 1)
 	if err != nil {
-		return fmt.Errorf("error marshalling export file: %v", err)
+		return fmt.Errorf("error marshalling export file: %w", err)
 	}
 	objectName := fmt.Sprintf("testExport-%d-records"+filenameSuffix, limit)
 	if err := storage.CreateObject(ctx, "apollo-public-bucket", objectName, data); err != nil {
-		return fmt.Errorf("error creating cloud storage object: %v", err)
+		return fmt.Errorf("error creating cloud storage object: %w", err)
 	}
 	return nil
 }

--- a/internal/api/federation/federation.go
+++ b/internal/api/federation/federation.go
@@ -99,7 +99,7 @@ func (s *federationServer) fetch(ctx context.Context, req *pb.FederationFetchReq
 
 	it, err := itFunc(ctx, criteria)
 	if err != nil {
-		return nil, fmt.Errorf("querying exposures (criteria: %#v): %v", criteria, err)
+		return nil, fmt.Errorf("querying exposures (criteria: %#v): %w", criteria, err)
 	}
 	defer it.Close()
 
@@ -114,12 +114,12 @@ func (s *federationServer) fetch(ctx context.Context, req *pb.FederationFetchReq
 		select {
 		case <-ctx.Done():
 			if err := ctx.Err(); err != context.DeadlineExceeded && err != context.Canceled { // May be context.Canceled due to test code.
-				return nil, fmt.Errorf("context error: %v", err)
+				return nil, fmt.Errorf("context error: %w", err)
 			}
 
 			cursor, err := it.Cursor()
 			if err != nil {
-				return nil, fmt.Errorf("generating cursor: %v", err)
+				return nil, fmt.Errorf("generating cursor: %w", err)
 			}
 
 			logger.Infof("Fetch request reached time out, returning partial response.")
@@ -133,7 +133,7 @@ func (s *federationServer) fetch(ctx context.Context, req *pb.FederationFetchReq
 
 		inf, done, err := it.Next()
 		if err != nil {
-			return nil, fmt.Errorf("iterating results: %v", err)
+			return nil, fmt.Errorf("iterating results: %w", err)
 		}
 
 		if done {

--- a/internal/api/federation/federationpull.go
+++ b/internal/api/federation/federationpull.go
@@ -146,7 +146,7 @@ func federationPull(ctx context.Context, deps pullDependencies, q *model.Federat
 
 	syncID, finalizeFn, err := deps.startFederationSync(ctx, q, batchStart)
 	if err != nil {
-		return fmt.Errorf("starting federation sync for query %s: %v", q.QueryID, err)
+		return fmt.Errorf("starting federation sync for query %s: %w", q.QueryID, err)
 	}
 
 	var maxTimestamp time.Time
@@ -163,7 +163,7 @@ func federationPull(ctx context.Context, deps pullDependencies, q *model.Federat
 
 		response, err := deps.fetch(ctx, request)
 		if err != nil {
-			return fmt.Errorf("fetching query %s: %v", q.QueryID, err)
+			return fmt.Errorf("fetching query %s: %w", q.QueryID, err)
 		}
 
 		responseTimestamp := time.Unix(response.FetchResponseKeyTimestamp, 0).UTC()
@@ -201,7 +201,7 @@ func federationPull(ctx context.Context, deps pullDependencies, q *model.Federat
 
 					if len(exposures) == fetchBatchSize {
 						if err := deps.insertExposures(ctx, exposures); err != nil {
-							return fmt.Errorf("inserting %d exposures: %v", len(exposures), err)
+							return fmt.Errorf("inserting %d exposures: %w", len(exposures), err)
 						}
 						total += len(exposures)
 						exposures = nil // Start a new batch.
@@ -211,7 +211,7 @@ func federationPull(ctx context.Context, deps pullDependencies, q *model.Federat
 		}
 		if len(exposures) > 0 {
 			if err := deps.insertExposures(ctx, exposures); err != nil {
-				return fmt.Errorf("inserting %d exposures: %v", len(exposures), err)
+				return fmt.Errorf("inserting %d exposures: %w", len(exposures), err)
 			}
 			total += len(exposures)
 		}
@@ -222,7 +222,7 @@ func federationPull(ctx context.Context, deps pullDependencies, q *model.Federat
 
 	if err := finalizeFn(maxTimestamp, total); err != nil {
 		// TODO(jasonco): how do we clean up here? Just leave the records in and have the exporter eliminate them? Other?
-		return fmt.Errorf("finalizing federation sync for query %s: %v", q.QueryID, err)
+		return fmt.Errorf("finalizing federation sync for query %s: %w", q.QueryID, err)
 	}
 
 	return nil

--- a/internal/api/wipeout/wipeout.go
+++ b/internal/api/wipeout/wipeout.go
@@ -119,14 +119,14 @@ func getCutoff(ttlVar string) (cutoff time.Time, err error) {
 	ttlString := os.Getenv(ttlVar)
 	ttlDuration, err := getAndValidateDuration(ttlString)
 	if err != nil {
-		err = fmt.Errorf("TTL env variable error: %v", err)
+		err = fmt.Errorf("TTL env variable error: %w", err)
 		return cutoff, err
 	}
 
 	// Parse and Validate min ttl duration string.
 	minTTL, err := getAndValidateDuration(minCutoffDuration)
 	if err != nil {
-		err = fmt.Errorf("min ttl const error: %v", err)
+		err = fmt.Errorf("min ttl const error: %w", err)
 		return cutoff, err
 	}
 

--- a/internal/serverenv/env.go
+++ b/internal/serverenv/env.go
@@ -96,7 +96,7 @@ func WithSecretManager(ctx context.Context, s *ServerEnv) (*ServerEnv, error) {
 
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("secretmanager.NewClient: %v", err)
+		return nil, fmt.Errorf("secretmanager.NewClient: %w", err)
 	}
 	s.smClient = client
 	return s, nil
@@ -130,7 +130,7 @@ func (s *ServerEnv) getSecretValue(ctx context.Context, envVar string) (string, 
 	// Call the API.
 	result, err := s.smClient.AccessSecretVersion(ctx, accessRequest)
 	if err != nil {
-		return "", fmt.Errorf("failed to access secret version for %v: %v", secretLocation, err)
+		return "", fmt.Errorf("failed to access secret version for %v: %w", secretLocation, err)
 	}
 	logger.Infof("loaded %v from secret %v", envVar, secretLocation)
 
@@ -163,7 +163,7 @@ func (s *ServerEnv) WriteSecretToFile(ctx context.Context, envVar string) (strin
 	data := []byte(secretVal)
 	err = ioutil.WriteFile(fName, data, 0600)
 	if err != nil {
-		return "", fmt.Errorf("unable to write secret for %v to file: %v", envVar, err)
+		return "", fmt.Errorf("unable to write secret for %v to file: %w", envVar, err)
 	}
 	logger.Infof("Wrote secret value for %v to file", envVar)
 	return fName, nil

--- a/internal/storage/objects.go
+++ b/internal/storage/objects.go
@@ -28,7 +28,7 @@ import (
 func CreateObject(ctx context.Context, bucket, objectName string, contents []byte) error {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
-		return fmt.Errorf("storage.NewClient: %v", err)
+		return fmt.Errorf("storage.NewClient: %w", err)
 	}
 	defer client.Close()
 
@@ -37,10 +37,10 @@ func CreateObject(ctx context.Context, bucket, objectName string, contents []byt
 
 	wc := client.Bucket(bucket).Object(objectName).NewWriter(ctx)
 	if _, err = wc.Write(contents); err != nil {
-		return fmt.Errorf("storage.Writer.Write: %v", err)
+		return fmt.Errorf("storage.Writer.Write: %w", err)
 	}
 	if err := wc.Close(); err != nil {
-		return fmt.Errorf("storage.Writer.Close: %v", err)
+		return fmt.Errorf("storage.Writer.Close: %w", err)
 	}
 	return nil
 }
@@ -49,7 +49,7 @@ func CreateObject(ctx context.Context, bucket, objectName string, contents []byt
 func DeleteObject(ctx context.Context, bucket, objectName string) error {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
-		return fmt.Errorf("storage.NewClient: %v", err)
+		return fmt.Errorf("storage.NewClient: %w", err)
 	}
 	defer client.Close()
 
@@ -61,7 +61,7 @@ func DeleteObject(ctx context.Context, bucket, objectName string) error {
 			// Object doesn't exist; presumably already deleted.
 			return nil
 		}
-		return fmt.Errorf("storage.DeleteObject: %v", err)
+		return fmt.Errorf("storage.DeleteObject: %w", err)
 	}
 	return nil
 }

--- a/internal/verification/verify.go
+++ b/internal/verification/verify.go
@@ -65,7 +65,7 @@ func VerifySafetyNet(ctx context.Context, requestTime time.Time, cfg *apiconfig.
 			logger.Errorf("safetynet failed, but bypass enabled for app: '%v', failure: %v", data.AppPackageName, err)
 			return nil
 		}
-		return fmt.Errorf("android.ValidateAttestation: %v", err)
+		return fmt.Errorf("android.ValidateAttestation: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
I changed %v to %w in a few places where I thought a caller might
want to check the underlying error.

I notably did not do that in `internal/database`, to allow for
using a different DB or driver without breaking clients. In other places
(e.g. `internalstorage`), I thought it was unlikely that a different
client would be used.