### PR TITLE
ci: stop formatting generated files

### DIFF
--- a/internal/pb/export/export.pb.go
+++ b/internal/pb/export/export.pb.go
@@ -21,12 +21,11 @@
 package export
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/internal/pb/federation.pb.go
+++ b/internal/pb/federation.pb.go
@@ -22,15 +22,14 @@ package pb
 
 import (
 	context "context"
-	reflect "reflect"
-	sync "sync"
-
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (


### PR DESCRIPTION
Avoid formatting generated files by checking for
the official [1] generated file header before formatting.

Because everyone uses the same docker image to
generate protobuf files, this shouldn't cause much disruption.
Every time the docker image is updated the corresponding
regeneration will have to be made in the repo.

[1]: https://github.com/golang/go/issues/13560#issuecomment-288457920

This version skips the generation of the array altogether, since it was not working in older versions of bash found on Macs.