### PR TITLE
Doc changes as docs/ is deployed self contained

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -51,7 +51,7 @@ infrastructure, database, service accounts, and first deployment of the services
 on Cloud Run. **Terraform does not manage the Cloud Run services after their
 initial creation!**
 
-See [Deploying with Terraform](../terraform/README.md) for more information.
+See [Deploying with Terraform](https://github.com/google/exposure-notifications-server/blob/master/terraform) for more information.
 
 ## Running services
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,11 +40,11 @@ The Exposure Notification Server is responsible for the following functions:
 You can read tutorials on deploying and using the reference Exposure Notification
 Server here:
 
-[Deployment guide](deploying.md)
-[Contributor guide](/CONTRIBUTING.md)
-[Server Functional Requirements](server_functional_requirements.md)
-[Server Deployment Options](server_deployment_options.md)
-[Reference documentation](https://pkg.go.dev/mod/github.com/google/exposure-notifications-server)
+* [Deployment guide](deploying.md)
+* [Contributor guide](/CONTRIBUTING.md)
+* [Server Functional Requirements](server_functional_requirements.md)
+* [Server Deployment Options](server_deployment_options.md)
+* [Reference documentation](https://pkg.go.dev/mod/github.com/google/exposure-notifications-server)
 
 ## Issues and Questions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ You can read tutorials on deploying and using the reference Exposure Notificatio
 Server here:
 
 * [Deployment guide](deploying.md)
-* [Contributor guide](/CONTRIBUTING.md)
+* [Contributor guide](https://github.com/google/exposure-notifications-server/blob/master/CONTRIBUTING.md)
 * [Server Functional Requirements](server_functional_requirements.md)
 * [Server Deployment Options](server_deployment_options.md)
 * [Reference documentation](https://pkg.go.dev/mod/github.com/google/exposure-notifications-server)


### PR DESCRIPTION
docs/ is hosted at https://google.github.io/exposure-notifications-server/ so relative links outside of docs will result in a 404.