### PR TITLE
Drop Cloud SQL proxy and switch to VPC connections

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -68,15 +68,15 @@ resource "google_sql_ssl_cert" "client_cert" {
   instance    = google_sql_database_instance.db-inst.name
 }
 
-resource "random_password" "userpassword" {
-  length  = 16
+resource "random_password" "db-password" {
+  length  = 64
   special = false
 }
 
 resource "google_sql_user" "user" {
   instance = google_sql_database_instance.db-inst.name
   name     = "notification"
-  password = random_password.userpassword.result
+  password = random_password.db-password.result
 }
 
 resource "google_sql_database" "db" {

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -30,6 +30,16 @@ resource "google_sql_database_instance" "db-inst" {
     disk_size         = var.cloudsql_disk_size_gb
     availability_type = "REGIONAL"
 
+    database_flags {
+      name  = "autovacuum"
+      value = "on"
+    }
+
+    database_flags {
+      name  = "max_connections"
+      value = "100000"
+    }
+
     backup_configuration {
       enabled    = true
       start_time = "02:00"

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -63,9 +63,16 @@ resource "google_sql_database_instance" "db-inst" {
   ]
 }
 
-resource "google_sql_ssl_cert" "client_cert" {
-  common_name = "apollo"
+resource "google_sql_database" "db" {
+  project  = data.google_project.project.project_id
+  instance = google_sql_database_instance.db-inst.name
+  name     = "main"
+}
+
+resource "google_sql_ssl_cert" "db-cert" {
+  project     = data.google_project.project.project_id
   instance    = google_sql_database_instance.db-inst.name
+  common_name = "expsoure-notification"
 }
 
 resource "random_password" "db-password" {
@@ -79,16 +86,17 @@ resource "google_sql_user" "user" {
   password = random_password.db-password.result
 }
 
-resource "google_sql_database" "db" {
-  instance = google_sql_database_instance.db-inst.name
+resource "google_secret_manager_secret" "db-secret" {
+  provider = google-beta
 
-  name    = "main"
-  project = data.google_project.project.project_id
-}
+  for_each = toset([
+    "sslcert",
+    "sslkey",
+    "sslrootcert",
+    "password",
+  ])
 
-resource "google_secret_manager_secret" "db-pwd" {
-  provider  = google-beta
-  secret_id = "dbPassword"
+  secret_id = "db-${each.key}"
 
   replication {
     automatic = true
@@ -99,17 +107,25 @@ resource "google_secret_manager_secret" "db-pwd" {
   ]
 }
 
-resource "google_secret_manager_secret_version" "db-pwd-initial" {
-  provider    = google-beta
-  secret      = google_secret_manager_secret.db-pwd.id
-  secret_data = google_sql_user.user.password
+resource "google_secret_manager_secret_version" "db-secret-version" {
+  provider = google-beta
+
+  for_each = {
+    sslcert     = google_sql_ssl_cert.db-cert.cert
+    sslkey      = google_sql_ssl_cert.db-cert.private_key
+    sslrootcert = google_sql_ssl_cert.db-cert.server_ca_cert
+    password    = google_sql_user.user.password
+  }
+
+  secret      = google_secret_manager_secret.db-secret[each.key].id
+  secret_data = each.value
 }
 
 # Grant Cloud Build the ability to access the database password (required to run
 # migrations).
 resource "google_secret_manager_secret_iam_member" "cloudbuild-db-pwd" {
   provider  = google-beta
-  secret_id = google_secret_manager_secret.db-pwd.id
+  secret_id = google_secret_manager_secret.db-secret["password"].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
 
@@ -124,7 +140,9 @@ resource "google_project_iam_member" "cloudbuild-sql" {
   role    = "roles/cloudsql.client"
   member  = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
 
-  depends_on = [google_project_service.services["cloudbuild.googleapis.com"]]
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"]
+  ]
 }
 
 # Migrate runs the initial database migrations.
@@ -133,7 +151,7 @@ resource "null_resource" "migrate" {
     environment = {
       PROJECT_ID     = data.google_project.project.project_id
       DB_CONN        = google_sql_database_instance.db-inst.connection_name
-      DB_PASS_SECRET = google_secret_manager_secret_version.db-pwd-initial.name
+      DB_PASS_SECRET = google_secret_manager_secret_version.db-secret-version["password"].name
       DB_NAME        = google_sql_database.db.name
       DB_USER        = google_sql_user.user.name
       COMMAND        = "up"
@@ -166,5 +184,5 @@ output "db_user" {
 }
 
 output "db_pass_secret" {
-  value = google_secret_manager_secret_version.db-pwd-initial.name
+  value = google_secret_manager_secret_version.db-secret-version["password"].name
 }

--- a/terraform/key_management.tf
+++ b/terraform/key_management.tf
@@ -16,6 +16,10 @@ resource "google_kms_key_ring" "export-signing" {
   project  = data.google_project.project.project_id
   name     = "export-signing"
   location = var.region
+
+  depends_on = [
+    google_project_service.services["cloudkms.googleapis.com"],
+  ]
 }
 
 resource "google_kms_crypto_key" "export-signer" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -54,20 +54,18 @@ resource "google_project_service" "services" {
 }
 
 resource "google_compute_global_address" "private_ip_address" {
-  provider = google-beta
-
   name          = "private-ip-address"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
   network       = data.google_compute_network.default.self_link
 
-  depends_on = [google_project_service.services["compute.googleapis.com"]]
+  depends_on = [
+    google_project_service.services["compute.googleapis.com"],
+  ]
 }
 
 resource "google_service_networking_connection" "private_vpc_connection" {
-  provider = google-beta
-
   network                 = data.google_compute_network.default.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -111,7 +111,7 @@ locals {
     },
     {
       name  = "DB_POOL_MAX_CONNS"
-      value = "10"
+      value = "50"
     },
     {
       name  = "DB_PASSWORD"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -114,24 +114,40 @@ locals {
       value = "50"
     },
     {
-      name  = "DB_PASSWORD"
-      value = "secret://${google_secret_manager_secret_version.db-pwd-initial.name}"
-    },
-    {
       name  = "DB_SSLMODE"
       value = "verify-ca"
     },
     {
       name  = "DB_HOST"
-      value = "/cloudsql/${data.google_project.project.project_id}:${var.region}:${google_sql_database_instance.db-inst.name}"
-    },
-    {
-      name  = "DB_USER"
-      value = google_sql_user.user.name
+      value = google_sql_database_instance.db-inst.private_ip_address
     },
     {
       name  = "DB_NAME"
       value = google_sql_database.db.name
+    },
+    {
+      name  = "DB_SSLCERT"
+      value = "secret://${google_secret_manager_secret_version.db-secret-version["sslcert"].id}?target=file"
+    },
+
+    {
+      name  = "DB_SSLKEY"
+      value = "secret://${google_secret_manager_secret_version.db-secret-version["sslkey"].id}?target=file"
+    },
+
+    {
+      name  = "DB_SSLROOTCERT"
+      value = "secret://${google_secret_manager_secret_version.db-secret-version["sslrootcert"].id}?target=file"
+    },
+
+    {
+      name  = "DB_USER"
+      value = google_sql_user.user.name
+    },
+
+    {
+      name  = "DB_PASSWORD"
+      value = "secret://${google_secret_manager_secret_version.db-secret-version["password"].id}"
     },
   ]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -147,17 +147,14 @@ locals {
       name  = "DB_SSLKEY"
       value = "secret://${google_secret_manager_secret_version.db-secret-version["sslkey"].id}?target=file"
     },
-
     {
       name  = "DB_SSLROOTCERT"
       value = "secret://${google_secret_manager_secret_version.db-secret-version["sslrootcert"].id}?target=file"
     },
-
     {
       name  = "DB_USER"
       value = google_sql_user.user.name
     },
-
     {
       name  = "DB_PASSWORD"
       value = "secret://${google_secret_manager_secret_version.db-secret-version["password"].id}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -118,11 +118,8 @@ locals {
       value = "secret://${google_secret_manager_secret_version.db-pwd-initial.name}"
     },
     {
-      # NOTE: We disable SSL here because the Cloud Run services use the Cloud
-      # SQL proxy which runs on localhost. The proxy still uses a secure
-      # connection to Cloud SQL.
       name  = "DB_SSLMODE"
-      value = "disable"
+      value = "verify-ca"
     },
     {
       name  = "DB_HOST"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,6 +41,7 @@ resource "google_project_service" "services" {
     "cloudkms.googleapis.com",
     "cloudscheduler.googleapis.com",
     "compute.googleapis.com",
+    "containerregistry.googleapis.com",
     "run.googleapis.com",
     "secretmanager.googleapis.com",
     "servicenetworking.googleapis.com",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -48,6 +48,7 @@ resource "google_project_service" "services" {
     "sql-component.googleapis.com",
     "sqladmin.googleapis.com",
     "storage-api.googleapis.com",
+    "vpcaccess.googleapis.com",
   ])
   service            = each.value
   disable_on_destroy = false
@@ -69,6 +70,18 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   network                 = data.google_compute_network.default.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
+}
+
+resource "google_vpc_access_connector" "connector" {
+  project       = data.google_project.project.project_id
+  name          = "serverless-vpc-connector"
+  region        = var.region
+  network       = data.google_compute_network.default.name
+  ip_cidr_range = "10.8.0.0/28"
+
+  depends_on = [
+    google_project_service.services["vpcaccess.googleapis.com"],
+  ]
 }
 
 # Build creates the container images. It does not deploy or promote them.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -124,7 +124,7 @@ locals {
     },
     {
       name  = "DB_POOL_MAX_CONNS"
-      value = "50"
+      value = "10"
     },
     {
       name  = "DB_SSLMODE"

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -142,5 +142,6 @@ resource "google_cloud_scheduler_job" "cleanup-export-worker" {
   depends_on = [
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.cleanup-export-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
   ]
 }

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -32,16 +32,17 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-cleanup-export" 
   ]
 }
 
-resource "google_project_iam_member" "cleanup-export-cloudsql" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudsql.client"
-  member  = "serviceAccount:${google_service_account.cleanup-export.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "cleanup-export-db-pwd" {
+resource "google_secret_manager_secret_iam_member" "cleanup-export-db" {
   provider = google-beta
 
-  secret_id = google_secret_manager_secret.db-pwd.id
+  for_each = toset([
+    "sslcert",
+    "sslkey",
+    "sslrootcert",
+    "password",
+  ])
+
+  secret_id = google_secret_manager_secret.db-secret[each.key].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.cleanup-export.email}"
 }
@@ -83,14 +84,14 @@ resource "google_cloud_run_service" "cleanup-export" {
     metadata {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1000",
-        "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
+        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }
   }
 
   depends_on = [
     google_project_service.services["run.googleapis.com"],
-    google_project_service.services["sqladmin.googleapis.com"],
+    google_secret_manager_secret_iam_member.cleanup-export-db,
     null_resource.build,
   ]
 

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -83,7 +83,7 @@ resource "google_cloud_run_service" "cleanup-export" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" : "1000",
+        "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -136,5 +136,6 @@ resource "google_cloud_scheduler_job" "cleanup-exposure-worker" {
   depends_on = [
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.cleanup-exposure-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
   ]
 }

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -32,16 +32,17 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-cleanup-exposure
   ]
 }
 
-resource "google_project_iam_member" "cleanup-exposure-cloudsql" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudsql.client"
-  member  = "serviceAccount:${google_service_account.cleanup-exposure.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "cleanup-exposure-db-pwd" {
+resource "google_secret_manager_secret_iam_member" "cleanup-exposure-db" {
   provider = google-beta
 
-  secret_id = google_secret_manager_secret.db-pwd.id
+  for_each = toset([
+    "sslcert",
+    "sslkey",
+    "sslrootcert",
+    "password",
+  ])
+
+  secret_id = google_secret_manager_secret.db-secret[each.key].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.cleanup-exposure.email}"
 }
@@ -77,14 +78,14 @@ resource "google_cloud_run_service" "cleanup-exposure" {
     metadata {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1000",
-        "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
+        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }
   }
 
   depends_on = [
     google_project_service.services["run.googleapis.com"],
-    google_project_service.services["sqladmin.googleapis.com"],
+    google_secret_manager_secret_iam_member.cleanup-exposure-db,
     null_resource.build,
   ]
 

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -77,7 +77,7 @@ resource "google_cloud_run_service" "cleanup-exposure" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" : "1000",
+        "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -95,11 +95,13 @@ resource "google_cloud_run_service" "export" {
           value = google_storage_bucket.export.name
         }
       }
+
+      container_concurrency = 10
     }
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" : "2",
+        "autoscaling.knative.dev/maxScale" : "10",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -158,6 +158,7 @@ resource "google_cloud_scheduler_job" "export-worker" {
   depends_on = [
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.export-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
   ]
 }
 
@@ -183,5 +184,6 @@ resource "google_cloud_scheduler_job" "export-create-batches" {
   depends_on = [
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.export-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
   ]
 }

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -99,7 +99,7 @@ resource "google_cloud_run_service" "export" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" : "1000",
+        "autoscaling.knative.dev/maxScale" : "2",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -77,7 +77,7 @@ resource "google_cloud_run_service" "exposure" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" : "50",
+        "autoscaling.knative.dev/maxScale" : "500",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -77,7 +77,7 @@ resource "google_cloud_run_service" "exposure" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" : "1000",
+        "autoscaling.knative.dev/maxScale" : "50",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -32,16 +32,17 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-exposure" {
   ]
 }
 
