### PR TITLE
Accept, but embargo currently valid keys

### DIFF
--- a/internal/generate/handler.go
+++ b/internal/generate/handler.go
@@ -87,7 +87,7 @@ func (h *generateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			AppPackageName: "generated.data",
 		}
 
-		exposures, err := h.transformer.TransformPublish(&publish, batchTime)
+		exposures, err := h.transformer.TransformPublish(ctx, &publish, batchTime)
 		if err != nil {
 			message := fmt.Sprintf("Error transofmring generated exposures: %v", err)
 			span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: message})

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -43,8 +43,8 @@ type Config struct {
 	TruncateWindow     time.Duration `envconfig:"TRUNCATE_WINDOW" default:"1h"`
 
 	// Flags for local development and testing.
-	DebugAPIResponses   bool `envconfig:"DEBUG_API_RESPONSES"`
-	DebugAllowRestOfDay bool `envconfig:"DEBUG_ALLOW_REST_OF_DAY"`
+	DebugAPIResponses       bool `envconfig:"DEBUG_API_RESPONSES"`
+	DebugReleaseSameDayKeys bool `envconfig:"DEBUG_RELEASE_SAME_DAY_KEYS"`
 }
 
 func (c *Config) AuthorizedAppConfig() *authorizedapp.Config {

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -95,8 +95,7 @@ func TruncateWindow(t time.Time, d time.Duration) time.Time {
 }
 
 // TimeForIntervalNumber returns the time at which a specific interval starts.
-// This is done by turning the internal number into the corresponding unix timestamp,
-// multiplying by 600 seconds (10 minutes).
+// The interval number * 600 (10m = 600s) is the corresponding unix timestamp.
 func TimeForIntervalNumber(interval int32) time.Time {
 	return time.Unix(int64(verifyapi.IntervalLength.Seconds())*int64(interval), 0)
 }
@@ -106,7 +105,7 @@ type Transformer struct {
 	maxExposureKeys     int
 	maxIntervalStartAge time.Duration // How many intervals old does this server accept?
 	truncateWindow      time.Duration
-	debugRelesaeSameDay bool // If true, still valid keys are not embarged.
+	debugReleaseSameDay bool // If true, still valid keys are not embargoed.
 }
 
 // NewTransformer creates a transformer for turning publish API requests into
@@ -120,7 +119,7 @@ func NewTransformer(maxExposureKeys int, maxIntervalStartAge time.Duration, trun
 		maxExposureKeys:     maxExposureKeys,
 		maxIntervalStartAge: maxIntervalStartAge,
 		truncateWindow:      truncateWindow,
-		debugRelesaeSameDay: releaseSameDayKeys,
+		debugReleaseSameDay: releaseSameDayKeys,
 	}, nil
 }
 
@@ -194,7 +193,7 @@ func TransformExposureKey(exposureKey verifyapi.ExposureKey, appPackageName stri
 // * > Transformer.maxExposureKeys in the request
 //
 func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Publish, batchTime time.Time) ([]*Exposure, error) {
-	if t.debugRelesaeSameDay {
+	if t.debugReleaseSameDay {
 		logging.FromContext(ctx).Errorf("DEBUG SERVER - Current day keys are not being embargoed.")
 	}
 
@@ -217,7 +216,7 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		// And the max valid interval is the maxStartInterval + 144
 		MaxEndInteral:         IntervalNumber(batchTime) + verifyapi.MaxIntervalCount,
 		CreatedAt:             defaultCreatedAt,
-		ReleaseStillValidKeys: t.debugRelesaeSameDay,
+		ReleaseStillValidKeys: t.debugReleaseSameDay,
 		BatchWindow:           t.truncateWindow,
 	}
 

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -15,12 +15,14 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/base64util"
+	"github.com/google/exposure-notifications-server/internal/logging"
 
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 )
@@ -92,18 +94,25 @@ func TruncateWindow(t time.Time, d time.Duration) time.Time {
 	return t.Truncate(d)
 }
 
+// TimeForIntervalNumber returns the time at which a specific interval starts.
+// This is done by turning the internal number into the corresponding unix timestamp,
+// multiplying by 600 seconds (10 minutes).
+func TimeForIntervalNumber(interval int32) time.Time {
+	return time.Unix(int64(verifyapi.IntervalLength.Seconds())*int64(interval), 0)
+}
+
 // Transformer represents a configured Publish -> Exposure[] transformer.
 type Transformer struct {
 	maxExposureKeys     int
 	maxIntervalStartAge time.Duration // How many intervals old does this server accept?
 	truncateWindow      time.Duration
-	debugAllowRestOfDay bool // raises end time of keys to the end of day, but doesn't embargo. For e2e testing only.
+	debugRelesaeSameDay bool // If true, still valid keys are not embarged.
 }
 
 // NewTransformer creates a transformer for turning publish API requests into
 // records for insertion into the database. On the call to TransformPublish
 // all data is validated according to the transformer that is used.
