### PR TITLE
Adjust batch boundary conditions so that published keys hit an open batch

### DIFF
--- a/internal/api/export/worker.go
+++ b/internal/api/export/worker.go
@@ -53,8 +53,11 @@ func (s *Server) WorkerHandler(w http.ResponseWriter, r *http.Request) {
 			// Fallthrough
 		}
 
+		// Only consider batches that closed a few minutes ago to allow the publish windows to close properly.
+		minutesAgo := time.Now().Add(-5 * time.Minute)
+
 		// Check for a batch and obtain a lease for it.
-		batch, err := s.db.LeaseBatch(ctx, s.config.WorkerTimeout, time.Now())
+		batch, err := s.db.LeaseBatch(ctx, s.config.WorkerTimeout, minutesAgo)
 		if err != nil {
 			logger.Errorf("Failed to lease batch: %v", err)
 			continue

--- a/internal/database/export_test.go
+++ b/internal/database/export_test.go
@@ -403,8 +403,8 @@ func TestKeysInBatch(t *testing.T) {
 		t.Errorf("End timestamps did not align original: %d, leased: %d", eb.EndTimestamp.UnixNano(), leased.EndTimestamp.UnixNano())
 	}
 
-	// Lookup the keys; they must be only the key created_at the endTimestamp
-	// (because start is exclusive, end is inclusive).
+	// Lookup the keys; they must be only the key created_at the startTimestamp
+	// (because start is inclusive, end is inclusive).
 	criteria := IterateExposuresCriteria{
 		IncludeRegions: []string{leased.Region},
 		SinceTimestamp: leased.StartTimestamp,
@@ -423,7 +423,7 @@ func TestKeysInBatch(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("Incorrect exposure key result length, got %d, want 1", len(got))
 	}
-	want := []byte("bbb")
+	want := []byte("aaa")
 	if string(got[0].ExposureKey) != string(want) {
 		t.Fatalf("Incorrect exposure key in batch, got %q, want %q", got[0].ExposureKey, want)
 	}

--- a/internal/database/exposure_test.go
+++ b/internal/database/exposure_test.go
@@ -93,18 +93,18 @@ func TestExposures(t *testing.T) {
 			[]int{1},
 		},
 		{
-			IterateExposuresCriteria{SinceTimestamp: exposures[1].CreatedAt},
-			[]int{2, 3}, // SinceTimestamp is exclusive
+			IterateExposuresCriteria{SinceTimestamp: exposures[2].CreatedAt},
+			[]int{2, 3}, // SinceTimestamp is inclusive
 		},
 		{
-			IterateExposuresCriteria{UntilTimestamp: exposures[1].CreatedAt},
-			[]int{0, 1}, // UntilTimestamp is inclusive
+			IterateExposuresCriteria{UntilTimestamp: exposures[2].CreatedAt},
+			[]int{0, 1}, // UntilTimestamp is exclusive
 		},
 		{
 			IterateExposuresCriteria{
 				IncludeRegions: []string{"CA"},
 				ExcludeRegions: []string{"MX"},
-				SinceTimestamp: exposures[1].CreatedAt,
+				SinceTimestamp: exposures[2].CreatedAt,
 			},
 			nil,
 		},


### PR DESCRIPTION
Fixes #284 