-resource "google_project_iam_member" "exposure-cloudsql" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudsql.client"
-  member  = "serviceAccount:${google_service_account.exposure.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "exposure-db-pwd" {
+resource "google_secret_manager_secret_iam_member" "exposure-db" {
   provider = google-beta
 
-  secret_id = google_secret_manager_secret.db-pwd.id
+  for_each = toset([
+    "sslcert",
+    "sslkey",
+    "sslrootcert",
+    "password",
+  ])
+
+  secret_id = google_secret_manager_secret.db-secret[each.key].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.exposure.email}"
 }
@@ -77,14 +78,14 @@ resource "google_cloud_run_service" "exposure" {
     metadata {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1000",
-        "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
+        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }
   }
 
   depends_on = [
     google_project_service.services["run.googleapis.com"],
-    google_project_service.services["sqladmin.googleapis.com"],
+    google_secret_manager_secret_iam_member.exposure-db,
     null_resource.build,
   ]
 

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -32,16 +32,17 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-federationin" {
   ]
 }
 
-resource "google_project_iam_member" "federationin-cloudsql" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudsql.client"
-  member  = "serviceAccount:${google_service_account.federationin.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "federationin-db-pwd" {
+resource "google_secret_manager_secret_iam_member" "federationin" {
   provider = google-beta
 
-  secret_id = google_secret_manager_secret.db-pwd.id
+  for_each = toset([
+    "sslcert",
+    "sslkey",
+    "sslrootcert",
+    "password",
+  ])
+
+  secret_id = google_secret_manager_secret.db-secret[each.key].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.federationin.email}"
 }
