### PR TITLE
fix issues with index file

### DIFF
--- a/internal/export/config.go
+++ b/internal/export/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	TruncateWindow time.Duration `envconfig:"TRUNCATE_WINDOW" default:"1h"`
 	MinWindowAge   time.Duration `envconfig:"MIN_WINDOW_AGE" default:"2h"`
 	BlobstoreType  string        `envconfig:"BLOBSTORE_TYPE" default:"CLOUD_STORAGE"`
+	TTL            time.Duration `envconfig:"CLEANUP_TTL" default:"336h"`
 }
 
 // DB returns the database config.

--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -394,7 +394,8 @@ func TestFinalizeBatch(t *testing.T) {
 	}
 
 	// Check that files were written.
-	gotFiles, err := exportDB.LookupExportFiles(ctx, eb.ConfigID)
+	ttl, _ := time.ParseDuration("20h")
+	gotFiles, err := exportDB.LookupExportFiles(ctx, ttl)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -252,9 +252,9 @@ func (s *Server) retryingCreateIndex(ctx context.Context, eb *model.ExportBatch,
 
 func (s *Server) createIndex(ctx context.Context, eb *model.ExportBatch, newObjectNames []string) (string, int, error) {
 	exportDB := database.New(s.db)
-	objects, err := exportDB.LookupExportFiles(ctx, eb.ConfigID)
+	objects, err := exportDB.LookupExportFiles(ctx, s.config.TTL)
 	if err != nil {
-		return "", 0, fmt.Errorf("lookup existing export files for batch %d: %w", eb.BatchID, err)
+		return "", 0, fmt.Errorf("lookup available export files: %w", err)
 	}
 
 	// Add the new objects (they haven't been committed to the database yet).


### PR DESCRIPTION
This fixes two problems in the index files:
1) no longer limit available export files to those in same
   export config. During a config rollover this would have
   caused all old files to disappear from index
2) fixes #453 by adding time constraint to lookup query.
   since emitIndexForEmptyBatch = true at least once we
  don't need to specially invoke index cleanup after wipeout
  and can rely on next batch worker