### PR TITLE
create debug mode for exposure notifications upload so developers can…

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	// Bypass flags for local development and testing.
 	BypassSafetyNet   bool `envconfig:"BYPASS_SAFETYNET"`
 	BypassDeviceCheck bool `envconfig:"BYPASS_DEVICECHECK"`
+	DebugAPIResponses bool `envconfig:"DEBUG_API_RESPONSES"`
 
 	AuthorizedApp *authorizedapp.Config
 	Database      *database.Config

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -66,11 +66,11 @@ type publishHandler struct {
 }
 
 type response struct {
-	status          int
-	message         string
-	metric          string
-	count           int // metricCount
-	errorInNonDebug bool
+	status      int
+	message     string
+	metric      string
+	count       int // metricCount
+	errorInProd bool
 }
 
 func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) response {
@@ -102,11 +102,11 @@ func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) r
 		// isn't transient.
 		logger.Errorf("no AuthorizedApp, dropping data: %v", err)
 		return response{
-			status:          http.StatusInternalServerError,
-			message:         http.StatusText(http.StatusInternalServerError),
-			metric:          "publish-error-loading-authorizedapp",
-			count:           1,
-			errorInNonDebug: true,
+			status:      http.StatusInternalServerError,
+			message:     http.StatusText(http.StatusInternalServerError),
+			metric:      "publish-error-loading-authorizedapp",
+			count:       1,
+			errorInProd: true,
 		}
 	}
 
