### PR TITLE
Use `gcloud run` instead of `gcloud alpha run`

### DIFF
--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -50,35 +50,31 @@ steps:
   entrypoint: 'bash'
   args:
   - '-c'
-  # `--platform managed` and `--no-traffic` only works in `alpha`
   - |
-    gcloud alpha run deploy exposure --image \
+    gcloud run deploy exposure --image \
       us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/exposure:latest --region us-central1 \
       --platform managed --update-labels=env=staging --no-traffic
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
   args:
   - '-c'
-  # `--platform managed` and `--no-traffic` only works in `alpha`
   - |
-    gcloud alpha run deploy export --image \
+    gcloud run deploy export --image \
       us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/export:latest --region us-central1 \
       --platform managed --update-labels=env=staging --no-traffic
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
   args:
   - '-c'
-  # `--platform managed` and `--no-traffic` only works in `alpha`
   - |
-    gcloud alpha run deploy federationin --image \
+    gcloud run deploy federationin --image \
       us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/federationin:latest --region us-central1 \
       --platform managed --update-labels=env=staging --no-traffic
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
   args:
   - '-c'
-  # `--platform managed` and `--no-traffic` only works in `alpha`
   - |
-    gcloud alpha run deploy federationout --image \
+    gcloud run deploy federationout --image \
       us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/federationout:latest --region us-central1 \
       --platform managed --update-labels=env=staging --no-traffic


### PR DESCRIPTION
`--no-traffic` has graduated to GA for `--platform managed` in Cloud SDK 288.0.0 (2020-04-07)  
See [release notes](https://cloud.google.com/sdk/docs/release-notes#28800_2020-04-07)

I confirmed by running the following:
```
$ gcloud run deploy hello --image gcr.io/cloudrun/hello --platform managed --region europe-west1 --no-traffic
Deploying container to Cloud Run service [hello] in project [steren-serverless] region [europe-west1]
✓ Deploying... Done.                                                           
  ✓ Creating Revision...
  ✓ Routing traffic...
Done.
Service [hello] revision [hello-00028-fuf] has been deployed and is serving 0 percent of traffic
```