### PR TITLE
Export bucket is not used, remove it

### DIFF
--- a/internal/export/database/export.go
+++ b/internal/export/database/export.go
@@ -28,10 +28,6 @@ import (
 	pgx "github.com/jackc/pgx/v4"
 )
 
-const (
-	bucketEnvVar = "EXPORT_BUCKET"
-)
-
 type ExportDB struct {
 	db *database.DB
 }

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -89,11 +89,6 @@ resource "google_cloud_run_service" "export" {
           name  = "EXPORT_FILE_MAX_RECORDS"
           value = "100"
         }
-
-        env {
-          name  = "EXPORT_BUCKET"
-          value = google_storage_bucket.export.name
-        }
       }
 
       container_concurrency = 10


### PR DESCRIPTION
This appears to be a remnant of when the system wasn't as multi-tenant. The bucket is now a per-row configuration in the database.