### PR TITLE
Add federation deployments to deploy.yaml

### DIFF
--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -64,7 +64,6 @@ steps:
     gcloud alpha run deploy export --image \
       us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/export:latest --region us-central1 \
       --platform managed --update-labels=env=staging --no-traffic
-
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
   args:

--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -64,3 +64,22 @@ steps:
     gcloud alpha run deploy export --image \
       us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/export:latest --region us-central1 \
       --platform managed --update-labels=env=staging --no-traffic
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  # `--platform managed` and `--no-traffic` only works in `alpha`
+  - |
+    gcloud alpha run deploy federationin --image \
+      us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/federationin:latest --region us-central1 \
+      --platform managed --update-labels=env=staging --no-traffic
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  # `--platform managed` and `--no-traffic` only works in `alpha`
+  - |
+    gcloud alpha run deploy federationout --image \
+      us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/federationout:latest --region us-central1 \
+      --platform managed --update-labels=env=staging --no-traffic


### PR DESCRIPTION
Missed in https://github.com/google/exposure-notifications-server/pull/260 because I didn't understand why we would need it, but now I do (because the Terraform deployments will only happen when Terraform is run, whereas this file will run every time a new commit is merged to master)