### PR TITLE
Restructure internal/api/export files.

### DIFF
--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -68,7 +68,7 @@ func main() {
 	}
 	defer db.Close(ctx)
 
-	batchServer, err := export.NewBatchServer(db, &config, env)
+	batchServer, err := export.NewServer(db, &config, env)
 	if err != nil {
 		logger.Fatalf("unable to create server: %v", err)
 	}

--- a/internal/api/export/batcher.go
+++ b/internal/api/export/batcher.go
@@ -1,0 +1,156 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package export defines the handlers for managing exposure key exporting.
+package export
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/logging"
+	"github.com/google/exposure-notifications-server/internal/model"
+)
+
+// CreateBatchesHandler is a handler to iterate the rows of ExportConfig and
+// create entries in ExportBatchJob as appropriate.
+func (s *Server) CreateBatchesHandler(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), s.config.CreateTimeout)
+	defer cancel()
+	logger := logging.FromContext(ctx)
+
+	// Obtain lock to make sure there are no other processes working to create batches.
+	lock := "create_batches"
+	unlockFn, err := s.db.Lock(ctx, lock, s.config.CreateTimeout)
+	if err != nil {
+		if errors.Is(err, database.ErrAlreadyLocked) {
+			msg := fmt.Sprintf("Lock %s already in use, no work will be performed", lock)
+			logger.Infof(msg)
+			w.Write([]byte(msg)) // We return status 200 here so that Cloud Scheduler does not retry.
+			return
+		}
+		logger.Errorf("Could not acquire lock %s: %v", lock, err)
+		http.Error(w, fmt.Sprintf("Could not acquire lock %s, check logs.", lock), http.StatusInternalServerError)
+		return
+	}
+	defer unlockFn()
+
+	now := time.Now()
+	err = s.db.IterateExportConfigs(ctx, now, func(ec *model.ExportConfig) error {
+		if err := s.maybeCreateBatches(ctx, ec, now); err != nil {
+			logger.Errorf("Failed to create batches for config %d: %v, continuing to next config", ec.ConfigID, err)
+		}
+		return nil
+	})
+	switch {
+	case err == nil:
+		return
+	case errors.Is(err, context.DeadlineExceeded):
+		logger.Infof("Timed out creating batches, batch creation will continue on next invocation")
+	case errors.Is(err, context.Canceled):
+		logger.Infof("Canceled while creating batches, batch creation will continue on next invocation")
+	default:
+		logger.Errorf("creating batches: %v", err)
+		http.Error(w, "Failed to create batches, check logs.", http.StatusInternalServerError)
+	}
+}
+
+func (s *Server) maybeCreateBatches(ctx context.Context, ec *model.ExportConfig, now time.Time) error {
+	logger := logging.FromContext(ctx)
+
+	latestEnd, err := s.db.LatestExportBatchEnd(ctx, ec)
+	if err != nil {
+		return fmt.Errorf("fetching most recent batch for config %d: %w", ec.ConfigID, err)
+	}
+
+	ranges := makeBatchRanges(ec.Period, latestEnd, now)
+	if len(ranges) == 0 {
+		logger.Infof("Batch creation for config %d is not required, skipping", ec.ConfigID)
+		return nil
+	}
+
+	var batches []*model.ExportBatch
+	for _, br := range ranges {
+		batches = append(batches, &model.ExportBatch{
+			ConfigID:       ec.ConfigID,
+			BucketName:     ec.BucketName,
+			FilenameRoot:   ec.FilenameRoot,
+			StartTimestamp: br.start,
+			EndTimestamp:   br.end,
+			Region:         ec.Region,
+			Status:         model.ExportBatchOpen,
+			SigningKey:     ec.SigningKey,
+		})
+	}
+
+	if err := s.db.AddExportBatches(ctx, batches); err != nil {
+		return fmt.Errorf("creating export batches for config %d: %w", ec.ConfigID, err)
+	}
+
+	logger.Infof("Created %d batch(es) for config %d", len(batches), ec.ConfigID)
+	return nil
+}
+
+type batchRange struct {
+	start, end time.Time
+}
+
+var sanityDate = time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func makeBatchRanges(period time.Duration, latestEnd, now time.Time) []batchRange {
+
+	// Compute the end of the exposure publish window; we don't want any batches with an end date greater than this time.
+	publishEnd := model.TruncateWindow(now)
+
+	// Special case: if there have not been batches before, return only a single one.
+	// We use sanityDate here because the loop below will happily create batch ranges
+	// until the beginning of time otherwise.
+	if latestEnd.Before(sanityDate) {
+		// We want to create a batch aligned on the period, but not overlapping the current publish window.
+		// To do this, we use the publishEnd and truncate it to the period; this becomes the end date.
+		// Then we just subtract the period to get the start date.
+		end := publishEnd.Truncate(period)
+		start := end.Add(-period)
+		return []batchRange{{start: start, end: end}}
+	}
+
+	// Truncate now to align with period; use this as the end date.
+	end := now.Truncate(period)
+
+	// If the end date < latest end date, we already have a batch that covers this period, so return no batches.
+	if end.Before(latestEnd) {
+		return nil
+	}
+
+	// Subtract period to get the start date.
+	start := end.Add(-period)
+
+	// Build up a list of batches until we reach that latestEnd.
+	// Allow for overlap so we don't miss keys; this might happen in the event that
+	// an ExportConfig was edited and the new settings don't quite align.
+	ranges := []batchRange{}
+	for end.After(latestEnd) {
+		// If the batch's end is after the publish window, don't add this range.
+		if !end.After(publishEnd) {
+			ranges = append([]batchRange{{start: start, end: end}}, ranges...)
+		}
+		start = start.Add(-period)
+		end = end.Add(-period)
+	}
+	return ranges
+}

