### PR TITLE
minor comment change on proto

### DIFF
--- a/internal/pb/export/export.pb.go
+++ b/internal/pb/export/export.pb.go
@@ -42,7 +42,7 @@ const _ = proto.ProtoPackageIsVersion4
 
 // Protobuf definition for exports of confirmed temporary exposure keys.
 //
-// These files have a 16-byte, zero-padded header before the protobuf data
+// These files have a 16-byte, space-padded header before the protobuf data
 // starts. They will be contained in a zip archive, alongside a signature
 // file verifying the contents.
 type TemporaryExposureKeyExport struct {

--- a/internal/pb/export/export.proto
+++ b/internal/pb/export/export.proto
@@ -18,7 +18,7 @@ option go_package = "internal/pb/export;export";
 
 // Protobuf definition for exports of confirmed temporary exposure keys.
 //
-// These files have a 16-byte, zero-padded header before the protobuf data
+// These files have a 16-byte, space-padded header before the protobuf data
 // starts. They will be contained in a zip archive, alongside a signature
 // file verifying the contents.
 message TemporaryExposureKeyExport {


### PR DESCRIPTION
I've thought about removing this section and treating the file format doc as authoritative, but I think what will happen is this will be the proto that's downloaded and used by anybody developing backends, so its useful to have a few comments in it.

Once the file format doc is published and there's a canonical link for it, I'll link to it from here.