### PR TITLE
fix(signing): add configuration option for azure key vault

### DIFF
--- a/internal/signing/config.go
+++ b/internal/signing/config.go
@@ -19,6 +19,7 @@ type KeyManagerType string
 
 const (
 	KeyManagerTypeAWSKMS         KeyManagerType = "AWS_KMS"
+	KeyManagerTypeAzureKeyVault  KeyManagerType = "AZURE_KEY_VAULT"
 	KeyManagerTypeGoogleCloudKMS KeyManagerType = "GOOGLE_CLOUD_KMS"
 	KeyManagerTypeHashiCorpVault KeyManagerType = "HASHICORP_VAULT"
 	KeyManagerTypeNoop           KeyManagerType = "NOOP"

--- a/internal/signing/signing.go
+++ b/internal/signing/signing.go
@@ -33,6 +33,8 @@ func KeyManagerFor(ctx context.Context, typ KeyManagerType) (KeyManager, error) 
 	switch typ {
 	case KeyManagerTypeAWSKMS:
 		return NewAWSKMS(ctx)
+	case KeyManagerTypeAzureKeyVault:
+		return NewAzureKeyVault(ctx)
 	case KeyManagerTypeGoogleCloudKMS:
 		return NewGoogleCloudKMS(ctx)
 	case KeyManagerTypeHashiCorpVault:


### PR DESCRIPTION
The code to support signing with Azure Key Vault was added in #527, but it was not added as a startup configuration option, this simply fixes that.