### PR TITLE
Add an index to exposure.create_at

### DIFF
--- a/migrations/000016_idx_exposure_created_at.down.sql
+++ b/migrations/000016_idx_exposure_created_at.down.sql
@@ -1,0 +1,19 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+DROP INDEX exposure_created_at_idx;
+
+END;

--- a/migrations/000016_idx_exposure_created_at.up.sql
+++ b/migrations/000016_idx_exposure_created_at.up.sql
@@ -1,0 +1,19 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+CREATE INDEX exposure_created_at_idx ON exposure USING BRIN(created_at);
+
+END;


### PR DESCRIPTION
This uses a BRIN index which will be most optimal given the size of the data.

Fixes GH-276