### PR TITLE
Revert "ci: stop formatting generated files"

### DIFF
--- a/internal/pb/export/export.pb.go
+++ b/internal/pb/export/export.pb.go
@@ -21,11 +21,12 @@
 package export
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/internal/pb/federation.pb.go
+++ b/internal/pb/federation.pb.go
@@ -22,14 +22,15 @@ package pb
 
 import (
 	context "context"
+	reflect "reflect"
+	sync "sync"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -17,6 +17,8 @@
 set -eEuo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
+SOURCE_DIRS="cmd internal tools"
+
 
 echo "🌳 Set up environment variables"
 eval $(${ROOT}/scripts/dev init)
@@ -24,12 +26,7 @@ eval $(${ROOT}/scripts/dev init)
 
 echo "🚒 Verify Protobufs are up to date"
 ${ROOT}/scripts/dev protoc
-git diff *.go | tee /dev/stderr | (! read)
-if [ $? -ne 0 ]; then
-   echo "✋ Found uncommited changes after regenerating Protobufs."
-   echo "✋ Commit these changes before merging."
-   exit 1
-fi
+# Don't verify generated pb files here as they are tidied later.
 
 
 echo "🧽 Verify goimports formattting"
@@ -41,12 +38,11 @@ if [ $? -ne 0 ]; then
    echo "✋ to enable import cleanup. Import cleanup skipped."
 else
    echo "🧽 Format with goimports"
-   # Find all non-generated Go files. This works by excluding
-   # files that start with the official "generated file" header.
-   # See https://github.com/golang/go/issues/13560#issuecomment-288457920
-   grep -L -HR "^\/\/ Code generated .* DO NOT EDIT\.$" --include="*.go" "${ROOT}" | xargs goimports -w
+   goimports -w $(echo $SOURCE_DIRS)
    # Check if there were uncommited changes.
-   git diff *.go | tee /dev/stderr | (! read)
+   # Ignore comment line changes as sometimes proto gen just updates versions
+   # of the generator
+   git diff -G'(^\s+[^/])' *.go | tee /dev/stderr | (! read)
    if [ $? -ne 0 ]; then
       echo "✋ Found uncommited changes after goimports."
       echo "✋ Commit these changes before merging."
@@ -58,11 +54,8 @@ set -e
 
 echo "🧹 Verify gofmt format"
 set +e
-# Find all non-generated Go files. This works by excluding
-# files that start with the official "generated file" header.
-# See https://github.com/golang/go/issues/13560#issuecomment-288457920
-grep -L -HR "^\/\/ Code generated .* DO NOT EDIT\.$" --include="*.go" "${ROOT}" | xargs gofmt -s -w 
-git diff *.go | tee /dev/stderr | (! read)
+diff -u <(echo -n) <(gofmt -d -s .)
+git diff -G'(^\s+[^/])' *.go | tee /dev/stderr | (! read)
 if [ $? -ne 0 ]; then
    echo "✋ Found uncommited changes after gofmt."
    echo "✋ Commit these changes before merging."


### PR DESCRIPTION
Reverts google/exposure-notifications-server#509

When running locally, this terminates after protoc.

Reverting. @johanbrandhorst 

```
exposure-notifications-server on 🌱 master [$] via 🐹 v1.14.2 took 9s 
✦ ❯ ./scripts/presubmit.sh 
🌳 Set up environment variables
🚒 Verify Protobufs are up to date
Protos regenerated (OK)

exposure-notifications-server on 🌱 master [$] via 🐹 v1.14.2 took 5s 
```