### PR TITLE
Suggests being transparent about user anonymity in the requirements

### DIFF
--- a/docs/server_functional_requirements.md
+++ b/docs/server_functional_requirements.md
@@ -5,6 +5,11 @@
 This documents the functional requirements for building a decentralized exposure
 notification system. For deployment strategies, see [Server Deployment Options](server_deployment_options.md).
 
+## Security requirements
+
+The current version of this software does not guarantee anonymity to Apple and/or Google
+of the person submitting exposure notification.
+
 ### System Components
 
 The Exposure Notification Server's architecture has been split into components.

--- a/internal/android/safetynet.go
+++ b/internal/android/safetynet.go
@@ -46,6 +46,10 @@ type VerifyOpts struct {
 // matches the properties that we expect based on the AuthorizedApp entry. See
 // https://developer.android.com/training/safetynet/attestation#use-response-server
 // for details on the format of these attestations.
+//
+// Given APK name is present in the attestation and that the attestation is provided
+// by Google Play Services in the context of exposure notification, it is possible for 
+// Google to determine and deanonymize the user of the app submitting notification.
 func ValidateAttestation(ctx context.Context, attestation string, opts *VerifyOpts) error {
 	defer trace.StartRegion(ctx, "ValidateAttestation").End()
 	logger := logging.FromContext(ctx)

--- a/internal/ios/devicecheck.go
+++ b/internal/ios/devicecheck.go
@@ -82,6 +82,11 @@ func ValidateDeviceToken(ctx context.Context, deviceToken string, opts *VerifyOp
 	}
 
 	// Build the request and add the authorization header.
+	//
+	// This request submits a unique device ID back to Apple in 
+	// the context of exposure notification.
+	// Combined with private key id (exposure app team's id), it informs 
+	// Apple precisely, which phone (and thus which person) reports the infection case.
 	req, err := http.NewRequest(http.MethodPost, endpoint, requestBody)
 	if err != nil {
 		return fmt.Errorf("failed to build request: %w", err)


### PR DESCRIPTION
Here I would like to politely and friendly suggest being transparent
on the security/privacy implications of people using the app.
From my comments in this commit it should (I hope) be evident,
why we potentially deanonymize (at least to Google and Apple) the
user while trying to perform device attestation.
qutorial@gmail.com