### PR TITLE
Get Terraform out of the CI/CD business

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 *.tfstate*
 *.terraform/
 terraform.tfvars
+terraform/state.tf
 
 /local/

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,0 @@
-defaultBaseImage: gcr.io/distroless/static:nonroot

--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -13,69 +13,26 @@
 # limitations under the License.
 
 #
-# Builds container imges.
+# Builds a container image.
 #
 
-options:
-  env:
-  - 'KO_DOCKER_REPO=us.gcr.io/${PROJECT_ID}'
-  - 'DOCKER_REPO_OVERRIDE=us.gcr.io/${PROJECT_ID}'
-  machineType: N1_HIGHCPU_8
+substitutions:
+  _SERVICE:
+  _TAG:
 
 steps:
-# Tests
-- id: test
-  name: 'mirror.gcr.io/library/golang'
-  env:
-  - GO111MODULE=on
-  args: ['go', 'test', './...']
-  waitFor: ['-']
+- id: 'build'
+  name: 'registry.hub.docker.com/library/docker:18'
+  args: [
+    'build',
+    '--tag', 'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-server/cmd/${_SERVICE}:${_TAG}',
+    '--build-arg', 'SERVICE=${_SERVICE}',
+    '.',
+  ]
 
-# Build and publish containers`
-- id: export
-  name: 'gcr.io/cloud-devrel-public-resources/exposure-notifications/ko:latest'
-  args:
-  - publish
-  - -P
-  - ./cmd/export
-  waitFor: ['test']
-
-- id: federationin
-  name: 'gcr.io/cloud-devrel-public-resources/exposure-notifications/ko:latest'
-  args:
-  - publish
-  - -P
-  - ./cmd/federationin
-  waitFor: ['test']
-
-- id: federationout
-  name: 'gcr.io/cloud-devrel-public-resources/exposure-notifications/ko:latest'
-  args:
-  - publish
-  - -P
-  - ./cmd/federationout
-  waitFor: ['test']
-
-- id: exposure
-  name: 'gcr.io/cloud-devrel-public-resources/exposure-notifications/ko:latest'
-  args:
-  - publish
-  - -P
-  - ./cmd/exposure
-  waitFor: ['test']
-
-- id: cleanup-export
-  name: 'gcr.io/cloud-devrel-public-resources/exposure-notifications/ko:latest'
-  args:
-  - publish
-  - -P
-  - ./cmd/cleanup-export
-  waitFor: ['test']
-
-- id: cleanup-exposure
-  name: 'gcr.io/cloud-devrel-public-resources/exposure-notifications/ko:latest'
-  args:
-  - publish
-  - -P
-  - ./cmd/cleanup-exposure
-  waitFor: ['test']
+- id: 'publish'
+  name: 'registry.hub.docker.com/library/docker:18'
+  args: [
+    'push',
+    'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-server/cmd/${_SERVICE}:${_TAG}',
+  ]

--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -13,100 +13,27 @@
 # limitations under the License.
 
 #
-# Re-deploys existing Cloud Run services. The services must have been deployed
-# with Terraform first, before using this script.
+# Deploys a Cloud Run service.
 #
 
 substitutions:
   _REGION:
+  _SERVICE:
+  _TAG:
 
 steps:
-- id: 'export'
+- id: 'deploy'
   name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
   args:
   - 'bash'
+  - '-eEuo'
+  - 'pipefail'
   - '-c'
   - |-
-    gcloud run deploy export \
+    gcloud run deploy "${_SERVICE}" \
       --quiet \
       --project "${PROJECT_ID}" \
       --platform "managed" \
       --region "${_REGION}" \
-      --image "us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/export:latest" \
+      --image "gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-server/cmd/${_SERVICE}:${_TAG}" \
       --no-traffic
-  waitFor: ['-']
-
-- id: 'federationin'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run deploy federationin \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --image "us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/federationin:latest" \
-      --no-traffic
-  waitFor: ['-']
-
-- id: 'federationout'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run deploy federationout \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --image "us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/federationout:latest" \
-      --no-traffic
-  waitFor: ['-']
-
-- id: 'exposure'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run deploy exposure \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --image "us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/exposure:latest" \
-      --no-traffic
-  waitFor: ['-']
-
-- id: 'cleanup-export'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run deploy cleanup-export \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --image "us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/cleanup-export:latest" \
-      --no-traffic
-  waitFor: ['-']
-
-- id: 'cleanup-exposure'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run deploy cleanup-exposure \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --image "us.gcr.io/$PROJECT_ID/github.com/google/exposure-notifications-server/cmd/cleanup-exposure:latest" \
-      --no-traffic
-  waitFor: ['-']

