### PR TITLE
Add cleanup-exposure and cleanup-export Terraform configs

### DIFF
--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -2,45 +2,72 @@ options:
   env:
   - 'KO_DOCKER_REPO=us.gcr.io/${PROJECT_ID}'
   - 'DOCKER_REPO_OVERRIDE=us.gcr.io/${PROJECT_ID}'
+  machineType: N1_HIGHCPU_8
+
 steps:
 # Build ko, prerequisite.
-- name: 'gcr.io/cloud-builders/docker'
+- id: ko-build
+  name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/ko', '-f', 'terraform/ko.Dockerfile', 'terraform/']
-- name: 'gcr.io/cloud-builders/docker'
+  waitFor: ['-']
+- id: ko-push
+  name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/ko']
+  waitFor: ['ko-build']
+
 # Tests
-- name: 'mirror.gcr.io/library/golang'
+- id: test
+  name: 'mirror.gcr.io/library/golang'
   env:
   - GO111MODULE=on
   args: ['go', 'test', './...']
+  waitFor: ['-']
+
 # Build and publish containers`
-- name: 'gcr.io/$PROJECT_ID/ko'
+- id: export
+  name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
   - -P
   - ./cmd/export
-- name: 'gcr.io/$PROJECT_ID/ko'
+  waitFor: ['ko-push', 'test']
+
+- id: federationin
+  name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
   - -P
   - ./cmd/federationin
-- name: 'gcr.io/$PROJECT_ID/ko'
+  waitFor: ['ko-push', 'test']
+
+- id: federationout
+  name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
   - -P
   - ./cmd/federationout
-- name: 'gcr.io/$PROJECT_ID/ko'
+  waitFor: ['ko-push', 'test']
+
+- id: exposure
+  name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
   - -P
   - ./cmd/exposure
-- name: 'gcr.io/$PROJECT_ID/ko'
+  waitFor: ['ko-push', 'test']
+
+- id: cleanup-export
+  name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
   - -P
   - ./cmd/cleanup-export
-- name: 'gcr.io/$PROJECT_ID/ko'
+  waitFor: ['ko-push', 'test']
+
+- id: cleanup-exposure
+  name: 'gcr.io/$PROJECT_ID/ko'
   args:
   - publish
   - -P
   - ./cmd/cleanup-exposure
+  waitFor: ['ko-push', 'test']

