### PR TITLE
Remove requirement for DC key_id and team_id to be secrets

### DIFF
--- a/internal/database/authorized_app_test.go
+++ b/internal/database/authorized_app_test.go
@@ -64,8 +64,6 @@ func TestGetAuthorizedApp(t *testing.T) {
 
 	sm := &testSecretManager{
 		values: map[string]string{
-			"team_id":     "ABCD1234",
-			"key_id":      "DEFG5678",
 			"private_key": string(pemBytes),
 		},
 	}
@@ -175,10 +173,10 @@ func TestGetAuthorizedApp(t *testing.T) {
 			sql: `
 				INSERT INTO AuthorizedApp (
 					app_package_name, platform, allowed_regions,
-					devicecheck_team_id_secret, devicecheck_key_id_secret, devicecheck_private_key_secret
+					devicecheck_team_id, devicecheck_key_id, devicecheck_private_key_secret
 				) VALUES ($1, $2, $3, $4, $5, $6)
 			`,
-			args: []interface{}{"myapp", "ios", []string{"US"}, "team_id", "key_id", "private_key"},
+			args: []interface{}{"myapp", "ios", []string{"US"}, "ABCD1234", "DEFG5678", "private_key"},
 			exp: &AuthorizedApp{
 				AppPackageName:           "myapp",
 				Platform:                 "ios",

--- a/migrations/000023_dc_less_secrets.down.sql
+++ b/migrations/000023_dc_less_secrets.down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE AuthorizedApp RENAME COLUMN devicecheck_team_id TO devicecheck_team_id_secret;
+ALTER TABLE AuthorizedApp RENAME COLUMN devicecheck_key_id TO devicecheck_key_id_secret;
+
+END;

--- a/migrations/000023_dc_less_secrets.up.sql
+++ b/migrations/000023_dc_less_secrets.up.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE AuthorizedApp RENAME COLUMN devicecheck_team_id_secret TO devicecheck_team_id;
+ALTER TABLE AuthorizedApp RENAME COLUMN devicecheck_key_id_secret TO devicecheck_key_id;
+
+END;

--- a/testdata/config.sql
+++ b/testdata/config.sql
@@ -17,11 +17,11 @@
 INSERT INTO AuthorizedApp (
   app_package_name, platform, allowed_regions,
   safetynet_cts_profile_match, safetynet_basic_integrity, safetynet_past_seconds, safetynet_future_seconds,
-  devicecheck_team_id_secret, devicecheck_key_id_secret, devicecheck_private_key_secret
+  devicecheck_team_id, devicecheck_key_id, devicecheck_private_key_secret
 ) VALUES (
   'com.example.ios.app', 'ios', ARRAY[]::VARCHAR[],
   false, false, 60, 60,
-  'projects/38554818207/secrets/ios-devicecheck-team-id/versions/1', 'projects/38554818207/secrets/ios-devicecheck-key-id/versions/1', 'projects/38554818207/secrets/ios-devicecheck-private-key/versions/1'
+  'ABCD1234', 'DEFG5678', 'projects/38554818207/secrets/ios-devicecheck-private-key/versions/1'
 ), (
   'com.example.android.app', 'android', ARRAY[]::VARCHAR[],
   false, false, 60, 60,


### PR DESCRIPTION
I've done a lot of reading and people generally don't consider these secrets.