### PR TITLE
Handle padded/non-padded and std/url-encoded base64

### DIFF
--- a/internal/android/safetynet.go
+++ b/internal/android/safetynet.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/base64"
 	"fmt"
 	"runtime/trace"
 	"time"
 
+	"github.com/google/exposure-notifications-server/internal/base64util"
 	"github.com/google/exposure-notifications-server/internal/logging"
 
 	"github.com/dgrijalva/jwt-go"
@@ -62,7 +62,7 @@ func ValidateAttestation(ctx context.Context, attestation string, opts VerifyOpt
 	if !ok {
 		return fmt.Errorf("invalid nonce claim, not a string")
 	}
-	nonceClaimBytes, err := base64.StdEncoding.DecodeString(nonceClaimB64)
+	nonceClaimBytes, err := base64util.DecodeString(nonceClaimB64)
 	if err != nil {
 		return fmt.Errorf("unable to decode nonce claim data: %w", err)
 	}
@@ -142,7 +142,7 @@ func keyFunc(ctx context.Context, tok *jwt.Token) (interface{}, error) {
 		if certStr == "" {
 			return nil, fmt.Errorf("certificate is empty")
 		}
-		certData, err := base64.StdEncoding.DecodeString(certStr.(string))
+		certData, err := base64util.DecodeString(certStr.(string))
 		if err != nil {
 			return nil, fmt.Errorf("invalid certificate encoding: %w", err)
 		}

--- a/internal/android/safetynet_test.go
+++ b/internal/android/safetynet_test.go
@@ -16,10 +16,10 @@ package android
 
 import (
 	"context"
-	"encoding/base64"
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/internal/base64util"
 	"github.com/google/exposure-notifications-server/internal/model"
 )
 
@@ -66,7 +66,7 @@ func TestVerifyAttestation(t *testing.T) {
 	}
 
 	expectedNonce := NewNonce(publish).Nonce()
-	actualBytes, err := base64.StdEncoding.DecodeString(claims["nonce"].(string))
+	actualBytes, err := base64util.DecodeString(claims["nonce"].(string))
 	actualNonce := string(actualBytes)
 	if err != nil {
 		t.Fatalf("unable to decode nonce from attestation: %v", err)

--- a/internal/base64util/decode.go
+++ b/internal/base64util/decode.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package base64util extracts base64 encoding/decoding logic into a single API
+// that is tolerant of various paddings.
+package base64util
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// DecodeString decodes the given string as base64.
+func DecodeString(s string) ([]byte, error) {
+	s = unpad(convertToURLEncoding(s))
+	return base64.RawURLEncoding.DecodeString(s)
+}
+
+// convertToURLEncoding converts the given string to URL-encoded.
+func convertToURLEncoding(s string) string {
+	s = strings.ReplaceAll(s, "+", "-")
+	s = strings.ReplaceAll(s, "/", "_")
+	return s
+}
+
+// unpad removes any padding from the string.
+func unpad(s string) string {
+	return strings.TrimRight(s, "=")
+}

--- a/internal/base64util/decode_test.go
+++ b/internal/base64util/decode_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base64util
+
+import (
+	"testing"
+)
+
+func TestDecodeString(t *testing.T) {
+	cases := []struct {
+		encoded string
+		raw     string
+	}{
+		{"FPucA9l+", "\x14\xfb\x9c\x03\xd9\x7e"},
+		{"FPucA9l-", "\x14\xfb\x9c\x03\xd9\x7e"},
+		{"FPucA9k=", "\x14\xfb\x9c\x03\xd9"},
+		{"FPucA9k", "\x14\xfb\x9c\x03\xd9"},
+		{"FPucAw==", "\x14\xfb\x9c\x03"},
+		{"FPucAw", "\x14\xfb\x9c\x03"},
+		{"", ""},
+		{"=", ""},
+		{"==", ""},
+		{"Zg==", "f"},
+		{"Zg=", "f"},
+		{"Zg", "f"},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		decoded, err := DecodeString(c.encoded)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := string(decoded), c.raw; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+	}
+}

--- a/internal/database/exposure.go
+++ b/internal/database/exposure.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/exposure-notifications-server/internal/base64util"
 	"github.com/google/exposure-notifications-server/internal/model"
 
 	pgx "github.com/jackc/pgx/v4"
@@ -229,7 +230,7 @@ func encodeCursor(s string) string {
 }
 
 func decodeCursor(encoded string) (string, error) {
-	b, err := base64.StdEncoding.DecodeString(encoded)
+	b, err := base64util.DecodeString(encoded)
 	if err != nil {
 		return "", fmt.Errorf("decoding cursor: %v", err)
 	}
@@ -241,5 +242,5 @@ func encodeExposureKey(b []byte) string {
 }
 
 func decodeExposureKey(encoded string) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(encoded)
+	return base64util.DecodeString(encoded)
 }

--- a/internal/model/exposure.go
+++ b/internal/model/exposure.go
@@ -15,10 +15,11 @@
 package model
 
 import (
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/google/exposure-notifications-server/internal/base64util"
 )
 
 const (
@@ -177,7 +178,7 @@ func (t *Transformer) TransformPublish(inData *Publish, batchTime time.Time) ([]
 	}
 
 	for _, exposureKey := range inData.Keys {
-		binKey, err := base64.StdEncoding.DecodeString(exposureKey.Key)
+		binKey, err := base64util.DecodeString(exposureKey.Key)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/model/exposure_test.go
+++ b/internal/model/exposure_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/internal/base64util"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -74,17 +75,6 @@ func TestInvalidBase64(t *testing.T) {
 	}
 }
 
-func decode(b64 string) ([]byte, error) {
-	data, err := base64.RawStdEncoding.DecodeString(b64)
-	if err != nil {
-		data, err = base64.StdEncoding.DecodeString(b64)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return data, nil
-}
-
 func TestDifferentEncodings(t *testing.T) {
 	data := "this is some data"
 
@@ -103,7 +93,7 @@ func TestDifferentEncodings(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		decoded, err := decode(c.input)
+		decoded, err := base64util.DecodeString(c.input)
 		if err != nil {
 			t.Errorf("%v error: %v", c.name, err)
 		} else if string(decoded) != data {
@@ -255,7 +245,7 @@ func encodeKey(key []byte) string {
 }
 
 func decodeKey(b64key string, t *testing.T) []byte {
-	k, err := base64.StdEncoding.DecodeString(b64key)
+	k, err := base64util.DecodeString(b64key)
 	if err != nil {
 		t.Fatalf("unable to decode key: %v", err)
 	}


### PR DESCRIPTION
This introduces a new internal package base64util that simplifies decoding base64 strings. It handles padded and non-padded strings as well as Standard and URL encoded values.

Fixes GH-160