--- a/internal/database/export.go
+++ b/internal/database/export.go
@@ -507,7 +507,7 @@ func (db *DB) DeleteFilesBefore(ctx context.Context, before time.Time, blobstore
 			SELECT
 				eb.batch_id,
 				eb.status,
-				eb.bucket_name
+				eb.bucket_name,
 				ef.filename,
 				ef.batch_size,
 				ef.status

--- a/terraform/ko.Dockerfile
+++ b/terraform/ko.Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang
 RUN go get github.com/google/ko/cmd/ko
 ENTRYPOINT ["ko"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 provider "google" {
   project = var.project
   region  = var.region

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -66,7 +66,6 @@ resource "google_cloud_run_service" "cleanup-export" {
     metadata {
       annotations = {
         "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
-        "autoscaling.knative.dev/maxScale" : "5"
       }
     }
   }

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -1,0 +1,122 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Create and deploy the service
+#
+
+resource "google_service_account" "cleanup-export" {
+  project      = data.google_project.project.project_id
+  account_id   = "en-cleanup-export-sa"
+  display_name = "Exposure Notification Cleanup Export"
+}
+
+resource "google_project_iam_member" "cleanup-export-cloudsql" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.cleanup-export.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "cleanup-export-db-pwd" {
+  provider = google-beta
+
+  secret_id = google_secret_manager_secret.db-pwd.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cleanup-export.email}"
+}
+
+resource "google_storage_bucket_iam_member" "cleanup-export-objectadmin" {
+  bucket = google_storage_bucket.export.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cleanup-export.email}"
+}
+
+resource "google_cloud_run_service" "cleanup-export" {
+  name     = "cleanup-export"
+  location = var.region
+
+  template {
+    spec {
+      service_account_name = google_service_account.cleanup-export.email
+
+      containers {
+        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-export:latest"
+
+        dynamic "env" {
+          for_each = local.common_cloudrun_env_vars
+          content {
+            name  = env.value["name"]
+            value = env.value["value"]
+          }
+        }
+      }
+    }
+
+    metadata {
+      annotations = {
+        "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
+        "autoscaling.knative.dev/maxScale" : "5"
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.services["run.googleapis.com"],
+    null_resource.submit-build-and-publish,
+  ]
+}
+
+
+#
+# Create scheduler job to invoke the service on a fixed interval.
+#
+
+resource "google_service_account" "cleanup-export-invoker" {
+  project      = data.google_project.project.project_id
+  account_id   = "en-cleanup-export-invoker-sa"
+  display_name = "Exposure Notification Cleanup Export Invoker"
+}
+
+resource "google_cloud_run_service_iam_member" "cleanup-export-invoker" {
+  project  = google_cloud_run_service.cleanup-export.project
+  location = google_cloud_run_service.cleanup-export.location
+  service  = google_cloud_run_service.cleanup-export.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler-export.email}"
+}
+
+resource "google_cloud_scheduler_job" "cleanup-export-worker" {
+  name             = "cleanup-export-worker"
+  schedule         = "0 */6 * * *"
+  time_zone        = "Etc/UTC"
+  attempt_deadline = "600s"
+
+  retry_config {
+    retry_count = 3
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "${google_cloud_run_service.cleanup-export.status.0.url}/"
+    oidc_token {
+      audience              = google_cloud_run_service.cleanup-export.status.0.url
+      service_account_email = google_service_account.scheduler-export.email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app,
+    google_cloud_run_service_iam_member.cleanup-export-invoker,
+  ]
+}

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -60,7 +60,6 @@ resource "google_cloud_run_service" "cleanup-exposure" {
     metadata {
       annotations = {
         "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
-        "autoscaling.knative.dev/maxScale" : "5"
       }
     }
   }

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -1,0 +1,116 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Create and deploy the service
+#
+
+resource "google_service_account" "cleanup-exposure" {
+  project      = data.google_project.project.project_id
+  account_id   = "en-cleanup-exposure-sa"
+  display_name = "Exposure Notification Cleanup Exposure"
+}
+
+resource "google_project_iam_member" "cleanup-exposure-cloudsql" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.cleanup-exposure.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "cleanup-exposure-db-pwd" {
+  provider = google-beta
+
+  secret_id = google_secret_manager_secret.db-pwd.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.cleanup-exposure.email}"
+}
+
+resource "google_cloud_run_service" "cleanup-exposure" {
+  name     = "cleanup-exposure"
+  location = var.region
+
+  template {
+    spec {
+      service_account_name = google_service_account.cleanup-exposure.email
+
+      containers {
+        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-exposure:latest"
+
+        dynamic "env" {
+          for_each = local.common_cloudrun_env_vars
+          content {
+            name  = env.value["name"]
+            value = env.value["value"]
+          }
+        }
+      }
+    }
+
+    metadata {
+      annotations = {
+        "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
+        "autoscaling.knative.dev/maxScale" : "5"
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.services["run.googleapis.com"],
+    null_resource.submit-build-and-publish,
+  ]
+}
+
+
+#
+# Create scheduler job to invoke the service on a fixed interval.
+#
+
+resource "google_service_account" "cleanup-exposure-invoker" {
+  project      = data.google_project.project.project_id
+  account_id   = "en-cleanup-exposure-invoker-sa"
+  display_name = "Exposure Notification Cleanup Exposure Invoker"
+}
+
+resource "google_cloud_run_service_iam_member" "cleanup-exposure-invoker" {
+  project  = google_cloud_run_service.cleanup-exposure.project
+  location = google_cloud_run_service.cleanup-exposure.location
+  service  = google_cloud_run_service.cleanup-exposure.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler-export.email}"
+}
+
+resource "google_cloud_scheduler_job" "cleanup-exposure-worker" {
+  name             = "cleanup-exposure-worker"
+  schedule         = "0 */4 * * *"
+  time_zone        = "Etc/UTC"
+  attempt_deadline = "600s"
+
+  retry_config {
+    retry_count = 3
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "${google_cloud_run_service.cleanup-exposure.status.0.url}/"
+    oidc_token {
+      audience              = google_cloud_run_service.cleanup-exposure.status.0.url
+      service_account_email = google_service_account.scheduler-export.email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app,
+    google_cloud_run_service_iam_member.cleanup-exposure-invoker,
+  ]
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "region" {
   type    = string
   default = "us-central1"


### PR DESCRIPTION
Adds configuration for cleanup-exposure and cleanup-export. Also speeds up the Terraform run by building the containers with ko in parallel during submission. Also also fixes a missing comma in the SQL command for export that caused invocation to fail.

Fixes GH-242