--- a/internal/api/export/batcher_test.go
+++ b/internal/api/export/batcher_test.go
@@ -19,11 +19,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/google/exposure-notifications-server/internal/database"
-	"github.com/google/exposure-notifications-server/internal/serverenv"
-	"github.com/google/exposure-notifications-server/internal/signing"
-	"github.com/google/exposure-notifications-server/internal/storage"
 )
 
 type simpleBatchRange struct {
@@ -165,43 +160,4 @@ func toSimpleBatchRange(t *testing.T, batches []batchRange) []simpleBatchRange {
 		simple = append(simple, simpleBatchRange{start: toSimpleTime(t, br.start), end: toSimpleTime(t, br.end)})
 	}
 	return simple
-}
-
-func TestNewBatchServer(t *testing.T) {
-	testCases := []struct {
-		name string
-		env  *serverenv.ServerEnv
-		err  error
-	}{
-		{
-			name: "nil Blobstore",
-			env:  &serverenv.ServerEnv{Blobstore: nil, KeyManager: nil},
-			err:  fmt.Errorf("export.NewBatchServer requires Blobstore present in the ServerEnv"),
-		},
-		{
-			name: "nil KeyManager",
-			env:  &serverenv.ServerEnv{Blobstore: &storage.GoogleCloudStorage{}, KeyManager: nil},
-			err:  fmt.Errorf("export.NewBatchServer requires KeyManager present in the ServerEnv"),
-		},
-		{
-			name: "Fully Specified",
-			env:  &serverenv.ServerEnv{Blobstore: &storage.GoogleCloudStorage{}, KeyManager: &signing.GCPKMS{}},
-			err:  nil,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := NewBatchServer(&database.DB{}, &Config{}, tc.env)
-			if tc.err != nil {
-				if err.Error() != tc.err.Error() {
-					t.Fatalf("got %+v: want %v", err, tc.err)
-				}
-			} else {
-				if got.env != tc.env {
-					t.Fatalf("got %+v: want %v", got.env, tc.env)
-				}
-			}
-		})
-	}
 }