@@ -77,14 +78,14 @@ resource "google_cloud_run_service" "federationin" {
     metadata {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1000",
-        "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
+        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }
   }
 
   depends_on = [
     google_project_service.services["run.googleapis.com"],
-    google_project_service.services["sqladmin.googleapis.com"],
+    google_secret_manager_secret_iam_member.federationin,
     null_resource.build,
   ]
 

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -77,7 +77,7 @@ resource "google_cloud_run_service" "federationin" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" : "1000",
+        "autoscaling.knative.dev/maxScale" : "3",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -22,12 +22,6 @@ resource "google_service_account" "federationout" {
   display_name = "Exposure Notification Federation (Out)"
 }
 
-resource "google_project_iam_member" "federationout-cloudsql" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudsql.client"
-  member  = "serviceAccount:${google_service_account.federationout.email}"
-}
-
 resource "google_service_account_iam_member" "cloudbuild-deploy-federationout" {
   service_account_id = google_service_account.federationout.id
   role               = "roles/iam.serviceAccountUser"
@@ -38,10 +32,17 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-federationout" {
   ]
 }
 
-resource "google_secret_manager_secret_iam_member" "federationout-db-pwd" {
+resource "google_secret_manager_secret_iam_member" "federationout-db" {
   provider = google-beta
 
-  secret_id = google_secret_manager_secret.db-pwd.id
+  for_each = toset([
+    "sslcert",
+    "sslkey",
+    "sslrootcert",
+    "password",
+  ])
+
+  secret_id = google_secret_manager_secret.db-secret[each.key].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.federationout.email}"
 }
