### PR TITLE
Revert "ci: stop formatting generated files"

### DIFF
--- a/internal/pb/export/export.pb.go
+++ b/internal/pb/export/export.pb.go
@@ -21,11 +21,12 @@
 package export
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/internal/pb/federation.pb.go
+++ b/internal/pb/federation.pb.go
@@ -22,14 +22,15 @@ package pb
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (


### PR DESCRIPTION
Reverts google/exposure-notifications-server#469

@johanbrandhorst - this change caused presubmits to terminate after the protoc step