--- a/internal/api/export/exportfile.go
+++ b/internal/api/export/exportfile.go
@@ -39,6 +39,7 @@ const (
 	algorithm = "1.2.840.10045.4.3.2"
 )
 
+// MarshalExportFile converts the inputs into an encoded byte array.
 func MarshalExportFile(eb *model.ExportBatch, exposures []*model.Exposure, batchNum, batchSize int, signer crypto.Signer) ([]byte, error) {
 	// create main exposure key export binary
 	expContents, err := marshalContents(eb, exposures, int32(batchNum), int32(batchSize))

--- a/internal/api/export/server.go
+++ b/internal/api/export/server.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"fmt"
+
+	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/serverenv"
+)
+
+// NewServer makes a Server.
+func NewServer(db *database.DB, config *Config, env *serverenv.ServerEnv) (*Server, error) {
+	// Validate config.
+	if env.Blobstore == nil {
+		return nil, fmt.Errorf("export.NewBatchServer requires Blobstore present in the ServerEnv")
+	}
+	if env.KeyManager == nil {
+		return nil, fmt.Errorf("export.NewBatchServer requires KeyManager present in the ServerEnv")
+	}
+
+	return &Server{
+		db:     db,
+		config: config,
+		env:    env,
+	}, nil
+}
+
+// Server hosts end points to manage export batches.
+type Server struct {
+	db     *database.DB
+	config *Config
+	env    *serverenv.ServerEnv
+}

--- a/internal/api/export/server_test.go
+++ b/internal/api/export/server_test.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/serverenv"
+	"github.com/google/exposure-notifications-server/internal/signing"
+	"github.com/google/exposure-notifications-server/internal/storage"
+)
+
+// TestNewServer tests NewServer().
+func TestNewServer(t *testing.T) {
+	testCases := []struct {
+		name string
+		env  *serverenv.ServerEnv
+		err  error
+	}{
+		{
+			name: "nil Blobstore",
+			env:  &serverenv.ServerEnv{Blobstore: nil, KeyManager: nil},
+			err:  fmt.Errorf("export.NewBatchServer requires Blobstore present in the ServerEnv"),
+		},
+		{
+			name: "nil KeyManager",
+			env:  &serverenv.ServerEnv{Blobstore: &storage.GoogleCloudStorage{}, KeyManager: nil},
+			err:  fmt.Errorf("export.NewBatchServer requires KeyManager present in the ServerEnv"),
+		},
+		{
+			name: "Fully Specified",
+			env:  &serverenv.ServerEnv{Blobstore: &storage.GoogleCloudStorage{}, KeyManager: &signing.GCPKMS{}},
+			err:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NewServer(&database.DB{}, &Config{}, tc.env)
+			if tc.err != nil {
+				if err.Error() != tc.err.Error() {
+					t.Fatalf("got %+v: want %v", err, tc.err)
+				}
+			} else {
+				if got.env != tc.env {
+					t.Fatalf("got %+v: want %v", got.env, tc.env)
+				}
+			}
+		})
+	}
+}