@@ -77,14 +78,14 @@ resource "google_cloud_run_service" "federationout" {
     metadata {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1000",
-        "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
+        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }
   }
 
   depends_on = [
     google_project_service.services["run.googleapis.com"],
-    google_project_service.services["sqladmin.googleapis.com"],
+    google_secret_manager_secret_iam_member.federationout-db,
     null_resource.build,
   ]
 

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -77,7 +77,7 @@ resource "google_cloud_run_service" "federationout" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" : "1000",
+        "autoscaling.knative.dev/maxScale" : "5",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }

--- a/terraform/service_gcr_cleaner.tf
+++ b/terraform/service_gcr_cleaner.tf
@@ -36,6 +36,10 @@ resource "google_storage_bucket_iam_member" "gcr-cleaner-objectadmin" {
   bucket = "artifacts.${data.google_project.project.project_id}.appspot.com"
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.gcr-cleaner.email}"
+
+  depends_on = [
+    google_project_service.services["containerregistry.googleapis.com"],
+  ]
 }
 
 resource "google_cloud_run_service" "gcr-cleaner" {
@@ -124,5 +128,6 @@ resource "google_cloud_scheduler_job" "gcr-cleaner-worker" {
   depends_on = [
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.gcr-cleaner-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
   ]
 }

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -32,16 +32,17 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-generate" {
   ]
 }
 
