### PR TITLE
Fixes for issue 252

### DIFF
--- a/internal/database/exposure_model.go
+++ b/internal/database/exposure_model.go
@@ -240,6 +240,12 @@ func (t *Transformer) TransformPublish(inData *Publish, batchTime time.Time) ([]
 			return nil, fmt.Errorf("interval number %v is in the future, must be < %v", exposureKey.IntervalNumber, maxIntervalNumber)
 		}
 
+		// Validate that the key is no longer effective.
+		if exposureKey.IntervalNumber+exposureKey.IntervalCount > maxIntervalNumber {
+			return nil, fmt.Errorf("interval number %v + interval count %v represents a key that is still valid, must end <= %v",
+				exposureKey.IntervalNumber, exposureKey.IntervalCount, maxIntervalNumber)
+		}
+
 		if tr := exposureKey.TransmissionRisk; tr < MinTransmissionRisk || tr > MaxTransmissionRisk {
 			return nil, fmt.Errorf("invalid transmission risk: %v, must be >= %v && <= %v", tr, MinTransmissionRisk, MaxTransmissionRisk)
 		}

--- a/internal/database/exposure_model_test.go
+++ b/internal/database/exposure_model_test.go
@@ -223,6 +223,19 @@ func TestPublishValidation(t *testing.T) {
 			},
 			m: fmt.Sprintf("interval number %v is in the future, must be < %v", currentInterval+1, currentInterval),
 		},
+		{
+			name: "interval end too high",
+			p: &Publish{
+				Keys: []ExposureKey{
+					{
+						Key:            encodeKey(generateKey(t)),
+						IntervalNumber: currentInterval - 143,
+						IntervalCount:  144,
+					},
+				},
+			},
+			m: fmt.Sprintf("interval number %v + interval count %v represents a key that is still valid, must end <= %v", currentInterval-143, 144, currentInterval),
+		},
 	}
 
 	for _, c := range cases {

--- a/internal/export/batcher.go
+++ b/internal/export/batcher.go
@@ -58,10 +58,10 @@ func (s *Server) CreateBatchesHandler(w http.ResponseWriter, r *http.Request) {
 		logger.Infof("Processed %d configs creating %d batches across %d configs", totalConfigs, totalBatches, totalConfigsWithBatches)
 	}()
 
-	now := time.Now()
-	err = s.db.IterateExportConfigs(ctx, now, func(ec *database.ExportConfig) error {
+	effectiveTime := time.Now().Add(-1 * s.config.MinWindowAge)
+	err = s.db.IterateExportConfigs(ctx, effectiveTime, func(ec *database.ExportConfig) error {
 		totalConfigs++
-		if batchesCreated, err := s.maybeCreateBatches(ctx, ec, now); err != nil {
+		if batchesCreated, err := s.maybeCreateBatches(ctx, ec, effectiveTime); err != nil {
 			logger.Errorf("Failed to create batches for config %d: %v, continuing to next config", ec.ConfigID, err)
 		} else {
 			totalBatches += batchesCreated

--- a/internal/export/config.go
+++ b/internal/export/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	PaddingRange   int           `envconfig:"EXPORT_FILE_PADDING_RANGE" default:"100"`
 	MaxRecords     int           `envconfig:"EXPORT_FILE_MAX_RECORDS" default:"30000"`
 	TruncateWindow time.Duration `envconfig:"TRUNCATE_WINDOW" default:"1h"`
+	MinWindowAge   time.Duration `envconfig:"MIN_WINDOW_AGE" default:"2h"`
 }
 
 // DB returns the database config.

--- a/internal/export/server.go
+++ b/internal/export/server.go
@@ -30,6 +30,9 @@ func NewServer(config *Config, env *serverenv.ServerEnv) (*Server, error) {
 	if env.KeyManager() == nil {
 		return nil, fmt.Errorf("export.NewBatchServer requires KeyManager present in the ServerEnv")
 	}
+	if config.MinWindowAge < 0 {
+		return nil, fmt.Errorf("MIN_WINDOW_AGE must be a duration of >= 0")
+	}
 
 	return &Server{
 		db:     env.Database(),


### PR DESCRIPTION
/fixes #252 

1. On publish, don't accept keys that are still valid, the rolling period hasn't ended (or isn't in the processes of ending during the current rolling interval)
2. On export, ensure that keys were received a certain age ago (2h by default) before being eligible for batching.