--- a/builders/migrate.yaml
+++ b/builders/migrate.yaml
@@ -30,6 +30,8 @@ steps:
   name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
   args:
   - 'bash'
+  - '-eEuo'
+  - 'pipefail'
   - '-c'
   - |-
     gcloud secrets versions access "${_DB_PASS_SECRET}" > ./dbpass

--- a/builders/promote.yaml
+++ b/builders/promote.yaml
@@ -17,91 +17,23 @@
 #
 
 substitutions:
+  _PERCENTAGE: '100'
   _REGION:
   _REVISION: 'LATEST'
-  _PERCENTAGE: '100'
+  _SERVICE:
 
 steps:
 - id: 'export'
   name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
   args:
   - 'bash'
+  - '-eEuo'
+  - 'pipefail'
   - '-c'
   - |-
-    gcloud run services update-traffic export \
+    gcloud run services update-traffic ${_SERVICE} \
       --quiet \
       --project "${PROJECT_ID}" \
       --platform "managed" \
       --region "${_REGION}" \
       --to-revisions "${_REVISION}=${_PERCENTAGE}"
-  waitFor: ['-']
-
-- id: 'federationin'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run services update-traffic federationin \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --to-revisions "${_REVISION}=${_PERCENTAGE}"
-  waitFor: ['-']
-
-- id: 'federationout'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run services update-traffic federationout \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --to-revisions "${_REVISION}=${_PERCENTAGE}"
-  waitFor: ['-']
-
-- id: 'exposure'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run services update-traffic exposure \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --to-revisions "${_REVISION}=${_PERCENTAGE}"
-  waitFor: ['-']
-
-- id: 'cleanup-export'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run services update-traffic cleanup-export \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --to-revisions "${_REVISION}=${_PERCENTAGE}"
-  waitFor: ['-']
-
-- id: 'cleanup-exposure'
-  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:293.0.0-alpine'
-  args:
-  - 'bash'
-  - '-c'
-  - |-
-    gcloud run services update-traffic cleanup-exposure \
-      --quiet \
-      --project "${PROJECT_ID}" \
-      --platform "managed" \
-      --region "${_REGION}" \
-      --to-revisions "${_REVISION}=${_PERCENTAGE}"
-  waitFor: ['-']

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -69,110 +69,155 @@ Each service's `main` package is located in the `cmd` directory.
 | exposure cleanup | cmd/cleanup-exposure | Deletes old exposure keys |
 | export cleanup | cmd/cleanup-export | Deletes old exported files published by the exposure key export service |
 
-### Deploying using Terraform
+### Provisioning infrastructure with Terraform
 
