### PR TITLE
remove unnecessary UTC time conversions

### DIFF
--- a/internal/api/export/export.go
+++ b/internal/api/export/export.go
@@ -82,7 +82,7 @@ func (s *BatchServer) CreateBatchesHandler(w http.ResponseWriter, r *http.Reques
 	}
 	defer unlockFn()
 
-	now := time.Now().UTC()
+	now := time.Now()
 	err = s.db.IterateExportConfigs(ctx, now, func(ec *model.ExportConfig) error {
 		if err := s.maybeCreateBatches(ctx, ec, now); err != nil {
 			logger.Errorf("Failed to create batches for config %d: %v, continuing to next config", ec.ConfigID, err)
@@ -208,7 +208,7 @@ func (s *BatchServer) WorkerHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Check for a batch and obtain a lease for it.
-		batch, err := s.db.LeaseBatch(ctx, s.bsc.WorkerTimeout, time.Now().UTC())
+		batch, err := s.db.LeaseBatch(ctx, s.bsc.WorkerTimeout, time.Now())
 		if err != nil {
 			logger.Errorf("Failed to lease batch: %v", err)
 			continue

--- a/internal/api/federation/federation.go
+++ b/internal/api/federation/federation.go
@@ -50,7 +50,7 @@ func (s *federationServer) Fetch(ctx context.Context, req *pb.FederationFetchReq
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 	logger := logging.FromContext(ctx)
-	response, err := s.fetch(ctx, req, s.db.IterateExposures, model.TruncateWindow(time.Now().UTC())) // Don't fetch the current window, which isn't complete yet. TODO(jasonco): should I double this for safety?
+	response, err := s.fetch(ctx, req, s.db.IterateExposures, model.TruncateWindow(time.Now())) // Don't fetch the current window, which isn't complete yet. TODO(jasonco): should I double this for safety?
 	if err != nil {
 		logger.Errorf("Fetch error: %v", err)
 		return nil, errors.New("internal error")
@@ -72,7 +72,7 @@ func (s *federationServer) fetch(ctx context.Context, req *pb.FederationFetchReq
 	// TODO(jasonco): Filter out other partner's data; don't re-federate.
 	// TODO(jasonco): moving to CloudSQL will allow this to be simplified.
 	criteria := database.IterateExposuresCriteria{
-		SinceTimestamp:      time.Unix(req.LastFetchResponseKeyTimestamp, 0).UTC(),
+		SinceTimestamp:      time.Unix(req.LastFetchResponseKeyTimestamp, 0),
 		UntilTimestamp:      fetchUntil,
 		LastCursor:          req.NextFetchToken,
 		OnlyLocalProvenance: true, // Do not return results that came from other federation partners.

--- a/internal/api/federation/federation_test.go
+++ b/internal/api/federation/federation_test.go
@@ -53,7 +53,7 @@ func makeExposure(diagKey *pb.ExposureKey, diagStatus pb.TransmissionRisk, regio
 		TransmissionRisk: int(diagStatus),
 		ExposureKey:      diagKey.ExposureKey,
 		IntervalNumber:   diagKey.IntervalNumber,
-		CreatedAt:        time.Unix(int64(diagKey.IntervalNumber*100), 0).UTC(), // Make unique from IntervalNumber.
+		CreatedAt:        time.Unix(int64(diagKey.IntervalNumber*100), 0), // Make unique from IntervalNumber.
 		LocalProvenance:  true,
 	}
 }
@@ -282,7 +282,7 @@ func TestFetch(t *testing.T) {
 				return &testIterator{iterations: tc.iterations, cancel: cancel}, nil
 			}
 
-			got, err := server.fetch(ctx, &req, itFunc, time.Now().UTC())
+			got, err := server.fetch(ctx, &req, itFunc, time.Now())
 
 			if err != nil {
 				t.Fatalf("fetch() returned err=%v, want err=nil", err)

--- a/internal/api/federation/federationpull.go
+++ b/internal/api/federation/federationpull.go
@@ -123,7 +123,7 @@ func (h *federationPullHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		insertExposures:     h.db.InsertExposures,
 		startFederationSync: h.db.StartFederationSync,
 	}
-	batchStart := time.Now().UTC()
+	batchStart := time.Now()
 	if err := federationPull(timeoutContext, deps, query, batchStart); err != nil {
 		logger.Errorf("Federation query %q failed: %v", queryID, err)
 		http.Error(w, fmt.Sprintf("Federation query %q fetch failed, check logs.", queryID), http.StatusInternalServerError)
@@ -166,7 +166,7 @@ func federationPull(ctx context.Context, deps pullDependencies, q *model.Federat
 			return fmt.Errorf("fetching query %s: %w", q.QueryID, err)
 		}
 
-		responseTimestamp := time.Unix(response.FetchResponseKeyTimestamp, 0).UTC()
+		responseTimestamp := time.Unix(response.FetchResponseKeyTimestamp, 0)
 		if responseTimestamp.After(maxTimestamp) {
 			maxTimestamp = responseTimestamp
 		}

--- a/internal/api/federation/federationpull_test.go
+++ b/internal/api/federation/federationpull_test.go
@@ -78,10 +78,10 @@ type syncDB struct {
 
 func (sdb *syncDB) startFederationSync(ctx context.Context, query *model.FederationQuery, start time.Time) (int64, database.FinalizeSyncFn, error) {
 	sdb.syncStarted = true
-	timerStart := time.Now().UTC()
+	timerStart := time.Now()
 	return syncID, func(maxTimestamp time.Time, totalInserted int) error {
 		sdb.syncCompleted = true
-		sdb.completed = start.Add(time.Now().UTC().Sub(timerStart))
+		sdb.completed = start.Add(time.Now().Sub(timerStart))
 		sdb.maxTimestamp = maxTimestamp
 		sdb.totalInserted = totalInserted
 		return nil
@@ -101,7 +101,7 @@ func TestFederationPull(t *testing.T) {
 		{
 			name:             "no results",
 			wantTokens:       []string{""},
-			wantMaxTimestamp: time.Unix(0, 0).UTC(),
+			wantMaxTimestamp: time.Unix(0, 0),
 		},
 		{
 			name: "basic results",
@@ -137,7 +137,7 @@ func TestFederationPull(t *testing.T) {
 				makeRemoteExposure(ddd, selfver, "", "US"),
 			},
 			wantTokens:       []string{""},
-			wantMaxTimestamp: time.Unix(400, 0).UTC(),
+			wantMaxTimestamp: time.Unix(400, 0),
 		},
 		{
 			name: "partial results",
@@ -180,7 +180,7 @@ func TestFederationPull(t *testing.T) {
 				makeRemoteExposure(ddd, selfver, "AAA", "CA"),
 			},
 			wantTokens:       []string{"", "abcdef"},
-			wantMaxTimestamp: time.Unix(400, 0).UTC(),
+			wantMaxTimestamp: time.Unix(400, 0),
 		},
 		{
 			name:      "too large for batch",
@@ -217,7 +217,7 @@ func TestFederationPull(t *testing.T) {
 				makeRemoteExposure(ddd, selfver, "", "US"),
 			},
 			wantTokens:       []string{""},
-			wantMaxTimestamp: time.Unix(400, 0).UTC(),
+			wantMaxTimestamp: time.Unix(400, 0),
 		},
 	}
 
@@ -228,7 +228,7 @@ func TestFederationPull(t *testing.T) {
 			remote := remoteFetchServer{responses: tc.fetchResponses}
 			idb := exposureDB{}
 			sdb := syncDB{}
-			batchStart := time.Now().UTC()
+			batchStart := time.Now()
 			if tc.batchSize > 0 {
 				oldBatchSize := fetchBatchSize
 				fetchBatchSize = tc.batchSize
@@ -263,7 +263,7 @@ func TestFederationPull(t *testing.T) {
 			if sdb.totalInserted != len(tc.wantExposures) {
 				t.Errorf("federation sync total inserted got %d, want %d", sdb.totalInserted, len(tc.wantExposures))
 			}
-			if sdb.maxTimestamp != tc.wantMaxTimestamp {
+			if !sdb.maxTimestamp.Equal(tc.wantMaxTimestamp) {
 				t.Errorf("federation sync max timestamp got %v, want %v", sdb.maxTimestamp, tc.wantMaxTimestamp)
 			}
 		})

--- a/internal/api/publish/publish.go
+++ b/internal/api/publish/publish.go
@@ -100,7 +100,7 @@ func (h *publishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	} else if cfg.IsAndroid() {
-		err = verification.VerifySafetyNet(ctx, time.Now().UTC(), cfg, data)
+		err = verification.VerifySafetyNet(ctx, time.Now(), cfg, data)
 		if err != nil {
 			logger.Errorf("unable to verify safetynet payload: %v", err)
 			metrics.WriteInt("publish-safetnet-invalid", true, 1)
@@ -116,7 +116,7 @@ func (h *publishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	batchTime := time.Now().UTC()
+	batchTime := time.Now()
 	exposures, err := model.TransformPublish(&data, batchTime)
 	if err != nil {
 		logger.Errorf("error transforming publish data: %v", err)

--- a/internal/api/wipeout/wipeout.go
+++ b/internal/api/wipeout/wipeout.go
@@ -137,7 +137,7 @@ func getCutoff(ttlVar string) (cutoff time.Time, err error) {
 	}
 
 	// Get cutoff timestamp
-	cutoff = time.Now().UTC().Add(-ttlDuration)
+	cutoff = time.Now().Add(-ttlDuration)
 	return cutoff, nil
 }
 

--- a/internal/database/export_test.go
+++ b/internal/database/export_test.go
@@ -32,7 +32,7 @@ func TestAddExportConfig(t *testing.T) {
 	defer resetTestDB(t)
 	ctx := context.Background()
 
-	fromTime := time.Now().UTC()
+	fromTime := time.Now()
 	thruTime := fromTime.Add(6 * time.Hour)
 	want := &model.ExportConfig{
 		FilenameRoot: "root",

--- a/internal/database/federation.go
+++ b/internal/database/federation.go
@@ -159,7 +159,7 @@ func (db *DB) StartFederationSync(ctx context.Context, q *model.FederationQuery,
 
 	// startedTime is used internally to compute a Duration between here and when finalize function below is executed.
 	// This allows the finalize function to not request a completed Time parameter.
-	startedTimer := time.Now().UTC()
+	startedTimer := time.Now()
 
 	var syncID int64
 	row := conn.QueryRow(ctx, `
@@ -175,7 +175,7 @@ func (db *DB) StartFederationSync(ctx context.Context, q *model.FederationQuery,
 	}
 
 	finalize := func(maxTimestamp time.Time, totalInserted int) error {
-		completed := started.Add(time.Now().UTC().Sub(startedTimer))
+		completed := started.Add(time.Now().Sub(startedTimer))
 
 		return db.inTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
 			// Special case: when no keys are pulled, the maxTimestamp will be 0, so we don't update the

--- a/internal/model/apiconfig/config.go
+++ b/internal/model/apiconfig/config.go
@@ -71,11 +71,11 @@ func (c *APIConfig) VerifyOpts(from time.Time) android.VerifyOpts {
 
 	// Calculate the valid time window based on now + config options.
 	if c.AllowedPastTime != nil {
-		minTime := from.UTC().Add(-*c.AllowedPastTime)
+		minTime := from.Add(-*c.AllowedPastTime)
 		rtn.MinValidTime = &minTime
 	}
 	if c.AllowedFutureTime != nil {
-		maxTime := from.UTC().Add(*c.AllowedFutureTime)
+		maxTime := from.Add(*c.AllowedFutureTime)
 		rtn.MaxValidTime = &maxTime
 	}
 

--- a/internal/model/apiconfig/config_test.go
+++ b/internal/model/apiconfig/config_test.go
@@ -43,7 +43,7 @@ func durationPtr(d time.Duration) *time.Duration {
 }
 
 func TestVerifyOpts(t *testing.T) {
-	testTime := time.Date(2020, 1, 13, 5, 6, 4, 6, time.UTC)
+	testTime := time.Date(2020, 1, 13, 5, 6, 4, 6, time.Local)
 
 	cases := []struct {
 		cfg  *APIConfig

--- a/internal/verification/verify.go
+++ b/internal/verification/verify.go
@@ -58,7 +58,7 @@ func VerifySafetyNet(ctx context.Context, requestTime time.Time, cfg *apiconfig.
 		return fmt.Errorf("cannot enforce safetynet, no application config")
 	}
 
-	opts := cfg.VerifyOpts(requestTime.UTC())
+	opts := cfg.VerifyOpts(requestTime)
 	err := ValidateAttestation(ctx, data.Verification, opts)
 	if err != nil {
 		if cfg.BypassSafetynet {

--- a/tools/export-config/main.go
+++ b/tools/export-config/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 	*region = strings.ToUpper(*region)
 
-	fromTime := time.Now().UTC()
+	fromTime := time.Now()
 	if *fromTimestamp != "" {
 		var err error
 		fromTime, err = time.Parse(time.RFC3339, *fromTimestamp)

--- a/tools/exposure-client/main.go
+++ b/tools/exposure-client/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	// When publishing multiple keys - they'll be on different days.
 	intervalCount := randIntervalCount()
-	intervalNumber := int32(time.Now().UTC().Unix()/600) - intervalCount
+	intervalNumber := int32(time.Now().Unix()/600) - intervalCount
 
 	exposureKeys := make([]model.ExposureKey, *numKeys)
 	for i, rawKey := range keys {

--- a/tools/federation-test/main.go
+++ b/tools/federation-test/main.go
@@ -56,7 +56,7 @@ func main() {
 		RegionIdentifiers:             includeRegions,
 		ExcludeRegionIdentifiers:      excludeRegions,
 		NextFetchToken:                *cursor,
-		LastFetchResponseKeyTimestamp: lastTime.UTC().Unix(),
+		LastFetchResponseKeyTimestamp: lastTime.Unix(),
 	}
 
 	// See https://github.com/grpc/grpc-go/blob/master/examples/route_guide/client/client.go


### PR DESCRIPTION
Now that the database uses TIMESTAMPTZ, time zones only affect the display
of times, not operations like comparison (provided Time.Equal is used) and
arithmetic.