### PR TITLE
unit tests for internal/cleanup 

### DIFF
--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -37,7 +37,7 @@ const (
 // from the database.
 func NewExposureHandler(config *Config, env *serverenv.ServerEnv) (http.Handler, error) {
 	if env.Database() == nil {
-		return nil, fmt.Errorf("missing database in server environment")
+		return nil, fmt.Errorf("cleanup.NewExposureHandler requires Database present in the ServerEnv")
 	}
 
 	return &exposureCleanupHandler{
@@ -89,10 +89,10 @@ func (h *exposureCleanupHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 // old export files that are no longer needed by clients for download.
 func NewExportHandler(config *Config, env *serverenv.ServerEnv) (http.Handler, error) {
 	if env.Database() == nil {
-		return nil, fmt.Errorf("missing database in server environment")
+		return nil, fmt.Errorf("export.NewExportHandler requires Database present in the ServerEnv")
 	}
 	if env.Blobstore() == nil {
-		return nil, fmt.Errorf("missing blobstore in server environment")
+		return nil, fmt.Errorf("export.NewExportHandler requires Blobstore present in the ServerEnv")
 	}
 
 	return &exportCleanupHandler{

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -37,7 +37,7 @@ const (
 // from the database.
 func NewExposureHandler(config *Config, env *serverenv.ServerEnv) (http.Handler, error) {
 	if env.Database() == nil {
-		return nil, fmt.Errorf("cleanup.NewExposureHandler requires Database present in the ServerEnv")
+		return nil, fmt.Errorf("missing database in server environment")
 	}
 
 	return &exposureCleanupHandler{
@@ -89,10 +89,10 @@ func (h *exposureCleanupHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 // old export files that are no longer needed by clients for download.
 func NewExportHandler(config *Config, env *serverenv.ServerEnv) (http.Handler, error) {
 	if env.Database() == nil {
-		return nil, fmt.Errorf("export.NewExportHandler requires Database present in the ServerEnv")
+		return nil, fmt.Errorf("missing database in server environment")
 	}
 	if env.Blobstore() == nil {
-		return nil, fmt.Errorf("export.NewExportHandler requires Blobstore present in the ServerEnv")
+		return nil, fmt.Errorf("missing blobstore in server environment")
 	}
 
 	return &exportCleanupHandler{

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func TestNewExposureHandler(t *testing.T) {
-	ctx := context.Background()
 	testDB := database.NewTestDatabase(t)
+	ctx := context.Background()
 
 	testCases := []struct {
 		name string
@@ -70,11 +70,7 @@ func TestNewExposureHandler(t *testing.T) {
 func TestNewExportHandler(t *testing.T) {
 	ctx := context.Background()
 	testDB := database.NewTestDatabase(t)
-
-	blobStorage, err := storage.NewFilesystemStorage(ctx)
-	if err != nil {
-		t.Fatalf("Failed to initialize Blobstore: %+v", err)
-	}
+	noopBlobstore, _ := storage.NewNoopBlobstore(ctx)
 
 	testCases := []struct {
 		name string
@@ -93,7 +89,7 @@ func TestNewExportHandler(t *testing.T) {
 		},
 		{
 			name: "Fully Specified",
-			env:  serverenv.New(ctx, serverenv.WithBlobStorage(blobStorage), serverenv.WithDatabase(testDB)),
+			env:  serverenv.New(ctx, serverenv.WithBlobStorage(noopBlobstore), serverenv.WithDatabase(testDB)),
 			err:  nil,
 		},
 	}

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -15,9 +15,109 @@
 package cleanup
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/serverenv"
+	"github.com/google/exposure-notifications-server/internal/storage"
 )
+
+func TestNewExposureHandler(t *testing.T) {
+	ctx := context.Background()
+	testDB := database.NewTestDatabase(t)
+
+	testCases := []struct {
+		name string
+		env  *serverenv.ServerEnv
+		err  error
+	}{
+		{
+			name: "nil Database",
+			env:  serverenv.New(ctx),
+			err:  fmt.Errorf("cleanup.NewExposureHandler requires Database present in the ServerEnv"),
+		},
+		{
+			name: "Fully Specified",
+			env:  serverenv.New(ctx, serverenv.WithDatabase(testDB)),
+			err:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NewExposureHandler(&Config{}, tc.env)
+			if tc.err != nil {
+				if err.Error() != tc.err.Error() {
+					t.Fatalf("got '%+v': want '%v'", err, tc.err)
+				}
+			} else if err != nil {
+				t.Fatalf("got unexpected error: %v", err)
+			} else {
+				handler, ok := got.(*exposureCleanupHandler)
+				if !ok {
+					t.Fatalf("exposureCleanupHandler does not satisfy http.Handler interface")
+				} else if handler.env != tc.env {
+					t.Fatalf("got %+v: want %v", handler.env, tc.env)
+				}
+			}
+		})
+	}
+}
+
+func TestNewExportHandler(t *testing.T) {
+	ctx := context.Background()
+	testDB := database.NewTestDatabase(t)
+
+	blobStorage, err := storage.NewFilesystemStorage(ctx)
+	if err != nil {
+		t.Fatalf("Failed to initialize Blobstore: %+v", err)
+	}
+
+	testCases := []struct {
+		name string
+		env  *serverenv.ServerEnv
+		err  error
+	}{
+		{
+			name: "nil Database",
+			env:  serverenv.New(ctx),
+			err:  fmt.Errorf("export.NewExportHandler requires Database present in the ServerEnv"),
+		},
+		{
+			name: "nil Blobstore",
+			env:  serverenv.New(ctx, serverenv.WithDatabase(testDB)),
+			err:  fmt.Errorf("export.NewExportHandler requires Blobstore present in the ServerEnv"),
+		},
+		{
+			name: "Fully Specified",
+			env:  serverenv.New(ctx, serverenv.WithBlobStorage(blobStorage), serverenv.WithDatabase(testDB)),
+			err:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NewExportHandler(&Config{}, tc.env)
+			if tc.err != nil {
+				if err.Error() != tc.err.Error() {
+					t.Fatalf("got %+v: want %v", err, tc.err)
+				}
+			} else if err != nil {
+				t.Fatalf("got unexpected error: %v", err)
+			} else {
+				handler, ok := got.(*exportCleanupHandler)
+				if !ok {
+					t.Fatal("exportCleanupHandler does not satisfy http.Handler interface")
+				} else if handler.env != tc.env {
+					t.Fatalf("got %+v: want %v", handler.env, tc.env)
+				}
+			}
+		})
+	}
+}
 
 func TestCutoffDate(t *testing.T) {
 	now := time.Now()

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -37,7 +37,7 @@ func TestNewExposureHandler(t *testing.T) {
 		{
 			name: "nil Database",
 			env:  serverenv.New(ctx),
-			err:  fmt.Errorf("cleanup.NewExposureHandler requires Database present in the ServerEnv"),
+			err:  fmt.Errorf("missing database in server environment"),
 		},
 		{
 			name: "Fully Specified",
@@ -80,12 +80,12 @@ func TestNewExportHandler(t *testing.T) {
 		{
 			name: "nil Database",
 			env:  serverenv.New(ctx),
-			err:  fmt.Errorf("export.NewExportHandler requires Database present in the ServerEnv"),
+			err:  fmt.Errorf("missing database in server environment"),
 		},
 		{
 			name: "nil Blobstore",
 			env:  serverenv.New(ctx, serverenv.WithDatabase(testDB)),
-			err:  fmt.Errorf("export.NewExportHandler requires Blobstore present in the ServerEnv"),
+			err:  fmt.Errorf("missing blobstore in server environment"),
 		},
 		{
 			name: "Fully Specified",

--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -589,4 +589,4 @@ func TestAddExportFileSkipsDuplicates(t *testing.T) {
 	}
 }
 
-// TODO TestDeleteFilesBefore
+// TODO(jan25) add TestDeleteFilesBefore. Related to issue #241

--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -588,3 +588,5 @@ func TestAddExportFileSkipsDuplicates(t *testing.T) {
 		t.Fatalf("bucket name mismatch got %q, want %q", got.BucketName, wantBucketName)
 	}
 }
+
+// TODO TestDeleteFilesBefore


### PR DESCRIPTION
Partially Fixes #241

Add basic tests for cleanup handler creator funcs.

Left a TODO: to add unit test for `export.database.DeleteFilesBefore`