### PR TITLE
ci: stop formatting generated files

### DIFF
--- a/internal/pb/export/export.pb.go
+++ b/internal/pb/export/export.pb.go
@@ -21,12 +21,11 @@
 package export
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/internal/pb/federation.pb.go
+++ b/internal/pb/federation.pb.go
@@ -22,15 +22,14 @@ package pb
 
 import (
 	context "context"
-	reflect "reflect"
-	sync "sync"
-
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -17,8 +17,10 @@
 set -eEuo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
-SOURCE_DIRS="cmd internal tools"
-
+# Find all non-generated Go files. This works by excluding
+# files that start with the official "generated file" header.
+# See https://github.com/golang/go/issues/13560#issuecomment-288457920
+SOURCE_FILES=($(grep -L -HR "^\/\/ Code generated .* DO NOT EDIT\.$" --include="*.go" ${ROOT}))
 
 echo "🌳 Set up environment variables"
 eval $(${ROOT}/scripts/dev init)
@@ -26,7 +28,12 @@ eval $(${ROOT}/scripts/dev init)
 
 echo "🚒 Verify Protobufs are up to date"
 ${ROOT}/scripts/dev protoc
-# Don't verify generated pb files here as they are tidied later.
+git diff *.go | tee /dev/stderr | (! read)
+if [ $? -ne 0 ]; then
+   echo "✋ Found uncommited changes after regenerating Protobufs."
+   echo "✋ Commit these changes before merging."
+   exit 1
+fi
 
 
 echo "🧽 Verify goimports formattting"
@@ -38,11 +45,9 @@ if [ $? -ne 0 ]; then
    echo "✋ to enable import cleanup. Import cleanup skipped."
 else
    echo "🧽 Format with goimports"
-   goimports -w $(echo $SOURCE_DIRS)
+   goimports -w ${SOURCE_FILES[@]}
    # Check if there were uncommited changes.
-   # Ignore comment line changes as sometimes proto gen just updates versions
-   # of the generator
-   git diff -G'(^\s+[^/])' *.go | tee /dev/stderr | (! read)
+   git diff *.go | tee /dev/stderr | (! read)
    if [ $? -ne 0 ]; then
       echo "✋ Found uncommited changes after goimports."
       echo "✋ Commit these changes before merging."
@@ -54,8 +59,8 @@ set -e
 
 echo "🧹 Verify gofmt format"
 set +e
-diff -u <(echo -n) <(gofmt -d -s .)
-git diff -G'(^\s+[^/])' *.go | tee /dev/stderr | (! read)
+gofmt -s -w ${SOURCE_FILES[@]}
+git diff *.go | tee /dev/stderr | (! read)
 if [ $? -ne 0 ]; then
    echo "✋ Found uncommited changes after gofmt."
    echo "✋ Commit these changes before merging."


### PR DESCRIPTION
Avoid formatting generated files by checking for
[the official generated file header](https://github.com/golang/go/issues/13560#issuecomment-288457920) before formatting.

Because everyone uses the same docker image to
generate protobuf files, this shouldn't cause much disruption.
Every time the docker image is updated the corresponding
regeneration will have to be made in the repo.

Happy to have a discussion on this as it's a bit more heavy handed than my other contributions.