### PR TITLE
Collect exposure keys in memory to avoid using COUNT.

### DIFF
--- a/internal/api/federation/federation.go
+++ b/internal/api/federation/federation.go
@@ -136,12 +136,11 @@ func (s *federationServer) fetch(ctx context.Context, req *pb.FederationFetchReq
 			return nil, fmt.Errorf("iterating results: %w", err)
 		}
 
-		if done {
-			// Reached the end of the result set.
-			break
-		}
-		// Iterator may go one past before returning done==true.
 		if inf == nil {
+			// Iterator may go one past before returning done==true.
+			if done {
+				break
+			}
 			continue
 		}
 
@@ -234,6 +233,10 @@ func (s *federationServer) fetch(ctx context.Context, req *pb.FederationFetchReq
 		}
 
 		count++
+
+		if done {
+			break
+		}
 	}
 
 	logger.Infof("Sent %d keys", count)

--- a/internal/database/export.go
+++ b/internal/database/export.go
@@ -366,9 +366,11 @@ func (db *DB) LookupExportFiles(ctx context.Context, exportConfigID int64) ([]st
 			ExportBatch eb ON (eb.batch_id = ef.batch_id)
 		WHERE
 			eb.config_id = $1
+		AND
+			eb.status = $2
 		ORDER BY
 			ef.filename
-		`, exportConfigID)
+		`, exportConfigID, model.ExportBatchComplete)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/exposure.go
+++ b/internal/database/exposure.go
@@ -74,18 +74,11 @@ func (db *DB) IterateExposures(ctx context.Context, criteria IterateExposuresCri
 		}
 	}
 
-	where, args, err := generateWhereClause(criteria)
+	query, args, err := generateExposureQuery(criteria)
 	if err != nil {
 		return nil, fmt.Errorf("generating where: %v", err)
 	}
 
-	query := `
-		SELECT
-			exposure_key, transmission_risk, app_package_name, regions, interval_number, interval_count,
-			created_at, local_provenance, verification_authority_name, sync_id
-		FROM
-			Exposure
-		` + where
 	rows, err := conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
@@ -137,35 +130,16 @@ func (i *postgresExposureIterator) Close() error {
 	return i.iter.close()
 }
 
-func (db *DB) CountExposures(ctx context.Context, criteria IterateExposuresCriteria) (int, error) {
-	conn, err := db.pool.Acquire(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("acquiring connection: %v", err)
-	}
-	defer conn.Release()
-
-	where, args, err := generateWhereClause(criteria)
-	if err != nil {
-		return 0, fmt.Errorf("generating where: %v", err)
-	}
-
-	query := `
+func generateExposureQuery(criteria IterateExposuresCriteria) (string, []interface{}, error) {
+	var args []interface{}
+	q := `
 		SELECT
-			COUNT(*)
+			exposure_key, transmission_risk, app_package_name, regions, interval_number, interval_count,
+			created_at, local_provenance, verification_authority_name, sync_id
 		FROM
 			Exposure
-		` + where
-	rows := conn.QueryRow(ctx, query, args...)
-	var count int
-	if err := rows.Scan(&count); err != nil {
-		return 0, err
-	}
-	return count, nil
-}
-
-func generateWhereClause(criteria IterateExposuresCriteria) (string, []interface{}, error) {
-	var args []interface{}
-	q := "WHERE 1=1 "
+		WHERE 1=1
+	`
 
 	if len(criteria.IncludeRegions) == 1 {
 		args = append(args, criteria.IncludeRegions)


### PR DESCRIPTION
Also, added various context timeout things so that the worker can keep doing work while there is work to do.