### PR TITLE
Enable to use scripts/presubmit.sh as a pre-push git hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,16 +57,6 @@ $ go test ./...
 You should run the presubmit checks before committing changes. The presubmit script
 is located at `scripts/presubmit.sh`.
 
-You can add a prepush hook by linking to the presubmit script to automatically
-run before pushing a branch to the remote GitHub repository. To add the
-presubmit script as a prepush hook, go to the root directory of the repository
-and type:
-
-```
-ln -s -f ../../scripts/presubmit.sh .git/hooks/pre-push
-chmod a+x .git/hooks/pre-push
-```
-
 ### Running locally
 
 These instructions use [Docker][docker] to run components locally. You may be

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -16,13 +16,9 @@
 
 set -eEuo pipefail
 
-ROOT_RELATIVE="/.."
-if [ "$0" == ".git/hooks/pre-push" ]; then
-   ROOT_RELATIVE="/../.."
-fi
-
-ROOT="$(cd "$(dirname "$0")${ROOT_RELATIVE}" &>/dev/null; pwd -P)"
+ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
 SOURCE_DIRS="cmd internal tools"
+
 
 echo "🌳 Set up environment variables"
 eval $(${ROOT}/scripts/dev init)

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -16,9 +16,13 @@
 
 set -eEuo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
-SOURCE_DIRS="cmd internal tools"
+ROOT_RELATIVE="/.."
+if [ "$0" == ".git/hooks/pre-push" ]; then
+   ROOT_RELATIVE="/../.."
+fi
 
+ROOT="$(cd "$(dirname "$0")${ROOT_RELATIVE}" &>/dev/null; pwd -P)"
+SOURCE_DIRS="cmd internal tools"
 
 echo "🌳 Set up environment variables"
 eval $(${ROOT}/scripts/dev init)


### PR DESCRIPTION
The CONTRIBUTING.md file suggests the presubmit script can be used as a
pre-push git hook but it fails because the script relies on being stored
in a directory directly below the project root and the git hooks are
stored two levels below it.

The current patch allows to run the checks as a pre-push git hook while
still being able to run it by direct invocation.