--- a/internal/api/export/worker.go
+++ b/internal/api/export/worker.go
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package export defines the handlers for managing exporure key exporting
 package export
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -27,7 +25,6 @@ import (
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/logging"
 	"github.com/google/exposure-notifications-server/internal/model"
-	"github.com/google/exposure-notifications-server/internal/serverenv"
 )
 
 const (
@@ -35,160 +32,8 @@ const (
 	blobOperationTimeout = 50 * time.Second
 )
 
-// NewBatchServer makes a BatchServer.
-func NewBatchServer(db *database.DB, config *Config, env *serverenv.ServerEnv) (*BatchServer, error) {
-	// Validate config.
-	if env.Blobstore == nil {
-		return nil, fmt.Errorf("export.NewBatchServer requires Blobstore present in the ServerEnv")
-	}
-	if env.KeyManager == nil {
-		return nil, fmt.Errorf("export.NewBatchServer requires KeyManager present in the ServerEnv")
-	}
-
-	return &BatchServer{
-		db:     db,
-		config: config,
-		env:    env,
-	}, nil
-}
-
-// BatchServer hosts end points to manage export batches.
-type BatchServer struct {
-	db     *database.DB
-	config *Config
-	env    *serverenv.ServerEnv
-}
-
-// CreateBatchesHandler is a handler to iterate the rows of ExportConfig and
-// create entries in ExportBatchJob as appropriate.
-func (s *BatchServer) CreateBatchesHandler(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithTimeout(r.Context(), s.config.CreateTimeout)
-	defer cancel()
-	logger := logging.FromContext(ctx)
-
-	// Obtain lock to make sure there are no other processes working to create batches.
-	lock := "create_batches"
-	unlockFn, err := s.db.Lock(ctx, lock, s.config.CreateTimeout)
-	if err != nil {
-		if errors.Is(err, database.ErrAlreadyLocked) {
-			msg := fmt.Sprintf("Lock %s already in use, no work will be performed", lock)
-			logger.Infof(msg)
-			w.Write([]byte(msg)) // We return status 200 here so that Cloud Scheduler does not retry.
-			return
-		}
-		logger.Errorf("Could not acquire lock %s: %v", lock, err)
-		http.Error(w, fmt.Sprintf("Could not acquire lock %s, check logs.", lock), http.StatusInternalServerError)
-		return
-	}
-	defer unlockFn()
-
-	now := time.Now()
-	err = s.db.IterateExportConfigs(ctx, now, func(ec *model.ExportConfig) error {
-		if err := s.maybeCreateBatches(ctx, ec, now); err != nil {
-			logger.Errorf("Failed to create batches for config %d: %v, continuing to next config", ec.ConfigID, err)
-		}
-		return nil
-	})
-	switch {
-	case err == nil:
-		return
-	case errors.Is(err, context.DeadlineExceeded):
-		logger.Infof("Timed out creating batches, batch creation will continue on next invocation")
-	case errors.Is(err, context.Canceled):
-		logger.Infof("Canceled while creating batches, batch creation will continue on next invocation")
-	default:
-		logger.Errorf("creating batches: %v", err)
-		http.Error(w, "Failed to create batches, check logs.", http.StatusInternalServerError)
-	}
-}
-
-func (s *BatchServer) maybeCreateBatches(ctx context.Context, ec *model.ExportConfig, now time.Time) error {
-	logger := logging.FromContext(ctx)
-
-	latestEnd, err := s.db.LatestExportBatchEnd(ctx, ec)
-	if err != nil {
-		return fmt.Errorf("fetching most recent batch for config %d: %w", ec.ConfigID, err)
-	}
-
-	ranges := makeBatchRanges(ec.Period, latestEnd, now)
-	if len(ranges) == 0 {
-		logger.Infof("Batch creation for config %d is not required, skipping", ec.ConfigID)
-		return nil
-	}
-
-	var batches []*model.ExportBatch
-	for _, br := range ranges {
-		batches = append(batches, &model.ExportBatch{
-			ConfigID:       ec.ConfigID,
-			BucketName:     ec.BucketName,
-			FilenameRoot:   ec.FilenameRoot,
-			StartTimestamp: br.start,
-			EndTimestamp:   br.end,
-			Region:         ec.Region,
-			Status:         model.ExportBatchOpen,
-			SigningKey:     ec.SigningKey,
-		})
-	}
-
-	if err := s.db.AddExportBatches(ctx, batches); err != nil {
-		return fmt.Errorf("creating export batches for config %d: %w", ec.ConfigID, err)
-	}
-
-	logger.Infof("Created %d batch(es) for config %d", len(batches), ec.ConfigID)
-	return nil
-}
-
-type batchRange struct {
-	start, end time.Time
-}
-
-var sanityDate = time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
-
-func makeBatchRanges(period time.Duration, latestEnd, now time.Time) []batchRange {
-
-	// Compute the end of the exposure publish window; we don't want any batches with an end date greater than this time.
-	publishEnd := model.TruncateWindow(now)
-
-	// Special case: if there have not been batches before, return only a single one.
-	// We use sanityDate here because the loop below will happily create batch ranges
-	// until the beginning of time otherwise.
-	if latestEnd.Before(sanityDate) {
-		// We want to create a batch aligned on the period, but not overlapping the current publish window.
-		// To do this, we use the publishEnd and truncate it to the period; this becomes the end date.
-		// Then we just subtract the period to get the start date.
-		end := publishEnd.Truncate(period)
-		start := end.Add(-period)
-		return []batchRange{{start: start, end: end}}
-	}
-
-	// Truncate now to align with period; use this as the end date.
-	end := now.Truncate(period)
-
-	// If the end date < latest end date, we already have a batch that covers this period, so return no batches.
-	if end.Before(latestEnd) {
-		return nil
-	}
-
-	// Subtract period to get the start date.
-	start := end.Add(-period)
-
-	// Build up a list of batches until we reach that latestEnd.
-	// Allow for overlap so we don't miss keys; this might happen in the event that
-	// an ExportConfig was edited and the new settings don't quite align.
-	ranges := []batchRange{}
-	for end.After(latestEnd) {
-		// If the batch's end is after the publish window, don't add this range.
-		if !end.After(publishEnd) {
-			ranges = append([]batchRange{{start: start, end: end}}, ranges...)
-		}
-		start = start.Add(-period)
-		end = end.Add(-period)
-	}
-	return ranges
-}
-
 // WorkerHandler is a handler to iterate the rows of ExportBatch, and creates GCS files.
-func (s *BatchServer) WorkerHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) WorkerHandler(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), s.config.WorkerTimeout)
 	defer cancel()
 	logger := logging.FromContext(ctx)