-You can use Terraform to deploy the reference Exposure Notification on Google
-Cloud. These instructions make use of the
-[Google Cloud Terraform provider](https://github.com/terraform-providers/terraform-provider-google).
+You can use [Terraform](https://www.terraform.io) to provision the initial
+infrastructure, database, service accounts, and first deployment of the services
+on Cloud Run. **Terraform does not manage the Cloud Run services after their
+initial creation!**
 
-1. [Download and install Terraform version 0.12](https://www.terraform.io/downloads.html)
-   or newer.
+See [Deploying with Terraform](../terraform/README.md) for more information.
 
-1. [Create a Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project)
+### Deploying services
 
-   Make a note of the project ID, you will be needed later. We recommend
-   setting it as an environment variable:
+While Terraform does an initial deployment of the services, it does not manage
+the Cloud Run services beyond their initial creation. If you make changes to the
+code, you will need to build, deploy, and promote new services. The general
+order of operations is:
 
-   ```console
-   export PROJECT_ID="PROJECT-ID"
-   ```
+1.  **Build** - this is the phase where the code is bundled into a container
+    image and pushed to a registry.
 
-1. **(OPTIONAL)** You can use [Cloud Build triggers](https://cloud.google.com/cloud-build/docs/automating-builds/create-github-app-triggers)
-   to automatically re-deploy when the Exposure Notification Server GitHub
-   repository is updated. To set up Cloud Build triggers:
+1.  **Deploy** - this is the phase where the container image is deployed onto
+    Cloud Run, but is not receiving any traffic.
 
-   1. Go to the
-   [Connect Repository Cloud Console page](https://console.cloud.google.com/cloud-build/triggers/connect)
-   and follow the instructions using GitHub as the source code location
-   (Cloud Build GitHub App). You must choose a repository on which you have
-   administrator permissions.
+1.  **Promote** - this is the phase where a deployed container image begins
+    receiving all or a percentage of traffic.
 
-   1. Make a note of the repository you have chosen. You must set the
-   repository name (for example, 'exposure-notification-server') and owner
-   (for example 'google') as variables when running the `terraform apply`
-   command.
+#### Building
 
-1. Authenticate with Google Cloud using the `gcloud` command-line tool:
+Build new services by using the script at `./scripts/build`, specifying the
+following values:
 
-   ```console
-   gcloud auth login && gcloud auth application-default login
-   ```
+-   `PROJECT_ID` (required) - your Google Cloud project ID.
 
-   This will open two authentication windows in your web browser.
+-   `SERVICES` (required) - comma-separated list of names of the services to
+    build, or "all" to build all. See the list of services in the table above.
 
-   You may need to `unset GOOGLE_APPLICATION_CREDENTIALS` as it takes precedence
-   over gcloud's login settings.
+-   `TAG` (optional) - tag to use for the images. If not specified, it uses a
+    datetime-based tag of the format YYYYMMDDhhmmss.
 
-1. Change to this directory and run `terraform init`.  Terraform will
-   automatically download the plugins required to execute this code.
+```text
+PROJECT_ID="my-project" \
+SERVICES="export" \
+./scripts/build
+```
 
-1. Run `terraform apply` to start deployment:
+Expect this process to take 3-5 minutes.
 
-   Without Cloud Build Triggers:
+#### Deploying
 
-   ```console
-   terraform apply \
-     -var project=$PROJECT_ID
-   ```
+Deploy already-built container using the script at `./scripts/deploy`,
+specifying the following values:
 
-   With Cloud Build Triggers:
+-   `PROJECT_ID` (required) - your Google Cloud project ID.
 
-   ```console
-   terraform apply \
-     -var project=${PROJECT_ID} \
-     -var region="us-central-1" \
-     -var use_build_triggers=true \
-     -var repo_owner=${YOUR_REPO_OWNER} \
-     -var repo_name=${YOUR_REPO_NAME}
-   ```
+-   `REGION` (required) - region in which to deploy the services.
 
-Terraform will begin by creating the service accounts and enabling the services
-on Google Cloud that are required to run this server.
+-   `SERVICES` (required) - comma-separated list of names of the services to
+    deploy, or "all" to deploy all. Note, if you specify multiple services, they
+    must use the same tag.
 
-1. Initialize or migrate the database.
+-   `TAG` (required) - tag of the deployed image (e.g. YYYYMMDDhhmmss).
 
-   To migrate the database, you will want to start the
-   [Cloud SQL Proxy](https://cloud.google.com/sql/docs/postgres/quickstart-proxy-test#install-proxy)
-   and then run the [`migrate`](https://github.com/golang-migrate/migrate)
-   command.
+```text
+PROJECT_ID="my-project" \
+REGION="us-central1" \
+SERVICES="export" \
+TAG="20200521084829" \
+./scripts/deploy
+```
 
-   ```console
-   DB_HOST="localhost"
-   DB_PORT="1433"
-   DB_USER="notification"
-   DB_PASSWORD="YOUR-DB-PASSWORD"
-   DB_SSLMODE="disable"
-   DB_NAME="main"
-   DB_URL="postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=${DB_SSLMODE}"
+Expect this process to take 1-2 minutes.
 
-   migrate -database ${DB_URL} -path ./migrations up
-   ```
+#### Promoting
 
-### Local development and testing example deployment
+Promote an already-deployed service to begin receiving production traffic using
+the script at `./scripts/promote`, specifying the following values:
 
-The default Terraform deployment is a production-ready, high traffic
-deployment. For local development and testing, we recommend you use the
-following sample deployment:
+-   `PROJECT_ID` (required) - your Google Cloud project ID.
 
-1. Run `terraform apply` with the following command:
+-   `REGION` (required) - region in which to promote the services.
 
-   ```console
-   terraform apply \
-     -var project=${PROJECT_ID} \
-     -var region="us-central-1" \
-     -var use_build_triggers=true \
-     -var repo_owner=${YOUR_REPO_OWNER} \
-     -var repo_name=${YOUR_REPO_NAME} \
-     -var cloudsql_tier="db-custom-1-3840" \
-     -var cloudsql_disk_size_gb="16"
-   ```
+-   `SERVICES` (required) - comma-separated list of names of the services to
+    promote, or "all" to deploy all. Note, if you specify multiple services,
+    then the revision must be "LATEST".
+
+-   `REVISION` (optional) - revision of the service to promote, usually the
+    output of a deployment step. Defaults to "LATEST".
+
+-   `PERCENTAGE` (optional) - percent of traffic to shift to the new revision.
+    Defaults to "100".
+
+```text
+PROJECT_ID="my-project" \
+REGION="us-central1" \
+SERVICES="export" \
+./scripts/promote
+```
+
+Expect this process to take 1-2 minutes.
+
+### Running migrations
+
+#### On Google Cloud
+
+To migrate the production database, use the script in `./scripts/migrate`. This
+script triggers a Cloud Build invocation which uses the Cloud SQL Proxy to run
+the database migrations and uses the following environment variables:
+
+-   `PROJECT_ID` (required) - your Google Cloud project ID.
+
+-   `DB_CONN` (required) - your Cloud SQL connection name.
+
+-   `DB_PASS_SECRET` (required) - the **reference** to the secret where the
+    database password is stored in Secret Manager.
+
+-   `DB_NAME` (default: "main") - the name of the database against which to run
+    migrations.
+
+-   `DB_USER` (default: "notification") - the username with which to
+    authenticate.
+
+-   `COMMAND` (default: "up") - the migration command to run.
+
+If you created the infrastructure using Terraform, you can get these values by
+running `terraform output` from inside the `terraform/` directory:
+
+```text
+PROJECT_ID=$(terraform output project)
+DB_CONN=$(terraform output db_conn)
+DB_PASS_SECRET=$(terraform output db_pass_secret)
+```
+
+#### On a custom setup
+
+If you did not use the Terraform configurations to provision your server, or if you are running your own Postgres server,
+
+1.  Download and install the
+    [`migrate`](https://github.com/golang-migrate/migrate) tool.
+
+1.  Construct the [database URL](https://github.com/golang-migrate/migrate/tree/master/database/postgres) for your database. This is usually of the format:
+
+    ```text
+    postgres://DB_USER:DB_PASSWORD@DB_HOST:DB_PORT/DB_NAME?sslmode=require
+    ```
+
+1.  Run the migrate command with this database URL:
+
+    ```text
+    migrate \
+      -database "YOUR_DB_URL" \
+      -path ./migrations \
+      up
+    ```

--- a/scripts/build
+++ b/scripts/build
@@ -17,12 +17,35 @@
 set -eEuo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
+ALL_SERVICES="cleanup-export,cleanup-exposure,export,exposure,federationin,federationout"
 
 if [ -z "${PROJECT_ID:-}" ]; then
   echo "✋ Missing PROJECT_ID!" >&2
   exit 1
 fi
 
-gcloud builds submit "${ROOT}" \
-  --config "${ROOT}/builders/build.yaml" \
-  --project "${PROJECT_ID}"
+if [ -z "${SERVICES:-}" ]; then
+  echo "✋ Missing SERVICES!" >&2
+  exit 1
+fi
+
+if [ "${SERVICES}" == "all" ]; then
+  SERVICES=${ALL_SERVICES}
+  echo "🚧 Building all services! (${SERVICES})" >&2
+fi
+
+if [ -z "${TAG:-}" ]; then
+  TAG="$(date '+%Y%m%d%H%M%S')"
+  echo "🚧 Using generated tag! (${TAG})" >&2
+fi
+
+IFS=',' read -ra SERVICES_ARR <<< "${SERVICES}"
+for SERVICE in "${SERVICES_ARR[@]}"; do
+  gcloud builds submit "${ROOT}" \
+    --project "${PROJECT_ID}" \
+    --config "${ROOT}/builders/build.yaml" \
+    --substitutions "_SERVICE=${SERVICE},_TAG=${TAG}" \
+    &
+done
+
+wait

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -17,6 +17,7 @@
 set -eEuo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
+ALL_SERVICES="cleanup-export,cleanup-exposure,export,exposure,federationin,federationout"
 
 if [ -z "${PROJECT_ID:-}" ]; then
   echo "✋ Missing PROJECT_ID!" >&2
@@ -28,7 +29,28 @@ if [ -z "${REGION:-}" ]; then
   exit 1
 fi
 
-gcloud builds submit "${ROOT}" \
-  --config "${ROOT}/builders/deploy.yaml" \
-  --substitutions "_REGION=${REGION}" \
-  --project "${PROJECT_ID}"
+if [ -z "${SERVICES:-}" ]; then
+  echo "✋ Missing SERVICES!" >&2
+  exit 1
+fi
+
+if [ "${SERVICES}" == "all" ]; then
+  SERVICES="${ALL_SERVICES}"
+  echo "🚧 Building all services! (${SERVICES})" >&2
+fi
+
+if [ -z "${TAG:-}" ]; then
+  TAG="$(date '+%Y%m%d%H%M%S')"
+  echo "🚧 Using generated tag! (${TAG})" >&2
+fi
+
+IFS=',' read -ra SERVICES_ARR <<< "${SERVICES}"
+for SERVICE in "${SERVICES_ARR[@]}"; do
+  gcloud builds submit --no-source \
+    --project "${PROJECT_ID}" \
+    --config "${ROOT}/builders/deploy.yaml" \
+    --substitutions "_REGION=${REGION},_SERVICE=${SERVICE},_TAG=${TAG}" \
+    &
+done
+
+wait

--- a/scripts/promote
+++ b/scripts/promote
@@ -17,6 +17,7 @@
 set -eEuo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
+ALL_SERVICES="cleanup-export,cleanup-exposure,export,exposure,federationin,federationout"
 
 if [ -z "${PROJECT_ID:-}" ]; then
   echo "✋ Missing PROJECT_ID!" >&2
@@ -26,6 +27,16 @@ fi
 if [ -z "${REGION:-}" ]; then
   echo "✋ Missing REGION!" >&2
   exit 1
+fi
+
+if [ -z "${SERVICES:-}" ]; then
+  echo "✋ Missing SERVICES!" >&2
+  exit 1
+fi
+
+if [ "${SERVICES}" == "all" ]; then
+  SERVICES="${ALL_SERVICES}"
+  echo "🚧 Building all services! (${SERVICES})" >&2
 fi
 
 if [ -z "${REVISION:-}" ]; then
@@ -38,7 +49,13 @@ if [ -z "${PERCENTAGE:-}" ]; then
   PERCENTAGE="100"
 fi
 
-gcloud builds submit "${ROOT}" \
-  --config "${ROOT}/builders/promote.yaml" \
-  --substitutions "_REGION=${REGION},_REVISION=${REVISION},_PERCENTAGE=${PERCENTAGE}" \
-  --project "${PROJECT_ID}"
+IFS=',' read -ra SERVICES_ARR <<< "${SERVICES}"
+for SERVICE in "${SERVICES_ARR[@]}"; do
+  gcloud builds submit --no-source \
+    --project "${PROJECT_ID}" \
+    --config "${ROOT}/builders/promote.yaml" \
+    --substitutions "_REGION=${REGION},_REVISION=${REVISION},_PERCENTAGE=${PERCENTAGE},_SERVICE=${SERVICE}" \
+    &
+done
+
+wait

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -128,6 +128,7 @@ resource "google_sql_database" "db" {
 resource "google_secret_manager_secret" "db-pwd" {
   provider  = google-beta
   secret_id = "dbPassword"
+
   replication {
     automatic = true
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,6 +86,8 @@ resource "null_resource" "build" {
   ]
 }
 
+# Grant Cloud Build the ability to deploy images. It does not do so in these
+# configurations, but it will do future deployments.
 resource "google_project_iam_member" "cloudbuild-deploy" {
   project = data.google_project.project.project_id
   role    = "roles/run.admin"
@@ -136,4 +138,12 @@ locals {
 resource "google_app_engine_application" "app" {
   project     = data.google_project.project.project_id
   location_id = var.appengine_location
+}
+
+output "region" {
+  value = var.region
+}
+
+output "project" {
+  value = data.google_project.project.project_id
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -68,47 +68,21 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
 }
 
-locals {
-  build_substitutions = {
-    "_REGION" : var.region,
-  }
-}
-
-# This step automatically runs a build as well, so everything that uses an image depends on it.
-resource "google_cloudbuild_trigger" "build-and-publish" {
-  provider = google-beta
-  count    = var.use_build_triggers ? 1 : 0
-
-  name        = "build-containers"
-  description = "Build the containers for the exposure notification service and deploy them to cloud run"
-  filename    = "builders/deploy.yaml"
-  github {
-    owner = var.repo_owner
-    name  = var.repo_name
-    push {
-      branch = "^master$"
-    }
-  }
-
-  substitutions = local.build_substitutions
-
-  depends_on = [google_project_service.services["cloudbuild.googleapis.com"]]
-}
-
-# "build" does first time setup - it is different from "deploy" which we set up to trigger for later.
-resource "null_resource" "submit-build-and-publish" {
+# Build creates the container images. It does not deploy or promote them.
+resource "null_resource" "build" {
   provisioner "local-exec" {
     environment = {
       PROJECT_ID = data.google_project.project.project_id
       REGION     = var.region
+      SERVICES   = "all"
+      TAG        = "initial"
     }
 
     command = "${path.module}/../scripts/build"
   }
 
   depends_on = [
-    google_project_iam_member.cloudbuild-secrets,
-    google_project_iam_member.cloudbuild-sql,
+    google_project_service.services["cloudbuild.googleapis.com"],
   ]
 }
 

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -61,7 +61,7 @@ resource "google_cloud_run_service" "cleanup-export" {
       service_account_name = google_service_account.cleanup-export.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-export:latest"
+        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-export:initial"
 
         resources {
           limits = {
@@ -91,7 +91,7 @@ resource "google_cloud_run_service" "cleanup-export" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
     google_project_service.services["sqladmin.googleapis.com"],
-    null_resource.submit-build-and-publish,
+    null_resource.build,
   ]
 }
 

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -61,7 +61,7 @@ resource "google_cloud_run_service" "cleanup-export" {
       service_account_name = google_service_account.cleanup-export.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-export:initial"
+        image = "gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-export:initial"
 
         resources {
           limits = {

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -93,6 +93,12 @@ resource "google_cloud_run_service" "cleanup-export" {
     google_project_service.services["sqladmin.googleapis.com"],
     null_resource.build,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      template,
+    ]
+  }
 }
 
 

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -55,7 +55,7 @@ resource "google_cloud_run_service" "cleanup-exposure" {
       service_account_name = google_service_account.cleanup-exposure.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-exposure:latest"
+        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-exposure:initial"
 
         resources {
           limits = {
@@ -85,7 +85,7 @@ resource "google_cloud_run_service" "cleanup-exposure" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
     google_project_service.services["sqladmin.googleapis.com"],
-    null_resource.submit-build-and-publish,
+    null_resource.build,
   ]
 }
 

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -55,7 +55,7 @@ resource "google_cloud_run_service" "cleanup-exposure" {
       service_account_name = google_service_account.cleanup-exposure.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-exposure:initial"
+        image = "gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/cleanup-exposure:initial"
 
         resources {
           limits = {

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -87,6 +87,12 @@ resource "google_cloud_run_service" "cleanup-exposure" {
     google_project_service.services["sqladmin.googleapis.com"],
     null_resource.build,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      template,
+    ]
+  }
 }
 
 

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -109,6 +109,12 @@ resource "google_cloud_run_service" "export" {
     google_project_service.services["sqladmin.googleapis.com"],
     null_resource.build,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      template,
+    ]
+  }
 }
 
 

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -67,7 +67,7 @@ resource "google_cloud_run_service" "export" {
       service_account_name = google_service_account.export.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/export:initial"
+        image = "gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/export:initial"
 
         resources {
           limits = {

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -67,7 +67,7 @@ resource "google_cloud_run_service" "export" {
       service_account_name = google_service_account.export.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/export:latest"
+        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/export:initial"
 
         resources {
           limits = {
@@ -107,7 +107,7 @@ resource "google_cloud_run_service" "export" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
     google_project_service.services["sqladmin.googleapis.com"],
-    google_cloudbuild_trigger.build-and-publish,
+    null_resource.build,
   ]
 }
 

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -55,7 +55,7 @@ resource "google_cloud_run_service" "exposure" {
       service_account_name = google_service_account.exposure.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/exposure:initial"
+        image = "gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/exposure:initial"
 
         resources {
           limits = {

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -87,6 +87,12 @@ resource "google_cloud_run_service" "exposure" {
     google_project_service.services["sqladmin.googleapis.com"],
     null_resource.build,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      template,
+    ]
+  }
 }
 
 resource "google_cloud_run_service_iam_member" "exposure-public" {

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -55,7 +55,7 @@ resource "google_cloud_run_service" "exposure" {
       service_account_name = google_service_account.exposure.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/exposure:latest"
+        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/exposure:initial"
 
         resources {
           limits = {
@@ -85,7 +85,7 @@ resource "google_cloud_run_service" "exposure" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
     google_project_service.services["sqladmin.googleapis.com"],
-    null_resource.submit-build-and-publish,
+    null_resource.build,
   ]
 }
 

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -55,7 +55,7 @@ resource "google_cloud_run_service" "federationin" {
       service_account_name = google_service_account.federationin.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/federationin:initial"
+        image = "gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/federationin:initial"
 
         resources {
           limits = {

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -55,7 +55,7 @@ resource "google_cloud_run_service" "federationin" {
       service_account_name = google_service_account.federationin.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/federationin:latest"
+        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/federationin:initial"
 
         resources {
           limits = {
@@ -85,6 +85,6 @@ resource "google_cloud_run_service" "federationin" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
     google_project_service.services["sqladmin.googleapis.com"],
-    null_resource.submit-build-and-publish,
+    null_resource.build,
   ]
 }

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -87,4 +87,10 @@ resource "google_cloud_run_service" "federationin" {
     google_project_service.services["sqladmin.googleapis.com"],
     null_resource.build,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      template,
+    ]
+  }
 }

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -87,6 +87,12 @@ resource "google_cloud_run_service" "federationout" {
     google_project_service.services["sqladmin.googleapis.com"],
     null_resource.build,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      template,
+    ]
+  }
 }
 
 resource "google_cloud_run_service_iam_member" "federationout-public" {

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -55,7 +55,7 @@ resource "google_cloud_run_service" "federationout" {
       service_account_name = google_service_account.federationout.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/federationout:latest"
+        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/federationout:initial"
 
         resources {
           limits = {
@@ -85,7 +85,7 @@ resource "google_cloud_run_service" "federationout" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
     google_project_service.services["sqladmin.googleapis.com"],
-    null_resource.submit-build-and-publish,
+    null_resource.build,
   ]
 }
 

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -55,7 +55,7 @@ resource "google_cloud_run_service" "federationout" {
       service_account_name = google_service_account.federationout.email
 
       containers {
-        image = "us.gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/federationout:initial"
+        image = "gcr.io/${data.google_project.project.project_id}/github.com/google/exposure-notifications-server/cmd/federationout:initial"
 
         resources {
           limits = {

--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,5 +1,0 @@
-terraform {
-  backend "gcs" {
-    bucket = "sv-tf-test-16-tf-state"
-  }
-}

--- a/terraform/state.tf
+++ b/terraform/state.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "gcs" {
+    bucket = "sv-tf-test-16-tf-state"
+  }
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -26,11 +26,6 @@ variable "project" {
   type = string
 }
 
-variable "use_build_triggers" {
-  type    = bool
-  default = false
-}
-
 variable "repo_owner" {
   type    = string
   default = "google"


### PR DESCRIPTION
I did a spike on this today, and I think it fixes GH-386. 

Terraform does the initial _everything_, but then ignores all future changes on Cloud Run services. This lets us run `terraform apply` and get a fully-functional setup, but then iterate and deploy on services individually.

The containers built by Terraform are tagged and deployed as `:initial`. Future builds use a timestamp-based tag.

I also addressed some of Steren's feedback in previous issues about being able to deploy individual services.