### PR TITLE
Build ko, as prerequisite, during deploy.

### DIFF
--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -3,6 +3,12 @@ options:
   - 'KO_DOCKER_REPO=us.gcr.io/${PROJECT_ID}'
   - 'DOCKER_REPO_OVERRIDE=us.gcr.io/${PROJECT_ID}'
 steps:
+# Build ko, prerequisite.
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/ko', '-f', 'ko.Dockerfile' 'terraform/']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', 'gcr.io/$PROJECT_ID/ko']
+
 # Tests
 - name: 'mirror.gcr.io/library/golang'
   env:

--- a/terraform/ko.Dockerfile
+++ b/terraform/ko.Dockerfile
@@ -1,0 +1,3 @@
+FROM golang
+RUN go get github.com/google/ko/cmd/ko
+ENTRYPOINT ["ko"]


### PR DESCRIPTION
This removes a manual step at a cost of ~1 minute per deploy, but
that ~1 minute was going to be mandatory on the first build anyway.

(this is up for debate - lmk if you think the manual step is better,
or, alternately, if you think it'd be better to add a little complexity
for the benefit of saving a little time.)