### PR TITLE
make truncate window configurable

### DIFF
--- a/internal/api/export/batcher_test.go
+++ b/internal/api/export/batcher_test.go
@@ -108,7 +108,7 @@ func TestMakeBatchRanges(t *testing.T) {
 			nowT := fromSimpleTime(t, now)
 			latestEndT := fromSimpleTime(t, tc.latestEnd)
 
-			got := makeBatchRanges(tc.period, latestEndT, nowT)
+			got := makeBatchRanges(tc.period, latestEndT, nowT, time.Hour)
 
 			if len(got) != len(tc.want) {
 				t.Errorf("incorrect number of batches got %v, want %v", toSimpleBatchRange(t, got), tc.want)

--- a/internal/api/export/config.go
+++ b/internal/api/export/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	MaxRecords        int           `envconfig:"EXPORT_FILE_MAX_RECORDS" default:"30000"`
 	DefaultKeyID      string        `envconfig:"EXPORT_FILE_DEFAULT_KEY_ID" default:"ExampleServer"`
 	DefaultKeyVersion string        `envconfig:"EXPORT_FILE_DEFAULT_KEY_VERSION" default:"1"`
+	TruncateWindow    time.Duration `envconfig:"TRUNCATE_WINDOW" default:"1h"`
 }
 
 // DB returns the database config.

--- a/internal/api/federationin/config.go
+++ b/internal/api/federationin/config.go
@@ -39,9 +39,10 @@ var _ setup.DBConfigProvider = (*Config)(nil)
 
 // Config is the configuration for federation-pull components (data pulled from other servers).
 type Config struct {
-	Database *database.Config
-	Port     string        `envconfig:"PORT" default:"8080"`
-	Timeout  time.Duration `envconfig:"RPC_TIMEOUT" default:"10m"`
+	Database       *database.Config
+	Port           string        `envconfig:"PORT" default:"8080"`
+	Timeout        time.Duration `envconfig:"RPC_TIMEOUT" default:"10m"`
+	TruncateWindow time.Duration `envconfig:"TRUNCATE_WINDOW" default:"1h"`
 
 	// TLSSkipVerify, if set to true, causes the server certificate to not be verified.
 	// This is typically used when testing locally with self-signed certificates.

--- a/internal/api/federationin/federationin.go
+++ b/internal/api/federationin/federationin.go
@@ -173,7 +173,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		startFederationSync: h.db.StartFederationInSync,
 	}
 	batchStart := time.Now()
-	if err := pull(timeoutContext, metrics, deps, query, batchStart); err != nil {
+	if err := pull(timeoutContext, metrics, deps, query, batchStart, h.config.TruncateWindow); err != nil {
 		internalErrorf(ctx, w, "Federation query %q failed: %v", queryID, err)
 		return
 	}
@@ -183,7 +183,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func pull(ctx context.Context, metrics metrics.Exporter, deps pullDependencies, q *model.FederationInQuery, batchStart time.Time) error {
+func pull(ctx context.Context, metrics metrics.Exporter, deps pullDependencies, q *model.FederationInQuery, batchStart time.Time, truncateWindow time.Duration) error {
 	logger := logging.FromContext(ctx)
 	logger.Infof("Processing query %q", q.QueryID)
 
@@ -204,7 +204,7 @@ func pull(ctx context.Context, metrics metrics.Exporter, deps pullDependencies, 
 		logger.Infof("Inserted %d keys", total)
 	}()
 
-	createdAt := model.TruncateWindow(batchStart)
+	createdAt := model.TruncateWindow(batchStart, truncateWindow)
 	partial := true
 	for partial {
 

--- a/internal/api/federationin/federationin_test.go
+++ b/internal/api/federationin/federationin_test.go
@@ -249,7 +249,7 @@ func TestFederationPull(t *testing.T) {
 				startFederationSync: sdb.startFederationSync,
 			}
 
-			err := pull(ctx, metrics.NewLogsBasedFromContext(ctx), deps, query, batchStart)
+			err := pull(ctx, metrics.NewLogsBasedFromContext(ctx), deps, query, batchStart, time.Hour)
 			if err != nil {
 				t.Fatalf("pull returned err=%v, want err=nil", err)
 			}

--- a/internal/api/federationout/config.go
+++ b/internal/api/federationout/config.go
@@ -26,9 +26,10 @@ var _ setup.DBConfigProvider = (*Config)(nil)
 
 // Config is the configuration for the federation components (data sent to other servers).
 type Config struct {
-	Port     string        `envconfig:"PORT" default:"8080"`
-	Timeout  time.Duration `envconfig:"RPC_TIMEOUT" default:"5m"`
-	Database *database.Config
+	Database       *database.Config
+	Port           string        `envconfig:"PORT" default:"8080"`
+	Timeout        time.Duration `envconfig:"RPC_TIMEOUT" default:"5m"`
+	TruncateWindow time.Duration `envconfig:"TRUNCATE_WINDOW" default:"1h"`
 
 	// AllowAnyClient, if true, removes authentication requirements on the federation endpoint.
 	// In practise, this is only useful in local testing.

--- a/internal/api/federationout/federationout.go
+++ b/internal/api/federationout/federationout.go
@@ -67,7 +67,7 @@ func (s Server) Fetch(ctx context.Context, req *pb.FederationFetchRequest) (*pb.
 	ctx, cancel := context.WithTimeout(ctx, s.config.Timeout)
 	defer cancel()
 	logger := logging.FromContext(ctx)
-	response, err := s.fetch(ctx, req, s.db.IterateExposures, model.TruncateWindow(time.Now())) // Don't fetch the current window, which isn't complete yet. TODO(squee1945): should I double this for safety?
+	response, err := s.fetch(ctx, req, s.db.IterateExposures, model.TruncateWindow(time.Now(), s.config.TruncateWindow)) // Don't fetch the current window, which isn't complete yet. TODO(squee1945): should I double this for safety?
 	if err != nil {
 		s.env.MetricsExporter(ctx).WriteInt("federation-fetch-failed", true, 1)
 		logger.Errorf("Fetch error: %v", err)

--- a/internal/api/publish/config.go
+++ b/internal/api/publish/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	MaxKeysOnPublish         int           `envconfig:"MAX_KEYS_ON_PUBLISH" default:"14"`
 	MaxIntervalAge           time.Duration `envconfig:"MAX_INTERVAL_AGE_ON_PUBLISH" default:"360h"`
 	APIConfigRefreshDuration time.Duration `envconfig:"CONFIG_REFRESH_DURATION" default:"5m"`
+	TruncateWindow           time.Duration `envconfig:"TRUNCATE_WINDOW" default:"1h"`
 
 	APIConfigOpts *dbapiconfig.ConfigOpts
 

--- a/internal/api/publish/publish.go
+++ b/internal/api/publish/publish.go
@@ -41,12 +41,13 @@ func NewHandler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (
 		return nil, fmt.Errorf("missing apiconfig provider in server environment")
 	}
 
-	transformer, err := model.NewTransformer(config.MaxKeysOnPublish, config.MaxIntervalAge)
+	transformer, err := model.NewTransformer(config.MaxKeysOnPublish, config.MaxIntervalAge, config.TruncateWindow)
 	if err != nil {
 		return nil, fmt.Errorf("model.NewTransformer: %w", err)
 	}
 	logger.Infof("max keys per upload: %v", config.MaxKeysOnPublish)
 	logger.Infof("max interval start age: %v", config.MaxIntervalAge)
+	logger.Infof("truncate window: %v", config.TruncateWindow)
 
 	return &publishHandler{
 		serverenv:   env,

--- a/internal/model/exposure_test.go
+++ b/internal/model/exposure_test.go
@@ -41,7 +41,7 @@ func TestInvalidNew(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		_, err := NewTransformer(c.maxKeys, time.Hour)
+		_, err := NewTransformer(c.maxKeys, time.Hour, time.Hour)
 		if err != nil && errMsg == "" {
 			t.Errorf("%v unexpected error: %v", i, err)
 		} else if err != nil && !strings.Contains(err.Error(), c.message) {
@@ -51,7 +51,7 @@ func TestInvalidNew(t *testing.T) {
 }
 
 func TestInvalidBase64(t *testing.T) {
-	transformer, err := NewTransformer(1, time.Hour*24)
+	transformer, err := NewTransformer(1, time.Hour*24, time.Hour)
 	if err != nil {
 		t.Fatalf("error creating transformer: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestPublishValidation(t *testing.T) {
 	currentInterval := IntervalNumber(captureStartTime)
 	minInterval := IntervalNumber(captureStartTime.Add(-1 * maxAge))
 
-	tf, err := NewTransformer(2, maxAge)
+	tf, err := NewTransformer(2, maxAge, time.Hour)
 	if err != nil {
 		t.Fatalf("unepected error: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestTransform(t *testing.T) {
 		},
 	}
 	batchTime := captureStartTime.Add(time.Hour * 24 * 7)
-	batchTimeRounded := TruncateWindow(batchTime)
+	batchTimeRounded := TruncateWindow(batchTime, time.Hour)
 	for i, v := range want {
 		want[i] = &Exposure{
 			ExposureKey:      v.ExposureKey,
@@ -334,7 +334,7 @@ func TestTransform(t *testing.T) {
 	}
 
 	allowedAge := 14 * 24 * time.Hour
-	transformer, err := NewTransformer(10, allowedAge)
+	transformer, err := NewTransformer(10, allowedAge, time.Hour)
 	if err != nil {
 		t.Fatalf("NewTransformer returned unexpected error: %v", err)
 	}
@@ -404,7 +404,7 @@ func TestTransformOverlapping(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			batchTime := captureStartTime.Add(time.Hour * 24 * 7)
 			allowedAge := 14 * 24 * time.Hour
-			transformer, err := NewTransformer(10, allowedAge)
+			transformer, err := NewTransformer(10, allowedAge, time.Hour)
 			if err != nil {
 				t.Fatalf("NewTransformer returned unexpected error: %v", err)
 			}


### PR DESCRIPTION
Eventually there might be a better home for this sort of
cross-cutting global config, but for now, an env var works.

This will allow quicker end-to-end tests of the round trip
of upload a key, wait for it to get into an export batch,
test exposure on another device.