### PR TITLE
temporaryTracingKeys is now temporaryExposureKeys

### DIFF
--- a/docs/server_functional_requirements.md
+++ b/docs/server_functional_requirements.md
@@ -108,7 +108,7 @@ The following snippet is an example POST request payload in JSON format.
 
 ```json
 {
-  "temporaryTracingKeys": [
+  "temporaryExposureKeys": [
     {"key": "base64 KEY1", "rollingStartNumber": 12345, "rollingPeriod": 144, "transmissionRisk": 5},
     {"key": "base64 KEY2", "rollingStartNumber": 12489, "rollingPeriod": 10, "transmissionRisk": 6},
     {"key": "base64 KEYN", "rollingStartNumber": 12499, "rollingPeriod": 100, "transmissionRisk": 7}],


### PR DESCRIPTION
As per the narrative docs, just above the sample JSON.