### PR TITLE
Remove bypass_safetynet from persistence

### DIFF
--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	minPublishDurationEnv     = "MIN_PUBLISH_DURATION"
+	bypassSafetyNetEnv        = "BYPASS_SAFETYNET"
 	defaultMinPublishDiration = 5 * time.Second
 )
 
@@ -57,6 +58,13 @@ func main() {
 	defer db.Close(ctx)
 
 	cfg := config.New(db)
+
+	bypassSafetyNet := serverenv.ParseBool(ctx, bypassSafetyNetEnv, false)
+	if bypassSafetyNet {
+		logger.Warn("SafetyNet verification is bypassed. Do not bypass SafetyNet " +
+			"verification in production environments!")
+		cfg.BypassSafetyNet()
+	}
 
 	minLatency := serverenv.ParseDuration(ctx, minPublishDurationEnv, defaultMinPublishDiration)
 	logger.Infof("Request minimum latency is: %v", minLatency.String())

--- a/internal/api/config/config.go
+++ b/internal/api/config/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	db            *database.DB
 	refreshPeriod time.Duration
 
+	bypassSafetyNet bool
+
 	mu           sync.RWMutex
 	lastLoadTime time.Time
 	cache        map[string]*apiconfig.APIConfig
@@ -82,11 +84,19 @@ func (c *Config) loadConfig(ctx context.Context) error {
 
 	c.cache = make(map[string]*apiconfig.APIConfig)
 	for _, apiConfig := range configs {
+		apiConfig.BypassSafetyNet = c.bypassSafetyNet
 		c.cache[apiConfig.AppPackageName] = apiConfig
 	}
 	logger.Info("loaded new APIConfig values")
 	c.lastLoadTime = time.Now()
 	return nil
+}
+
+// BypassSafetyNet disables verification for testing purposes.
+func (c *Config) BypassSafetyNet() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.bypassSafetyNet = true
 }
 
 func (c *Config) AppPkgConfig(ctx context.Context, appPkg string) (*apiconfig.APIConfig, error) {

--- a/internal/database/apiconfig.go
+++ b/internal/database/apiconfig.go
@@ -34,7 +34,7 @@ func (db *DB) ReadAPIConfigs(ctx context.Context) ([]*apiconfig.APIConfig, error
 	query := `
 	    SELECT
 	    	app_package_name, platform, apk_digest, enforce_apk_digest, cts_profile_match, basic_integrity,
-        allowed_past_seconds, allowed_future_seconds, allowed_regions, all_regions, bypass_safetynet
+        allowed_past_seconds, allowed_future_seconds, allowed_regions, all_regions
 	    FROM
 	    	APIConfig`
 	rows, err := conn.Query(ctx, query)
@@ -57,7 +57,7 @@ func (db *DB) ReadAPIConfigs(ctx context.Context) ([]*apiconfig.APIConfig, error
 		if err := rows.Scan(&config.AppPackageName, &config.Platform, &apkDigest,
 			&config.EnforceApkDigest, &config.CTSProfileMatch, &config.BasicIntegrity,
 			&allowedPastSeconds, &allowedFutureSeconds, &regions,
-			&config.AllowAllRegions, &config.BypassSafetynet); err != nil {
+			&config.AllowAllRegions); err != nil {
 			return nil, err
 		}
 		if apkDigest.Valid {

--- a/internal/model/apiconfig/config.go
+++ b/internal/model/apiconfig/config.go
@@ -39,7 +39,11 @@ type APIConfig struct {
 	AllowedFutureTime time.Duration   `db:"allowed_future_seconds"`
 	AllowedRegions    map[string]bool `db:"allowed_regions"`
 	AllowAllRegions   bool            `db:"all_regions"`
-	BypassSafetynet   bool            `db:"bypass_safetynet"`
+
+	// BypassSafetyNet is an internal field for testing that bypasses
+	// SafetyNet verification. It is not read from a database and is used for
+	// testing only.
+	BypassSafetyNet bool
 }
 
 // New creates a new, empty API config

--- a/internal/serverenv/env.go
+++ b/internal/serverenv/env.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/logging"
@@ -240,4 +241,21 @@ func ParseDuration(ctx context.Context, name string, defaultValue time.Duration)
 		return defaultValue
 	}
 	return dur
+}
+
+// ParseBool parses a bool string stored in the named environment variable. If
+// the variable's values is empty or cannot be parsed as a bool, the default
+// value is returned instead.
+func ParseBool(ctx context.Context, name string, defaultValue bool) bool {
+	val := os.Getenv(name)
+	if val == "" {
+		return defaultValue
+	}
+
+	b, err := strconv.ParseBool(val)
+	if err != nil {
+		logging.FromContext(ctx).Warnf("Failed to parse $%s value %q, using default %t", name, val, defaultValue)
+		return defaultValue
+	}
+	return b
 }

--- a/internal/verification/verify.go
+++ b/internal/verification/verify.go
@@ -59,12 +59,12 @@ func VerifySafetyNet(ctx context.Context, requestTime time.Time, cfg *apiconfig.
 	}
 
 	opts := cfg.VerifyOpts(requestTime)
-	err := ValidateAttestation(ctx, data.Verification, opts)
-	if err != nil {
-		if cfg.BypassSafetynet {
-			logger.Errorf("safetynet failed, but bypass enabled for app: '%v', failure: %v", data.AppPackageName, err)
+	if err := ValidateAttestation(ctx, data.Verification, opts); err != nil {
+		if cfg.BypassSafetyNet {
+			logger.Errorf("bypassing safetynet verification for: '%v'", data.AppPackageName)
 			return nil
 		}
+
 		return fmt.Errorf("android.ValidateAttestation: %w", err)
 	}
 

--- a/internal/verification/verify_test.go
+++ b/internal/verification/verify_test.go
@@ -96,7 +96,7 @@ func TestVerifySafetyNet(t *testing.T) {
 	allRegionsSafetyCheckDisabled := &apiconfig.APIConfig{
 		AppPackageName:  appPkgName,
 		AllowAllRegions: true,
-		BypassSafetynet: true,
+		BypassSafetyNet: true,
 	}
 
 	cases := []struct {

--- a/migrations/000007_drop_bypass_safetynet.down.sql
+++ b/migrations/000007_drop_bypass_safetynet.down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE APIConfig
+  ADD COLUMN bypass_safetynet bool NOT NULL;
+
+END;

--- a/migrations/000007_drop_bypass_safetynet.up.sql
+++ b/migrations/000007_drop_bypass_safetynet.up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- Drop bypass_safetynet field from persistence
+
+ALTER TABLE APIConfig
+  DROP COLUMN bypass_safetynet;
+
+END;


### PR DESCRIPTION
This removes the bypass_safetynet column from the database and associated migrations. It's still possible to disable SafetyNet verifications during testing and during server startup.

Fixes GH-96