### PR TITLE
add federation services to terraform config

### DIFF
--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -23,12 +23,12 @@ steps:
   args:
   - publish
   - -P
-  - ./cmd/federation-pull
+  - ./cmd/federationin
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
   - -P
-  - ./cmd/federation
+  - ./cmd/federationout
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish

--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -24,12 +24,12 @@ steps:
   args:
   - publish
   - -P
-  - ./cmd/federation-pull
+  - ./cmd/federationin
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
   - -P
-  - ./cmd/federation
+  - ./cmd/federationout
 - name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -267,20 +267,20 @@ locals {
       value = "10"
     },
     {
-      name  = "DB_PASSWORD_SECRET"
-      value = google_secret_manager_secret_version.db-pwd-initial.name
+      name  = "DB_PASSWORD"
+      value = "secret://${google_secret_manager_secret_version.db-pwd-initial.name}"
     },
     {
-      name  = "DB_SSLKEY_SECRET"
-      value = google_secret_manager_secret_version.db-key.name
+      name  = "DB_SSLKEY"
+      value = "secret://${google_secret_manager_secret_version.db-key.name}"
     },
     {
-      name  = "DB_SSLCERT_SECRET"
-      value = google_secret_manager_secret_version.db-cert.name
+      name  = "DB_SSLCERT"
+      value = "secret://{$google_secret_manager_secret_version.db-cert.name}"
     },
     {
-      name  = "DB_SSLROOTCERT_SECRET"
-      value = google_secret_manager_secret_version.db-ca-cert.name
+      name  = "DB_SSLROOTCERT"
+      value = "secret://{$google_secret_manager_secret_version.db-ca-cert.name}"
     },
     {
       name  = "DB_SSLMODE"


### PR DESCRIPTION
I haven't actually run this yet, but the `terraform plan` output looks right.

I noticed there were a lot of env variables that seemed like they would apply across all our services, so I extracted those out into a local var. PTAL if any seem like they should not apply across all services.

I only added the noauth IAM for `federationout` since that's how it's configured in the test project.

I also didn't add the extra `gcloud alpha run` to deploy.yaml for these services since I wasn't sure why we would need them if we're using terraform to run the services.