### PR TITLE
Add full paths

### DIFF
--- a/examples/export/README.md
+++ b/examples/export/README.md
@@ -34,7 +34,7 @@ The export file in this directory was generated with the keys above
 and the `keys.json` file as follows:
 
 ```shell
-$ go run ./tools/export-generate --signing-key=private.pem --tek-file=keys.json
+$ go run ./tools/export-generate --signing-key=./examples/export/private.pem --tek-file=./examples/export/keys.json
 ```
 
 ## Inspecting an export


### PR DESCRIPTION
The command fails for me without full paths:

```sh
$ go run ./tools/export-generate --signing-key=private.pem --tek-file=keys.json
2020/05/20 22:34:38 unable to generate signing key: Invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key
exit status 1
```

(I think the actual error message is bogus.)