### PR TITLE
ensure a minimum export file length

### DIFF
--- a/internal/api/export/config.go
+++ b/internal/api/export/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	CreateTimeout     time.Duration `envconfig:"CREATE_BATCHES_TIMEOUT" default:"5m"`
 	WorkerTimeout     time.Duration `envconfig:"WORKER_TIMEOUT" default:"5m"`
 	MinRecords        int           `envconfig:"EXPORT_FILE_MIN_RECORDS" default:"1000"`
+	PaddingRange      int           `envconfig:"EXPORT_FILE_PADDING_RANGE" default:"100"`
 	MaxRecords        int           `envconfig:"EXPORT_FILE_MAX_RECORDS" default:"30000"`
 	DefaultKeyID      string        `envconfig:"EXPORT_FILE_DEFAULT_KEY_ID" default:"ExampleServer"`
 	DefaultKeyVersion string        `envconfig:"EXPORT_FILE_DEFAULT_KEY_VERSION" default:"1"`

--- a/internal/api/export/config.go
+++ b/internal/api/export/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Port              string        `envconfig:"PORT" default:"8080"`
 	CreateTimeout     time.Duration `envconfig:"CREATE_BATCHES_TIMEOUT" default:"5m"`
 	WorkerTimeout     time.Duration `envconfig:"WORKER_TIMEOUT" default:"5m"`
+	MinRecords        int           `envconfig:"EXPORT_FILE_MIN_RECORDS" default:"1000"`
 	MaxRecords        int           `envconfig:"EXPORT_FILE_MAX_RECORDS" default:"30000"`
 	DefaultKeyID      string        `envconfig:"EXPORT_FILE_DEFAULT_KEY_ID" default:"ExampleServer"`
 	DefaultKeyVersion string        `envconfig:"EXPORT_FILE_DEFAULT_KEY_VERSION" default:"1"`

--- a/internal/api/export/worker.go
+++ b/internal/api/export/worker.go
@@ -16,7 +16,9 @@ package export
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
+	"math/big"
 	"net/http"
 	"sort"
 	"strings"
@@ -112,6 +114,11 @@ func (s *Server) exportBatch(ctx context.Context, eb *model.ExportBatch) error {
 
 	if len(groups) == 0 {
 		logger.Infof("No records for export batch %d", eb.BatchID)
+	}
+
+	exposures, err = ensureMinNumExposures(exposures, eb.Region, s.config.MinRecords)
+	if err != nil {
+		return fmt.Errorf("ensureMinNumExposures: %w", err)
 	}
 
 	// Create the export files.
@@ -246,4 +253,61 @@ func exportFilename(eb *model.ExportBatch, batchNum int) string {
 
 func exportIndexFilename(eb *model.ExportBatch) string {
 	return fmt.Sprintf("%s/index.txt", eb.FilenameRoot)
+}
+
+// randomInt is inclusive, [min:max]
+func randomInt(min, max int) (int, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(max-min+1)))
+	if err != nil {
+		return 0, err
+	}
+	return int(n.Int64()) + min, nil
+}
+
+func ensureMinNumExposures(exposures []*model.Exposure, region string, minLength int) ([]*model.Exposure, error) {
+	if len(exposures) == 0 {
+		return nil, fmt.Errorf("cannot pad zero length exposures")
+	}
+	for len(exposures) < minLength {
+		// Pieces needed are
+		// (1) exposure key, (2) inerval number, (3) tranismission risk
+		// Exposure key is 16 random bytes.
+		eKey := make([]byte, model.KeyLength)
+		_, err := rand.Read(eKey)
+		if err != nil {
+			return nil, fmt.Errorf("rand.Read: %w", err)
+		}
+
+		// Transmission risk is within the bounds.
+		transmissionRisk, err := randomInt(model.MinTransmissionRisk, model.MaxTransmissionRisk)
+		if err != nil {
+			return nil, fmt.Errorf("randomInt: %w", err)
+		}
+
+		// The interval number is pulled from an existing one in the batch
+		// at random.
+		fromIdx, err := randomInt(0, len(exposures)-1)
+		if err != nil {
+			return nil, fmt.Errorf("randomInt: %w", err)
+		}
+		intervalNumber := exposures[fromIdx].IntervalNumber
+		// Same with the interval count.
+		fromIdx, err = randomInt(0, len(exposures)-1)
+		if err != nil {
+			return nil, fmt.Errorf("randomInt: %w", err)
+		}
+		intervalCount := exposures[fromIdx].IntervalCount
+
+		ek := &model.Exposure{
+			ExposureKey:      eKey,
+			TransmissionRisk: transmissionRisk,
+			Regions:          []string{region},
+			IntervalNumber:   intervalNumber,
+			IntervalCount:    intervalCount,
+			// The rest of the model.Exposure fields are not used in the export file.
+		}
+		exposures = append(exposures, ek)
+	}
+
+	return exposures, nil
 }