-resource "google_project_iam_member" "generate-cloudsql" {
-  project = data.google_project.project.project_id
-  role    = "roles/cloudsql.client"
-  member  = "serviceAccount:${google_service_account.generate.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "generate-db-pwd" {
+resource "google_secret_manager_secret_iam_member" "generate-db" {
   provider = google-beta
 
-  secret_id = google_secret_manager_secret.db-pwd.id
+  for_each = toset([
+    "sslcert",
+    "sslkey",
+    "sslrootcert",
+    "password",
+  ])
+
+  secret_id = google_secret_manager_secret.db-secret[each.key].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.generate.email}"
 }
@@ -77,14 +78,14 @@ resource "google_cloud_run_service" "generate" {
     metadata {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1000",
-        "run.googleapis.com/cloudsql-instances" : google_sql_database_instance.db-inst.connection_name
+        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }
   }
 
   depends_on = [
     google_project_service.services["run.googleapis.com"],
-    google_project_service.services["sqladmin.googleapis.com"],
+    google_secret_manager_secret_iam_member.generate-db,
     null_resource.build,
   ]
 

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -77,7 +77,7 @@ resource "google_cloud_run_service" "generate" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" : "1000",
+        "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
       }
     }


### PR DESCRIPTION
This also tunes the max instances to what each service can reasonable scale to before exhausting the maximum number of connections. I think we still need to do some additional benchmarking, but I was able to execute the following benchmark steadily:

```text
Summary:
  Total:	517.7146 secs
  Slowest:	13.7738 secs
  Fastest:	5.0447 secs
  Average:	5.1063 secs
  Requests/sec:	19.3157


Response time histogram:
  5.045 [1]	|
  5.918 [9978]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  6.791 [1]	|
  7.663 [1]	|
  8.536 [1]	|
  9.409 [1]	|
  10.282 [0]	|
  11.155 [10]	|
  12.028 [0]	|
  12.901 [0]	|
  13.774 [7]	|


Latency distribution:
  10% in 5.0512 secs
  25% in 5.0588 secs
  50% in 5.0923 secs
  75% in 5.1053 secs
  90% in 5.1224 secs
  95% in 5.1465 secs
  99% in 5.3603 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0008 secs, 5.0447 secs, 13.7738 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0020 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0015 secs
  resp wait:	5.1054 secs, 5.0446 secs, 13.7079 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0016 secs

Status code distribution:
  [200]	10000 responses
```

I also uncovered a few small bugs when using the configurations in a brand new project.