@@ -230,7 +75,7 @@ func (s *BatchServer) WorkerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *BatchServer) exportBatch(ctx context.Context, eb *model.ExportBatch) error {
+func (s *Server) exportBatch(ctx context.Context, eb *model.ExportBatch) error {
 	logger := logging.FromContext(ctx)
 	logger.Infof("Processing export batch %d (root: %q, region: %s), max records per file %d", eb.BatchID, eb.FilenameRoot, eb.Region, s.config.MaxRecords)
 
@@ -338,7 +183,7 @@ func (s *BatchServer) exportBatch(ctx context.Context, eb *model.ExportBatch) er
 	return nil
 }
 
-func (s *BatchServer) createFile(ctx context.Context, exposures []*model.Exposure, eb *model.ExportBatch, batchNum, batchSize int) (string, error) {
+func (s *Server) createFile(ctx context.Context, exposures []*model.Exposure, eb *model.ExportBatch, batchNum, batchSize int) (string, error) {
 	logger := logging.FromContext(ctx)
 	signer, err := s.env.GetSignerForKey(ctx, eb.SigningKey)
 	if err != nil {
@@ -361,7 +206,7 @@ func (s *BatchServer) createFile(ctx context.Context, exposures []*model.Exposur
 	return objectName, nil
 }
 
-func (s *BatchServer) createIndex(ctx context.Context, eb *model.ExportBatch, newObjectNames []string) (string, int, error) {
+func (s *Server) createIndex(ctx context.Context, eb *model.ExportBatch, newObjectNames []string) (string, int, error) {
 	objects, err := s.db.LookupExportFiles(ctx, eb.ConfigID)
 	if err != nil {
 		return "", 0, fmt.Errorf("lookup existing export files for batch %d: %w", eb.BatchID, err)


### PR DESCRIPTION
This PR breaks things down into simpler files (e.g., `/create-batches` and `/worker` handlers are in separate files).