### PR TITLE
fix logger.Fatal calls

### DIFF
--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -48,7 +48,7 @@ func main() {
 	// It is possible to install a different secret management system here that conforms to secrets.SecretManager{}
 	sm, err := secrets.NewGCPSecretManager(ctx)
 	if err != nil {
-		logger.Fatal("unable to connect to secret manager: %w", err)
+		logger.Fatalf("unable to connect to secret manager: %v", err)
 	}
 	env := serverenv.New(ctx,
 		serverenv.WithSecretManager(sm),

--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -44,7 +44,7 @@ func main() {
 	// It is possible to install a different secret management system here that conforms to secrets.SecretManager{}
 	sm, err := secrets.NewGCPSecretManager(ctx)
 	if err != nil {
-		logger.Fatal("unable to connect to secret manager: %w", err)
+		logger.Fatalf("unable to connect to secret manager: %v", err)
 	}
 	env := serverenv.New(ctx,
 		serverenv.WithSecretManager(sm),

--- a/cmd/federation-pull/main.go
+++ b/cmd/federation-pull/main.go
@@ -45,7 +45,7 @@ func main() {
 	// It is possible to install a different secret management system here that conforms to secrets.SecretManager{}
 	sm, err := secrets.NewGCPSecretManager(ctx)
 	if err != nil {
-		logger.Fatal("unable to connect to secret manager: %w", err)
+		logger.Fatalf("unable to connect to secret manager: %v", err)
 	}
 	env := serverenv.New(ctx,
 		serverenv.WithSecretManager(sm),

--- a/cmd/federation/main.go
+++ b/cmd/federation/main.go
@@ -45,7 +45,7 @@ func main() {
 	// It is possible to install a different secret management system here that conforms to secrets.SecretManager{}
 	sm, err := secrets.NewGCPSecretManager(ctx)
 	if err != nil {
-		logger.Fatal("unable to connect to secret manager: %w", err)
+		logger.Fatalf("unable to connect to secret manager: %v", err)
 	}
 	env := serverenv.New(ctx,
 		serverenv.WithSecretManager(sm),

--- a/cmd/wipeout-export/main.go
+++ b/cmd/wipeout-export/main.go
@@ -45,7 +45,7 @@ func main() {
 	// It is possible to install a different secret management system here that conforms to secrets.SecretManager{}
 	sm, err := secrets.NewGCPSecretManager(ctx)
 	if err != nil {
-		logger.Fatal("unable to connect to secret manager: %w", err)
+		logger.Fatalf("unable to connect to secret manager: %v", err)
 	}
 	env := serverenv.New(ctx,
 		serverenv.WithSecretManager(sm),

--- a/cmd/wipeout-exposure/main.go
+++ b/cmd/wipeout-exposure/main.go
@@ -45,7 +45,7 @@ func main() {
 	// It is possible to install a different secret management system here that conforms to secrets.SecretManager{}
 	sm, err := secrets.NewGCPSecretManager(ctx)
 	if err != nil {
-		logger.Fatal("unable to connect to secret manager: %w", err)
+		logger.Fatalf("unable to connect to secret manager: %v", err)
 	}
 	env := serverenv.New(ctx,
 		serverenv.WithSecretManager(sm),


### PR DESCRIPTION
- Needs Fatalf to use formatted output.
- %w is only supported for fmt.Errorf.