### PR TITLE
Clarify the text on signing the 'incremental files' and distributing public keys for this

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The server is responsible for the following functions:
 * Periodically generating incremental files that will be downloaded by mobile
   devices to perform the key matching algorithm on the mobile device.
 
-* Sending a public key to devices to digitally sign the incremental files with
-  a private key on the device.
+* Sending a public key to devices, and digitally signing the incremental files with
+  a private key.
 
 * Periodically deleting old temporary exposure keys. After 14 days, or
   configured time period, the exposure keys can no longer be matched to a device.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,7 @@ The Exposure Notification Server is responsible for the following functions:
 * Periodically generating incremental files that will be downloaded by mobile
   devices to perform the key-matching algorithm on the mobile device.
 
-* Sending a public key to devices to digitally sign the incremental files with
-  a private key on the device.
+* Sending a public key to devices, and digitally signing the incremental files with a private key.
 
 * Periodically deleting old temporary exposure keys. After 14 days, or
   configured time period, the exposure keys can no longer be matched to a device.


### PR DESCRIPTION
The original text 
"Sending a public key to devices to digitally sign the incremental files with a private key on the device."
was unclear, it somewhat implied that the mobile devices use the private key that's required for signing the "incremental files".