@@ -186,7 +186,7 @@ func (h *publishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// If this error is written in non-debug times or if debug is enabled, write
 	// out the error and status.
-	if h.config.DebugAPIResponses || response.errorInNonDebug {
+	if h.config.DebugAPIResponses || response.errorInProd {
 		w.WriteHeader(response.status)
 		w.Write([]byte(response.message))
 		return

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -65,21 +65,25 @@ type publishHandler struct {
 	authorizedAppProvider authorizedapp.Provider
 }
 
-// There is a target normalized latency for this function. This is to help prevent
-// clients from being able to distinguish from successful or errored requests.
-func (h *publishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+type response struct {
+	status          int
+	message         string
+	metric          string
+	count           int // metricCount
+	errorInNonDebug bool
+}
+
+func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) response {
 	ctx := r.Context()
 	logger := logging.FromContext(ctx)
-	metrics := h.serverenv.MetricsExporter(ctx)
 
 	var data *database.Publish
 	code, err := jsonutil.Unmarshal(w, r, &data)
 	if err != nil {
 		// Log the unparsable JSON, but return success to the client.
-		logger.Errorf("error unmarshalling API call, code: %v: %v", code, err)
-		metrics.WriteInt("publish-bad-json", true, 1)
-		w.WriteHeader(http.StatusOK)
-		return
+		message := fmt.Sprintf("error unmarshalling API call, code: %v: %v", code, err)
+		logger.Error(message)
+		return response{status: http.StatusBadRequest, message: message, metric: "publish-bad-json", count: 1}
 	}
 
 	appConfig, err := h.authorizedAppProvider.AppConfig(ctx, data.AppPackageName)
@@ -88,83 +92,106 @@ func (h *publishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// happen if the app was recently registered but the cache hasn't been
 		// refreshed.
 		if err == authorizedapp.AppNotFound {
-			logger.Errorf("unauthorized app: %v", data.AppPackageName)
-			metrics.WriteInt("publish-app-not-authorized", true, 1)
-			// This returns success to the client.
-			w.WriteHeader(http.StatusOK)
-			return
+			message := fmt.Sprintf("unauthorized app: %v", data.AppPackageName)
+			logger.Error(message)
+			return response{status: http.StatusUnauthorized, message: message, metric: "publish-app-not-authorized", count: 1}
 		}
 
 		// A higher-level configuration error occurred, likely while trying to read
 		// from the database. This is retryable, although won't succeed if the error
 		// isn't transient.
 		logger.Errorf("no AuthorizedApp, dropping data: %v", err)
-		metrics.WriteInt("publish-error-loading-authorizedapp", true, 1)
-		http.Error(w, http.StatusText(http.StatusInternalServerError),
-			http.StatusInternalServerError)
-		return
+		return response{
+			status:          http.StatusInternalServerError,
+			message:         http.StatusText(http.StatusInternalServerError),
+			metric:          "publish-error-loading-authorizedapp",
+			count:           1,
+			errorInNonDebug: true,
+		}
 	}
 
 	if err := verification.VerifyRegions(appConfig, data); err != nil {
-		logger.Errorf("verification.VerifyRegions: %v", err)
-		metrics.WriteInt("publish-region-not-authorized", true, 1)
-		// This returns success to the client.
-		w.WriteHeader(http.StatusOK)
-		return
+		message := fmt.Sprintf("verifying allowed regions: %v", err)
+		return response{status: http.StatusUnauthorized, message: message, metric: "publish-region-not-authorized", count: 1}
 	}
 
 	if appConfig.IsIOS() {
 		if h.config.BypassDeviceCheck {
 			logger.Errorf("bypassing DeviceCheck for %v", data.AppPackageName)
-			metrics.WriteInt("publish-devicecheck-bypass", true, 1)
+			h.serverenv.MetricsExporter(ctx).WriteInt("publish-devicecheck-bypass", true, 1)
 		} else if err := verification.VerifyDeviceCheck(ctx, appConfig, data); err != nil {
-			logger.Errorf("unable to verify devicecheck payload: %v", err)
-			metrics.WriteInt("publish-devicecheck-invalid", true, 1)
-			// Return success to the client.
-			w.WriteHeader(http.StatusOK)
-			return
+			message := fmt.Sprintf("unable to verify devicecheck payload: %v", err)
+			logger.Error(message)
+			return response{status: http.StatusUnauthorized, message: message, metric: "publish-devicecheck-invalid", count: 1}
 		}
 	} else if appConfig.IsAndroid() {
 		if h.config.BypassSafetyNet {
 			logger.Errorf("bypassing SafetyNet for %v", data.AppPackageName)
-			metrics.WriteInt("publish-safetynet-bypass", true, 1)
+			h.serverenv.MetricsExporter(ctx).WriteInt("publish-safetynet-bypass", true, 1)
 		} else if err := verification.VerifySafetyNet(ctx, time.Now(), appConfig, data); err != nil {
-			logger.Errorf("unable to verify safetynet payload: %v", err)
-			metrics.WriteInt("publish-safetnet-invalid", true, 1)
-			// Return success to the client.
-			w.WriteHeader(http.StatusOK)
-			return
+			message := fmt.Sprintf("unable to verify safetynet payload: %v", err)
+			logger.Error(message)
+			return response{status: http.StatusUnauthorized, message: message, metric: "publish-safetnet-invalid", count: 1}
 		}
 	} else {
-		logger.Errorf("invalid AuthorizedApp config %v: invalid platform %v",
-			data.AppPackageName, data.Platform)
-		metrics.WriteInt("publish-authorizedapp-missing-platform", true, 1)
-		// This returns success to the client.
-		w.WriteHeader(http.StatusOK)
-		return
+		message := fmt.Sprintf("invalid AuthorizedApp config %v: invalid platform %v", data.AppPackageName, data.Platform)
+		logger.Error(message)
+		return response{status: http.StatusInternalServerError, message: message, metric: "publish-authorizedapp-missing-platform", count: 1}
 	}
 
 	batchTime := time.Now()
 	exposures, err := h.transformer.TransformPublish(data, batchTime)
 	if err != nil {
-		logger.Errorf("error transforming publish data: %v", err)
-		metrics.WriteInt("publish-transform-fail", true, 1)
-		// This returns success to the client.
-		w.WriteHeader(http.StatusOK)
-		return
+		message := fmt.Sprintf("unable to read request data: %v", err)
+		logger.Error(message)
+		return response{status: http.StatusBadRequest, message: message, metric: "publish-transform-fail", count: 1}
 	}
 
 	err = h.database.InsertExposures(ctx, exposures)
 	if err != nil {
 		logger.Errorf("error writing exposure record: %v", err)
-		metrics.WriteInt("publish-db-write-error", true, 1)
-		// This is retryable at the client - database error at the server.
-		http.Error(w, http.StatusText(http.StatusInternalServerError),
-			http.StatusInternalServerError)
+		return response{status: http.StatusInternalServerError, message: http.StatusText(http.StatusInternalServerError), metric: "publish-db-write-error", count: 1}
+	}
+
+	message := fmt.Sprintf("Inserted %d exposures.", len(exposures))
+	logger.Info(message)
+	return response{
+		status:  http.StatusOK,
+		message: message,
+		metric:  "publish-exposures-written",
+		count:   len(exposures),
+	}
+}
+
+// There is a target normalized latency for this function. This is to help prevent
+// clients from being able to distinguish from successful or errored requests.
+func (h *publishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	response := h.handleRequest(w, r)
+
+	if response.metric != "" {
+		ctx := r.Context()
+		metrics := h.serverenv.MetricsExporter(ctx)
+		metrics.WriteInt(response.metric, true, response.count)
+	}
+
+	// Handle success. If debug enabled, write the message in the response.
+	if response.status == http.StatusOK {
+		if h.config.DebugAPIResponses {
+			w.Write([]byte(response.message))
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
 		return
 	}
-	metrics.WriteInt("publish-exposures-written", true, len(exposures))
-	logger.Infof("Inserted %d exposures.", len(exposures))
 
+	// If this error is written in non-debug times or if debug is enabled, write
+	// out the error and status.
+	if h.config.DebugAPIResponses || response.errorInNonDebug {
+		w.WriteHeader(response.status)
+		w.Write([]byte(response.message))
+		return
+	}
+
+	// Normal production behaviour. Success it up.
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -66,11 +66,11 @@ func Setup(ctx context.Context, config DBConfigProvider) (*serverenv.ServerEnv, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to connect to secret manager: %v", err)
 	}
-	logger.Infof("Effective environment variables: %+v", config)
 
 	if err := envconfig.Process(ctx, config, sm); err != nil {
 		return nil, nil, fmt.Errorf("error loading environment variables: %v", err)
 	}
+	logger.Infof("Effective environment variables: %+v", config)
 
 	// Start building serverenv opts
 	opts := []serverenv.Option{

--- a/tools/exposure-client/main.go
+++ b/tools/exposure-client/main.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"flag"
+	"io/ioutil"
 	"log"
 	"math/big"
 	"net/http"
@@ -98,14 +99,14 @@ func main() {
 		log.Fatalf("unable to marshal json payload")
 	}
 
-	sendRequest(jsonData)
-
 	prettyJSON, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		log.Printf("Can't display JSON that was sent, error: %v", err)
 	} else {
-		log.Printf("payload: \n%v", string(prettyJSON))
+		log.Printf("SENDING: \n%v", string(prettyJSON))
 	}
+
+	sendRequest(jsonData)
 
 	if *twice {
 		time.Sleep(1 * time.Second)
@@ -178,7 +179,15 @@ func sendRequest(jsonData []byte) {
 	}
 	defer resp.Body.Close()
 
-	log.Printf("response: %v", resp.Status)
+	log.Printf("status: %v", resp.Status)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("unable to read http response: %v", err)
+	} else {
+		log.Printf("response: %v", string(body))
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		log.Fatalf("Failure response from server.")
 	}


### PR DESCRIPTION
… see error messages for testing

fixes #350 
part of #197 - doesn't address federation API responses - since those are gRPC, probably want to handle separate.