-func NewTransformer(maxExposureKeys int, maxIntervalStartAge time.Duration, truncateWindow time.Duration, allowRestOfDay bool) (*Transformer, error) {
+func NewTransformer(maxExposureKeys int, maxIntervalStartAge time.Duration, truncateWindow time.Duration, releaseSameDayKeys bool) (*Transformer, error) {
 	if maxExposureKeys < 0 || maxExposureKeys > verifyapi.MaxKeysPerPublish {
 		return nil, fmt.Errorf("maxExposureKeys must be > 0 and <= %v, got %v", verifyapi.MaxKeysPerPublish, maxExposureKeys)
 	}
@@ -111,8 +120,17 @@ func NewTransformer(maxExposureKeys int, maxIntervalStartAge time.Duration, trun
 		maxExposureKeys:     maxExposureKeys,
 		maxIntervalStartAge: maxIntervalStartAge,
 		truncateWindow:      truncateWindow,
-		debugAllowRestOfDay: allowRestOfDay,
+		debugRelesaeSameDay: releaseSameDayKeys,
 	}, nil
+}
+
+type keyTransform struct {
+	minStartInterval      int32
+	maxStartInterval      int32
+	maxEndInteral         int32
+	createdAt             time.Time
+	releaseStillValidKeys bool
+	batchWindow           time.Duration
 }
 
 // TransformExposureKey converts individual key data to an exposure entity.
@@ -122,7 +140,7 @@ func NewTransformer(maxExposureKeys int, maxIntervalStartAge time.Duration, trun
 // * minInterval <= interval number <= maxInterval
 // * MinIntervalCount <= interval count <= MaxIntervalCount
 //
-func TransformExposureKey(exposureKey verifyapi.ExposureKey, appPackageName string, upcaseRegions []string, createdAt time.Time, minIntervalNumber, maxIntervalNumber int32) (*Exposure, error) {
+func TransformExposureKey(exposureKey verifyapi.ExposureKey, appPackageName string, upcaseRegions []string, settings *keyTransform) (*Exposure, error) {
 	binKey, err := base64util.DecodeString(exposureKey.Key)
 	if err != nil {
 		return nil, err
@@ -137,17 +155,20 @@ func TransformExposureKey(exposureKey verifyapi.ExposureKey, appPackageName stri
 	}
 
 	// Validate the IntervalNumber.
-	if exposureKey.IntervalNumber < minIntervalNumber {
-		return nil, fmt.Errorf("interval number %v is too old, must be >= %v", exposureKey.IntervalNumber, minIntervalNumber)
+	if exposureKey.IntervalNumber < settings.minStartInterval {
+		return nil, fmt.Errorf("interval number %v is too old, must be >= %v", exposureKey.IntervalNumber, settings.minStartInterval)
 	}
-	if exposureKey.IntervalNumber >= maxIntervalNumber {
-		return nil, fmt.Errorf("interval number %v is in the future, must be < %v", exposureKey.IntervalNumber, maxIntervalNumber)
+	if exposureKey.IntervalNumber > settings.maxStartInterval {
+		return nil, fmt.Errorf("interval number %v is in the future, must be <= %v", exposureKey.IntervalNumber, settings.maxStartInterval)
 	}
 
-	// Validate that the key is no longer effective.
-	if exposureKey.IntervalNumber+exposureKey.IntervalCount > maxIntervalNumber {
-		return nil, fmt.Errorf("interval number %v + interval count %v represents a key that is still valid, must end <= %v",
-			exposureKey.IntervalNumber, exposureKey.IntervalCount, maxIntervalNumber)
+	createdAt := settings.createdAt
+	// If the key is valid beyond the current interval number. Adjust the createdAt time for the key.
+	if exposureKey.IntervalNumber+exposureKey.IntervalCount > settings.maxStartInterval {
+		// key is still valid. The created At for this key needs to be adjusted unless debuggin is enabled.
+		if !settings.releaseStillValidKeys {
+			createdAt = TimeForIntervalNumber(exposureKey.IntervalNumber + exposureKey.IntervalCount).Truncate(settings.batchWindow)
+		}
 	}
 
 	if tr := exposureKey.TransmissionRisk; tr < verifyapi.MinTransmissionRisk || tr > verifyapi.MaxTransmissionRisk {
@@ -172,7 +193,11 @@ func TransformExposureKey(exposureKey verifyapi.ExposureKey, appPackageName stri
 // * 0 exposure Keys in the requests
 // * > Transformer.maxExposureKeys in the request
 //
-func (t *Transformer) TransformPublish(inData *verifyapi.Publish, batchTime time.Time) ([]*Exposure, error) {
+func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Publish, batchTime time.Time) ([]*Exposure, error) {
+	if t.debugRelesaeSameDay {
+		logging.FromContext(ctx).Errorf("DEBUG SERVER - Current day keys are not being embargoed.")
+	}
+
 	// Validate the number of keys that want to be published.
 	if len(inData.Keys) == 0 {
 		return nil, fmt.Errorf("no exposure keys in publish request")
@@ -181,18 +206,19 @@ func (t *Transformer) TransformPublish(inData *verifyapi.Publish, batchTime time
 		return nil, fmt.Errorf("too many exposure keys in publish: %v, max of %v is allowed", len(inData.Keys), t.maxExposureKeys)
 	}
 
-	createdAt := TruncateWindow(batchTime, t.truncateWindow)
+	defaultCreatedAt := TruncateWindow(batchTime, t.truncateWindow)
 	entities := make([]*Exposure, 0, len(inData.Keys))
 
-	// An exposure key must have an interval >= minInterval (max configured age)
-	minIntervalNumber := IntervalNumber(batchTime.Add(-1 * t.maxIntervalStartAge))
-	// And have an interval <= maxInterval (configured allowed clock skew)
-	maxIntervalNumber := IntervalNumber(batchTime)
-
-	// If, for testing, we are accepting keys that are valid the rest of the day:
-	// adjust the maxIntervalNumber to be the end of the UTC day.
-	if t.debugAllowRestOfDay {
-		maxIntervalNumber = IntervalNumber(batchTime.Add(24 * time.Hour).Truncate(24 * time.Hour))
+	settings := keyTransform{
+		// An exposure key must have an interval >= minInterval (max configured age)
+		minStartInterval: IntervalNumber(batchTime.Add(-1 * t.maxIntervalStartAge)),
+		// A key must have been issued on the device in the current interval or earlier.
+		maxStartInterval: IntervalNumber(batchTime),
+		// And the max valid interval is the maxStartInterval + 144
+		maxEndInteral:         IntervalNumber(batchTime) + verifyapi.MaxIntervalCount,
+		createdAt:             defaultCreatedAt,
+		releaseStillValidKeys: t.debugRelesaeSameDay,
+		batchWindow:           t.truncateWindow,
 	}
 
 	// Regions are a multi-value property, uppercase them for storage.
@@ -205,7 +231,7 @@ func (t *Transformer) TransformPublish(inData *verifyapi.Publish, batchTime time
 	}
 
 	for _, exposureKey := range inData.Keys {
-		exposure, err := TransformExposureKey(exposureKey, inData.AppPackageName, upcaseRegions, createdAt, minIntervalNumber, maxIntervalNumber)
+		exposure, err := TransformExposureKey(exposureKey, inData.AppPackageName, upcaseRegions, &settings)
 		if err != nil {
 			return nil, fmt.Errorf("invalid publish data: %v", err)
 		}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -160,7 +160,7 @@ func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) r
 	}
 
 	batchTime := time.Now()
-	exposures, err := h.transformer.TransformPublish(&data, batchTime)
+	exposures, err := h.transformer.TransformPublish(ctx, &data, batchTime)
 	if err != nil {
 		message := fmt.Sprintf("unable to read request data: %v", err)
 		logger.Error(message)

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -46,7 +46,7 @@ func NewHandler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (
 		return nil, fmt.Errorf("missing AuthorizedApp provider in server environment")
 	}
 
-	transformer, err := model.NewTransformer(config.MaxKeysOnPublish, config.MaxIntervalAge, config.TruncateWindow, config.DebugAllowRestOfDay)
+	transformer, err := model.NewTransformer(config.MaxKeysOnPublish, config.MaxIntervalAge, config.TruncateWindow, config.DebugReleaseSameDayKeys)
 	if err != nil {
 		return nil, fmt.Errorf("model.NewTransformer: %w", err)
 	}

--- a/tools/export-generate/main.go
+++ b/tools/export-generate/main.go
@@ -106,7 +106,13 @@ func main() {
 			log.Fatalf("unable to parse json: %v", err)
 		}
 		for _, k := range data.Keys {
-			ek, err := publishmodel.TransformExposureKey(k, "", []string{}, time.Now(), int32(0), int32(time.Now().Unix()/600))
+			settings := publishmodel.KeyTransform{
+				MinStartInterval:      0,
+				MaxStartInterval:      int32(time.Now().Unix() / 600),
+				CreatedAt:             time.Now(),
+				ReleaseStillValidKeys: false,
+			}
+			ek, err := publishmodel.TransformExposureKey(k, "", []string{}, &settings)
 			if err != nil {
 				log.Fatalf("invalid exposure key: %v", err)
 			}


### PR DESCRIPTION
Instead of rejecting keys that have started before the instant now, but aren't yet expired, accept those keys and emabargo them until they can no longer be used.
This is done by setting the createdAt time on that key.

There is an invariant here that there can only be one key in this state since we don't allow overlapping intervals and we don't allow keys to start in the future.

/fixes #543