### PR TITLE
Lower the spec for Cloud SQL to avoid excessive overprovisioning

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -29,14 +29,14 @@ variable "repo_name" {
 
 variable "cloudsql_tier" {
   type    = string
-  default = "db-custom-32-122880"
+  default = "db-custom-8-30720"
 
   description = "Size of the Cloud SQL tier. Set to db-custom-1-3840 or a smaller instance for local dev."
 }
 
 variable "cloudsql_disk_size_gb" {
   type    = number
-  default = 500
+  default = 256
 
   description = "Size of the Cloud SQL disk, in GB."
 }


### PR DESCRIPTION
During a walkthough of our terraform configs, we debated a bit on the sizing of Cloud SQL.

I think these are reasonable but lower limits.
[Memory of the instance determines concurrent connections](https://cloud.google.com/sql/docs/quotas#cloud-sql-for-postgresql-connection-limits)
db-custom-8-30720 -> 30Gb of memory -> 500 concurrent connections

[Disk size will determine achievable IOPS] (https://cloud.google.com/compute/docs/disks/performance#ssd_persistent_disk_performance_by_disk_size)
256 GB SSD -> 7,680 IOPS

I think this should be sufficient and we can adjust further if needed