--- a/internal/api/export/worker_test.go
+++ b/internal/api/export/worker_test.go
@@ -1,0 +1,117 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/google/exposure-notifications-server/internal/model"
+)
+
+func TestRandomInt(t *testing.T) {
+	expected := make(map[int]bool)
+	for i := model.MinTransmissionRisk; i <= model.MaxTransmissionRisk; i++ {
+		expected[i] = true
+	}
+
+	// Run through 1,000 iterations. To ensure the entire range can be hit.
+	for i := 0; i < 1000; i++ {
+		v, err := randomInt(model.MinTransmissionRisk, model.MaxTransmissionRisk)
+		if err != nil {
+			t.Fatalf("error getting random data")
+		}
+		if v < model.MinTransmissionRisk || v > model.MaxTransmissionRisk {
+			t.Fatalf("random data outside expected bounds. %v <= %v <= %v",
+				model.MinTransmissionRisk, v, model.MaxTransmissionRisk)
+		}
+		delete(expected, v)
+	}
+	if len(expected) != 0 {
+		t.Fatalf("not all values hit in random range: %v", expected)
+	}
+}
+
+func TestDoNotPadZeroLength(t *testing.T) {
+	exposures := make([]*model.Exposure, 0)
+	_, err := ensureMinNumExposures(exposures, "US", 1000)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+}
+
+func addExposure(t *testing.T, exposures []*model.Exposure, interval, count int32, risk int) []*model.Exposure {
+	key := make([]byte, model.KeyLength)
+	_, err := rand.Read(key)
+	if err != nil {
+		t.Fatalf("error getting random data: %v", err)
+	}
+	return append(exposures,
+		&model.Exposure{
+			ExposureKey:      key,
+			TransmissionRisk: risk,
+			IntervalNumber:   interval,
+			IntervalCount:    count,
+		})
+}
+
+func TestEnsureMinExposures(t *testing.T) {
+	expectedTR := make(map[int]bool)
+	for i := model.MinTransmissionRisk; i <= model.MaxTransmissionRisk; i++ {
+		expectedTR[i] = true
+	}
+	// Insert a few exposures - that will be used to base the interval information off of.
+	exposures := make([]*model.Exposure, 0)
+	exposures = addExposure(t, exposures, 123456, 144, 0)
+	exposures = addExposure(t, exposures, 789101, 88, 0)
+	exposures = addExposure(t, exposures, 334455, 72, 0)
+	// all of these combinations are expected
+	eIntervals := make(map[string]bool)
+	eIntervals["123456.144"] = true // covered by input
+	eIntervals["123456.88"] = false
+	eIntervals["123456.72"] = false
+	eIntervals["789101.144"] = false
+	eIntervals["789101.88"] = true
+	eIntervals["789101.72"] = false
+	eIntervals["334455.144"] = false
+	eIntervals["334455.88"] = false
+	eIntervals["334455.72"] = true
+
+	// pad the download.
+	exposures, err := ensureMinNumExposures(exposures, "US", 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(exposures) != 1000 {
+		t.Errorf("wrong number of exposures, want: 1000, got: %v", len(exposures))
+	}
+
+	for _, e := range exposures {
+		delete(expectedTR, e.TransmissionRisk)
+		eIntervals[fmt.Sprintf("%v.%v", e.IntervalNumber, e.IntervalCount)] = true
+	}
+	if len(expectedTR) != 0 {
+		t.Errorf("Didn't cover all expected transmission risks in batch of 1000: %v", expectedTR)
+	}
+	if len(eIntervals) != 9 {
+		t.Errorf("Unexpected number of intervalNum/count combinations, want: 6, got: %v", len(eIntervals))
+	}
+	for k, v := range eIntervals {
+		if !v {
+			t.Errorf("interval %v was not found in output", k)
+		}
+	}
+}

--- a/internal/api/export/worker_test.go
+++ b/internal/api/export/worker_test.go
@@ -47,7 +47,7 @@ func TestRandomInt(t *testing.T) {
 
 func TestDoNotPadZeroLength(t *testing.T) {
 	exposures := make([]*model.Exposure, 0)
-	_, err := ensureMinNumExposures(exposures, "US", 1000)
+	_, err := ensureMinNumExposures(exposures, "US", 1000, 100)
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
@@ -77,26 +77,20 @@ func TestEnsureMinExposures(t *testing.T) {
 	exposures := make([]*model.Exposure, 0)
 	exposures = addExposure(t, exposures, 123456, 144, 0)
 	exposures = addExposure(t, exposures, 789101, 88, 0)
-	exposures = addExposure(t, exposures, 334455, 72, 0)
 	// all of these combinations are expected
 	eIntervals := make(map[string]bool)
 	eIntervals["123456.144"] = true // covered by input
 	eIntervals["123456.88"] = false
-	eIntervals["123456.72"] = false
 	eIntervals["789101.144"] = false
 	eIntervals["789101.88"] = true
-	eIntervals["789101.72"] = false
-	eIntervals["334455.144"] = false
-	eIntervals["334455.88"] = false
-	eIntervals["334455.72"] = true
 
 	// pad the download.
-	exposures, err := ensureMinNumExposures(exposures, "US", 1000)
+	exposures, err := ensureMinNumExposures(exposures, "US", 2000, 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(exposures) != 1000 {
-		t.Errorf("wrong number of exposures, want: 1000, got: %v", len(exposures))
+	if len(exposures) < 2000 || len(exposures) > 2010 {
+		t.Errorf("wrong number of exposures, want: >=2000 and <=2010, got: %v", len(exposures))
 	}
 
 	for _, e := range exposures {
@@ -106,8 +100,8 @@ func TestEnsureMinExposures(t *testing.T) {
 	if len(expectedTR) != 0 {
 		t.Errorf("Didn't cover all expected transmission risks in batch of 1000: %v", expectedTR)
 	}
-	if len(eIntervals) != 9 {
-		t.Errorf("Unexpected number of intervalNum/count combinations, want: 6, got: %v", len(eIntervals))
+	if len(eIntervals) != 4 {
+		t.Errorf("Unexpected number of intervalNum/count combinations, want: 4, got: %v", len(eIntervals))
 	}
 	for k, v := range eIntervals {
 		if !v {

--- a/internal/model/exposure.go
+++ b/internal/model/exposure.go
@@ -28,16 +28,16 @@ const (
 	maxKeysPerPublish = 21
 
 	// only valid exposure key keyLength
-	keyLength = 16
+	KeyLength = 16
 
 	// Transmission risk constraints (inclusive..inclusive)
-	minTransmissionRisk = 0 // 0 indicates, no/unknown risk.
-	maxTransmissionRisk = 8
+	MinTransmissionRisk = 0 // 0 indicates, no/unknown risk.
+	MaxTransmissionRisk = 8
 
 	// Intervals are defined as 10 minute periods, there are 144 of them in a day.
 	// IntervalCount constraints (inclusive..inclusive)
-	minIntervalCount = 1
-	maxIntervalCount = 144
+	MinIntervalCount = 1
+	MaxIntervalCount = 144
 
 	// Self explanitory.
 	oneDay = time.Hour * 24
@@ -178,8 +178,8 @@ func (t *Transformer) TransformPublish(inData *Publish, batchTime time.Time) ([]
 	// Transmission risk for the whole batch is deprecated - it is now part
 	// of the ExposureKey.
 	defaultTR := inData.TransmissionRisk
-	if defaultTR < minTransmissionRisk || defaultTR > maxTransmissionRisk {
-		return nil, fmt.Errorf("invalid transmission risk: %v, must be >= %v && <= %v", defaultTR, minTransmissionRisk, maxTransmissionRisk)
+	if defaultTR < MinTransmissionRisk || defaultTR > MaxTransmissionRisk {
+		return nil, fmt.Errorf("invalid transmission risk: %v, must be >= %v && <= %v", defaultTR, MinTransmissionRisk, MaxTransmissionRisk)
 	}
 
 	for _, exposureKey := range inData.Keys {
@@ -189,11 +189,11 @@ func (t *Transformer) TransformPublish(inData *Publish, batchTime time.Time) ([]
 		}
 
 		// Validate individual pieces of this publish request.
-		if len(binKey) != keyLength {
-			return nil, fmt.Errorf("invalid key length, %v, must be %v", len(binKey), keyLength)
+		if len(binKey) != KeyLength {
+			return nil, fmt.Errorf("invalid key length, %v, must be %v", len(binKey), KeyLength)
 		}
-		if ic := exposureKey.IntervalCount; ic < minIntervalCount || ic > maxIntervalCount {
-			return nil, fmt.Errorf("invalid interval count, %v, must be >= %v && <= %v", ic, minIntervalCount, maxIntervalCount)
+		if ic := exposureKey.IntervalCount; ic < MinIntervalCount || ic > MaxIntervalCount {
+			return nil, fmt.Errorf("invalid interval count, %v, must be >= %v && <= %v", ic, MinIntervalCount, MaxIntervalCount)
 		}
 
 		// Validate the IntervalNumber.
@@ -209,8 +209,8 @@ func (t *Transformer) TransformPublish(inData *Publish, batchTime time.Time) ([]
 		if tr == 0 && defaultTR != 0 {
 			tr = defaultTR
 		}
-		if tr < minTransmissionRisk || tr > maxTransmissionRisk {
-			return nil, fmt.Errorf("invalid transmission risk: %v, must be >= %v && <= %v", tr, minTransmissionRisk, maxTransmissionRisk)
+		if tr < MinTransmissionRisk || tr > MaxTransmissionRisk {
+			return nil, fmt.Errorf("invalid transmission risk: %v, must be >= %v && <= %v", tr, MinTransmissionRisk, MaxTransmissionRisk)
 		}
 
 		exposure := &Exposure{

--- a/internal/model/exposure_test.go
+++ b/internal/model/exposure_test.go
@@ -144,11 +144,11 @@ func TestPublishValidation(t *testing.T) {
 						Key:              encodeKey(generateKey(t)),
 						IntervalNumber:   currentInterval - 2,
 						IntervalCount:    1,
-						TransmissionRisk: minTransmissionRisk - 1,
+						TransmissionRisk: MinTransmissionRisk - 1,
 					},
 				},
 			},
-			m: fmt.Sprintf("invalid transmission risk: %v, must be >= %v && <= %v", minTransmissionRisk-1, minTransmissionRisk, maxTransmissionRisk),
+			m: fmt.Sprintf("invalid transmission risk: %v, must be >= %v && <= %v", MinTransmissionRisk-1, MinTransmissionRisk, MaxTransmissionRisk),
 		},
 		{
 			name: "tranismission risk too high",
@@ -158,21 +158,21 @@ func TestPublishValidation(t *testing.T) {
 						Key:              encodeKey(generateKey(t)),
 						IntervalNumber:   currentInterval - 2,
 						IntervalCount:    1,
-						TransmissionRisk: maxTransmissionRisk + 1,
+						TransmissionRisk: MaxTransmissionRisk + 1,
 					},
 				},
 			},
-			m: fmt.Sprintf("invalid transmission risk: %v, must be >= %v && <= %v", maxTransmissionRisk+1, minTransmissionRisk, maxTransmissionRisk),
+			m: fmt.Sprintf("invalid transmission risk: %v, must be >= %v && <= %v", MaxTransmissionRisk+1, MinTransmissionRisk, MaxTransmissionRisk),
 		},
 		{
 			name: "key length too short",
 			p: &Publish{
 				Keys: []ExposureKey{
-					{Key: encodeKey(generateKey(t)[0 : keyLength-2])},
+					{Key: encodeKey(generateKey(t)[0 : KeyLength-2])},
 				},
-				TransmissionRisk: maxTransmissionRisk - 1,
+				TransmissionRisk: MaxTransmissionRisk - 1,
 			},
-			m: fmt.Sprintf("invalid key length, %v, must be %v", keyLength-2, keyLength),
+			m: fmt.Sprintf("invalid key length, %v, must be %v", KeyLength-2, KeyLength),
 		},
 		{
 			name: "interval count too small",
@@ -180,12 +180,12 @@ func TestPublishValidation(t *testing.T) {
 				Keys: []ExposureKey{
 					{
 						Key:           encodeKey(generateKey(t)),
-						IntervalCount: minIntervalCount - 1,
+						IntervalCount: MinIntervalCount - 1,
 					},
 				},
-				TransmissionRisk: maxTransmissionRisk - 1,
+				TransmissionRisk: MaxTransmissionRisk - 1,
 			},
-			m: fmt.Sprintf("invalid interval count, %v, must be >= %v && <= %v", minIntervalCount-1, minIntervalCount, maxIntervalCount),
+			m: fmt.Sprintf("invalid interval count, %v, must be >= %v && <= %v", MinIntervalCount-1, MinIntervalCount, MaxIntervalCount),
 		},
 		{
 			name: "interval count too high",
@@ -193,12 +193,12 @@ func TestPublishValidation(t *testing.T) {
 				Keys: []ExposureKey{
 					{
 						Key:           encodeKey(generateKey(t)),
-						IntervalCount: maxIntervalCount + 1,
+						IntervalCount: MaxIntervalCount + 1,
 					},
 				},
-				TransmissionRisk: maxTransmissionRisk - 1,
+				TransmissionRisk: MaxTransmissionRisk - 1,
 			},
-			m: fmt.Sprintf("invalid interval count, %v, must be >= %v && <= %v", maxIntervalCount+1, minIntervalCount, maxIntervalCount),
+			m: fmt.Sprintf("invalid interval count, %v, must be >= %v && <= %v", MaxIntervalCount+1, MinIntervalCount, MaxIntervalCount),
 		},
 		{
 			name: "interval number too low",
@@ -207,10 +207,10 @@ func TestPublishValidation(t *testing.T) {
 					{
 						Key:            encodeKey(generateKey(t)),
 						IntervalNumber: minInterval - 1,
-						IntervalCount:  maxIntervalCount,
+						IntervalCount:  MaxIntervalCount,
 					},
 				},
-				TransmissionRisk: maxTransmissionRisk - 1,
+				TransmissionRisk: MaxTransmissionRisk - 1,
 			},
 			m: fmt.Sprintf("interval number %v is too old, must be >= %v", minInterval-1, minInterval),
 		},
@@ -224,7 +224,7 @@ func TestPublishValidation(t *testing.T) {
 						IntervalCount:  1,
 					},
 				},
-				TransmissionRisk: maxTransmissionRisk - 1,
+				TransmissionRisk: MaxTransmissionRisk - 1,
 			},
 			m: fmt.Sprintf("interval number %v is in the future, must be < %v", currentInterval+1, currentInterval),
 		},
@@ -272,21 +272,21 @@ func TestTransform(t *testing.T) {
 			{
 				Key:            encodeKey(generateKey(t)),
 				IntervalNumber: intervalNumber,
-				IntervalCount:  maxIntervalCount,
+				IntervalCount:  MaxIntervalCount,
 			},
 			{
 				Key:            encodeKey(generateKey(t)),
-				IntervalNumber: intervalNumber + maxIntervalCount,
-				IntervalCount:  maxIntervalCount,
+				IntervalNumber: intervalNumber + MaxIntervalCount,
+				IntervalCount:  MaxIntervalCount,
 			},
 			{
 				Key:            encodeKey(generateKey(t)),
-				IntervalNumber: intervalNumber + 2*maxIntervalCount,
-				IntervalCount:  maxIntervalCount, // Invalid, should get rounded down
+				IntervalNumber: intervalNumber + 2*MaxIntervalCount,
+				IntervalCount:  MaxIntervalCount, // Invalid, should get rounded down
 			},
 			{
 				Key:            encodeKey(generateKey(t)),
-				IntervalNumber: intervalNumber + 3*maxIntervalCount,
+				IntervalNumber: intervalNumber + 3*MaxIntervalCount,
 				IntervalCount:  42,
 			},
 		},
@@ -300,21 +300,21 @@ func TestTransform(t *testing.T) {
 		{
 			ExposureKey:    decodeKey(source.Keys[0].Key, t),
 			IntervalNumber: intervalNumber,
-			IntervalCount:  maxIntervalCount,
+			IntervalCount:  MaxIntervalCount,
 		},
 		{
 			ExposureKey:    decodeKey(source.Keys[1].Key, t),
-			IntervalNumber: intervalNumber + maxIntervalCount,
-			IntervalCount:  maxIntervalCount,
+			IntervalNumber: intervalNumber + MaxIntervalCount,
+			IntervalCount:  MaxIntervalCount,
 		},
 		{
 			ExposureKey:    decodeKey(source.Keys[2].Key, t),
-			IntervalNumber: intervalNumber + 2*maxIntervalCount,
-			IntervalCount:  maxIntervalCount,
+			IntervalNumber: intervalNumber + 2*MaxIntervalCount,
+			IntervalCount:  MaxIntervalCount,
 		},
 		{
 			ExposureKey:    decodeKey(source.Keys[3].Key, t),
-			IntervalNumber: intervalNumber + 3*maxIntervalCount,
+			IntervalNumber: intervalNumber + 3*MaxIntervalCount,
 			IntervalCount:  42,
 		},
 	}
@@ -365,12 +365,12 @@ func TestTransformOverlapping(t *testing.T) {
 					{
 						Key:            encodeKey(generateKey(t)),
 						IntervalNumber: intervalNumber,
-						IntervalCount:  maxIntervalCount,
+						IntervalCount:  MaxIntervalCount,
 					},
 					{
 						Key:            encodeKey(generateKey(t)),
-						IntervalNumber: intervalNumber + maxIntervalCount - 2,
-						IntervalCount:  maxIntervalCount,
+						IntervalNumber: intervalNumber + MaxIntervalCount - 2,
+						IntervalCount:  MaxIntervalCount,
 					},
 				},
 				Regions:          []string{"us", "cA", "Mx"}, // will be upcased
@@ -385,12 +385,12 @@ func TestTransformOverlapping(t *testing.T) {
 					{
 						Key:            encodeKey(generateKey(t)),
 						IntervalNumber: intervalNumber,
-						IntervalCount:  maxIntervalCount,
+						IntervalCount:  MaxIntervalCount,
 					},
 					{
 						Key:            encodeKey(generateKey(t)),
-						IntervalNumber: intervalNumber - maxIntervalCount + 1,
-						IntervalCount:  maxIntervalCount,
+						IntervalNumber: intervalNumber - MaxIntervalCount + 1,
+						IntervalCount:  MaxIntervalCount,
 					},
 				},
 				Regions:          []string{"us", "cA", "Mx"}, // will be upcased


### PR DESCRIPTION
This change will pad the export files with a minimum size.

The generated data is random, but uses real data as a basis to ensure that it is realistic. (making the fake keys too old would give them away).

/fixes #290 