### PR TITLE
Move test steps into make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VETTERS = "asmdecl,assign,atomic,bools,buildtag,cgocall,composites,copylocks,errorsas,httpresponse,loopclosure,lostcancel,nilfunc,printf,shift,stdmethods,structtag,tests,unmarshal,unreachable,unsafeptr,unusedresult"
+GOFMT_FILES = $(shell go list -f '{{.Dir}}' ./... | grep -v '/pb')
+
+fmtcheck:
+	@command -v goimports &>/dev/null || go get golang.org/x/tools/cmd/goimports
+	@CHANGES="$$(goimports -d $(GOFMT_FILES))"; \
+		if [[ -n "$${CHANGES}" ]]; then \
+			echo "Unformatted (run goimports -w .):\n\n$${CHANGES}\n\n"; \
+			exit 1; \
+		fi
+	@# Annoyingly, goimports does not support the simplify flag.
+	@CHANGES="$$(gofmt -s -d $(GOFMT_FILES))"; \
+		if [[ -n "$${CHANGES}" ]]; then \
+			echo "Unformatted (run gofmt -s -w .):\n\n$${CHANGES}\n\n"; \
+			exit 1; \
+		fi
+.PHONY: fmtcheck
+
+spellcheck:
+	@command -v misspell &>/dev/null || go get github.com/client9/misspell/cmd/misspell
+	@misspell -locale="US" -error -source="text" **/*
+.PHONY: spellcheck
+
+staticcheck:
+	@command -v staticcheck &>/dev/null || go get honnef.co/go/tools/cmd/staticcheck
+	@staticcheck -checks="all" -tests $(GOFMT_FILES)
+.PHONY: staticcheck
+
+test:
+	@go test \
+		-count=1 \
+		-short \
+		-timeout=5m \
+		-vet="${VETTERS}" \
+		./...
+.PHONY: test
+
+test-acc:
+	@go test \
+		-count=1 \
+		-race \
+		-timeout=10m \
+		-vet="${VETTERS}" \
+		./...
+.PHONY: test-acc

--- a/internal/admin/authorizedapps/form.go
+++ b/internal/admin/authorizedapps/form.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package authorizedapps is part of the admin system.
 package authorizedapps
 
 import (

--- a/internal/admin/authorizedapps/view.go
+++ b/internal/admin/authorizedapps/view.go
@@ -41,7 +41,7 @@ func addHealthAuthorityInfo(ctx context.Context, haDB *verdb.HealthAuthorityDB, 
 	// Load the health authorities.
 	healthAuthorities, err := haDB.ListAllHealthAuthoritiesWithoutKeys(ctx)
 	if err != nil {
-		return fmt.Errorf("Error loading health authorities: %w", err)
+		return fmt.Errorf("error loading health authorities: %w", err)
 	}
 
 	usedAuthorities := make(map[int64]bool)

--- a/internal/admin/config.go
+++ b/internal/admin/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This tool provides a small admin UI. Requires connection to the database
+// Package admin provides a small admin UI. Requires connection to the database
 // and permissions to access whatever else you might need to access.
 package admin
 

--- a/internal/admin/exports/form.go
+++ b/internal/admin/exports/form.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package exports is part of the admin system.
 package exports
 
 import (

--- a/internal/admin/healthauthority/form.go
+++ b/internal/admin/healthauthority/form.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package healthauthority is part of the admin system.
 package healthauthority
 
 import (

--- a/internal/admin/healthauthority/keys.go
+++ b/internal/admin/healthauthority/keys.go
@@ -43,13 +43,12 @@ func (h *keyController) Execute(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	haDB := database.New(h.env.Database())
-	healthAuthority := &model.HealthAuthority{}
 	haID, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
 		admin.ErrorPage(c, "Unable to parse `id` param")
 		return
 	}
-	healthAuthority, err = haDB.GetHealthAuthorityByID(ctx, haID)
+	healthAuthority, err := haDB.GetHealthAuthorityByID(ctx, haID)
 	if err != nil {
 		admin.ErrorPage(c, fmt.Sprintf("error processing health authority: %v", err))
 		return

--- a/internal/admin/siginfo/form.go
+++ b/internal/admin/siginfo/form.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package siginfo is part of the admin system.
 package siginfo
 
 import (

--- a/internal/authorizedapp/config.go
+++ b/internal/authorizedapp/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package authorizedapp handles allowed applications.
 package authorizedapp
 
 import (

--- a/internal/authorizedapp/database/authorized_app.go
+++ b/internal/authorizedapp/database/authorized_app.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package database is a database interface to authorized apps.
 package database
 
 import (

--- a/internal/authorizedapp/model/authorized_app_model.go
+++ b/internal/authorizedapp/model/authorized_app_model.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package model is a model abstraction of authorized apps.
 package model
 
 import (

--- a/internal/export/batcher.go
+++ b/internal/export/batcher.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package export defines the handlers for managing exposure key exporting.
 package export
 
 import (

--- a/internal/export/config.go
+++ b/internal/export/config.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package export defines the handlers for managing exposure key exporting.
 package export
 
 import (

--- a/internal/export/database/export.go
+++ b/internal/export/database/export.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package database is a database interface to export.
 package database
 
 import (

--- a/internal/export/exportfile.go
+++ b/internal/export/exportfile.go
@@ -89,7 +89,7 @@ func MarshalExportFile(eb *model.ExportBatch, exposures []*publishmodel.Exposure
 	return buf.Bytes(), nil
 }
 
-// Unmarshal extracts the protobuf encoded exposure key present in the zip archived payload.
+// UnmarshalExportFile extracts the protobuf encoded exposure key present in the zip archived payload.
 func UnmarshalExportFile(zippedProtoPayload []byte) (*export.TemporaryExposureKeyExport, error) {
 	zp, err := zip.NewReader(bytes.NewReader(zippedProtoPayload), int64(len(zippedProtoPayload)))
 	if err != nil {

--- a/internal/export/model/export_model.go
+++ b/internal/export/model/export_model.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package model is a model abstraction of exports.
 package model
 
 import (

--- a/internal/federationin/database/federationin.go
+++ b/internal/federationin/database/federationin.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package database is a database interface to federation in.
 package database
 
 import (
@@ -60,8 +61,8 @@ func getFederationInQuery(ctx context.Context, queryID string, queryRow queryRow
 		SELECT
 			query_id, server_addr, oidc_audience, include_regions, exclude_regions, last_timestamp
 		FROM
-			FederationInQuery 
-		WHERE 
+			FederationInQuery
+		WHERE
 			query_id=$1
 		`, queryID)
 

--- a/internal/federationin/model/federation_model.go
+++ b/internal/federationin/model/federation_model.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package model is a model abstraction of federation in.
 package model
 
 import (

--- a/internal/federationout/database/federationout.go
+++ b/internal/federationout/database/federationout.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package database is a database interface to federation out.
 package database
 
 import (

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package flag includes custom flag parsing logic.
 package flag
 
 import (

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package logging sets up and configures logging.
 package logging
 
 import (

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package observability sets up and configures observability tools.
 package observability
 
 import (

--- a/internal/pb/export/export.pb.go
+++ b/internal/pb/export/export.pb.go
@@ -21,12 +21,11 @@
 package export
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	proto "github.com/golang/protobuf/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/internal/pb/federation.pb.go
+++ b/internal/pb/federation.pb.go
@@ -22,15 +22,14 @@ package pb
 
 import (
 	context "context"
-	reflect "reflect"
-	sync "sync"
-
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (

--- a/internal/publish/database/exposure.go
+++ b/internal/publish/database/exposure.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package database is a database interface to publish.
 package database
 
 import (

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package model is a model abstraction of publish.
 package model
 
 import (

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package retry provides generic function-based retry helpers.
 package retry
 
 import (

--- a/internal/secrets/aws_secrets_manager.go
+++ b/internal/secrets/aws_secrets_manager.go
@@ -59,12 +59,12 @@ func NewAWSSecretsManager(ctx context.Context) (SecretManager, error) {
 // Secrets are expected to be string plaintext values (not JSON, YAML,
 // key-value, etc).
 func (sm *AWSSecretsManager) GetSecretValue(ctx context.Context, name string) (string, error) {
-	var secretId, versionId, versionStage string
+	var secretID, versionID, versionStage string
 
-	current := &secretId
+	current := &secretID
 	for _, ch := range name {
 		if ch == '@' {
-			current = &versionId
+			current = &versionID
 			continue
 		}
 
@@ -77,11 +77,11 @@ func (sm *AWSSecretsManager) GetSecretValue(ctx context.Context, name string) (s
 	}
 
 	req := &secretsmanager.GetSecretValueInput{
-		SecretId: aws.String(secretId),
+		SecretId: aws.String(secretID),
 	}
 
-	if versionId != "" {
-		req.VersionId = aws.String(versionId)
+	if versionID != "" {
+		req.VersionId = aws.String(versionID)
 	}
 
 	if versionStage != "" {

--- a/internal/secrets/cacher.go
+++ b/internal/secrets/cacher.go
@@ -32,11 +32,6 @@ type Cacher struct {
 	cache *cache.Cache
 }
 
-type cachedItem struct {
-	value    string
-	cachedAt time.Time
-}
-
 // NewCacher creates a new secret manager that caches results for the given ttl.
 func NewCacher(ctx context.Context, f SecretManagerFunc, ttl time.Duration) (SecretManager, error) {
 	sm, err := f(ctx)

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package setup provides common logic for configuring the various services.
 package setup
 
 import (

--- a/internal/util/generate.go
+++ b/internal/util/generate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This package is a CLI tool for generating test exposure key data.
+// Package util is a CLI tool for generating test exposure key data.
 package util
 
 import (
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/google/exposure-notifications-server/internal/base64util"
 	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 	"github.com/google/exposure-notifications-server/testing/enclient"
 )
@@ -32,6 +33,7 @@ const (
 	maxIntervalCount = 144
 )
 
+// RandomIntervalCount produces a random interval.
 func RandomIntervalCount() (int32, error) {
 	n, err := rand.Int(rand.Reader, big.NewInt(maxIntervalCount))
 	if err != nil {
@@ -40,6 +42,7 @@ func RandomIntervalCount() (int32, error) {
 	return int32(n.Int64() + 1), nil // valid values start at 1
 }
 
+// RandomInt produces a random integer up to but not including maxValue.
 func RandomInt(maxValue int) (int, error) {
 	n, err := rand.Int(rand.Reader, big.NewInt(int64(maxValue)))
 	if err != nil {
@@ -57,11 +60,13 @@ func RandomIntWithMin(min, max int) (int, error) {
 	return int(n.Int64()) + min, nil
 }
 
+// RandomTransmissionRisk produces a random transmission risk score.
 func RandomTransmissionRisk() (int, error) {
 	n, err := RandomInt(v1alpha1.MaxTransmissionRisk)
 	return n + 1, err
 }
 
+// RandomArrValue chooses a random element from the array.
 func RandomArrValue(arr []string) (string, error) {
 	n, err := RandomInt(len(arr))
 	if err != nil {
@@ -70,6 +75,7 @@ func RandomArrValue(arr []string) (string, error) {
 	return arr[n], nil
 }
 
+// GenerateExposureKeys creates the given number of exposure keys.
 func GenerateExposureKeys(numKeys, tr int, randomInterval bool) []v1alpha1.ExposureKey {
 	// When publishing multiple keys - they'll be on different days.
 	var err error
@@ -109,7 +115,7 @@ func GenerateExposureKeys(numKeys, tr int, randomInterval bool) []v1alpha1.Expos
 	return exposureKeys
 }
 
-// Creates a random exposure key.
+// RandomExposureKey creates a random exposure key.
 func RandomExposureKey(intervalNumber enclient.Interval, intervalCount int32, transmissionRisk int) (v1alpha1.ExposureKey, error) {
 	key, err := GenerateKey()
 	if err != nil {
@@ -123,7 +129,7 @@ func RandomExposureKey(intervalNumber enclient.Interval, intervalCount int32, tr
 	}, nil
 }
 
-// Generates the random byte sequence.
+// RandomBytes generates a random byte sequence.
 func RandomBytes(arrLen int) ([]byte, error) {
 	padding := make([]byte, arrLen)
 	_, err := rand.Read(padding)
@@ -133,6 +139,7 @@ func RandomBytes(arrLen int) ([]byte, error) {
 	return padding, nil
 }
 
+// GenerateKey generates a key.
 func GenerateKey() (string, error) {
 	b, err := RandomBytes(dkLen)
 	if err != nil {
@@ -141,14 +148,14 @@ func GenerateKey() (string, error) {
 	return ToBase64(b), nil
 }
 
-// Encodes bytes array to base64.
+// ToBase64 encodes bytes array to base64.
 func ToBase64(key []byte) string {
 	return base64.StdEncoding.EncodeToString(key)
 }
 
-// Decodes base64 string to []byte.
+// DecodeKey decodes base64 string to []byte.
 func DecodeKey(b64key string) []byte {
-	k, err := base64.StdEncoding.DecodeString(b64key)
+	k, err := base64util.DecodeString(b64key)
 	if err != nil {
 		log.Fatalf("unable to decode key: %v", err)
 	}

--- a/internal/verification/database/health_authority_db.go
+++ b/internal/verification/database/health_authority_db.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package database is a database interface to health authorities.
 package database
 
 import (

--- a/internal/verification/model/health_authority.go
+++ b/internal/verification/model/health_authority.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package model is a model abstraction of health authorities.
 package model
 
 import (

--- a/pkg/api/v1alpha1/verification_types.go
+++ b/pkg/api/v1alpha1/verification_types.go
@@ -48,7 +48,7 @@ func (a TransmissionRiskVector) Len() int {
 	return len(a)
 }
 
-// This sorts the TransmissionRiskVector vector with the largest SinceRollingPeriod
+// Less sorts the TransmissionRiskVector vector with the largest SinceRollingPeriod
 // value first. Descending sort.
 func (a TransmissionRiskVector) Less(i, j int) bool {
 	return a[i].SinceRollingPeriod > a[j].SinceRollingPeriod

--- a/pkg/verification/utils.go
+++ b/pkg/verification/utils.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package verification provides verification utilities.
 package verification
 
 import (

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -30,8 +30,7 @@ ${ROOT}/scripts/dev protoc
 
 echo "🧹 Verify formatting"
 make fmtcheck || {
-  echo "✋ Found uncommited changes after goimports."
-  echo "✋ Commit these changes before merging."
+  echo "✋ Found formatting errors."
   exit 1
 }
 

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -26,87 +26,57 @@ eval $(${ROOT}/scripts/dev init)
 
 echo "🚒 Verify Protobufs are up to date"
 ${ROOT}/scripts/dev protoc
-# Don't verify generated pb files here as they are tidied later.
 
 
-echo "🧽 Verify goimports formattting"
-set +e
-which goimports >/dev/null 2>&1
+echo "🧹 Verify formatting"
+make fmtcheck || {
+  echo "✋ Found uncommited changes after goimports."
+  echo "✋ Commit these changes before merging."
+  exit 1
+}
+
+
+echo "🐝 Lint"
+make staticcheck || {
+  echo "✋ Found linter errors."
+  exit 1
+}
+
+
+echo "🐝 Verify spelling"
+make spellcheck || {
+  echo "✋ Found spelling errors."
+  exit 1
+}
+
+
+echo "📚 Fetch dependencies"
+OUT="$(go get -t ./...)"
 if [ $? -ne 0 ]; then
-   echo "✋ No 'goimports' found. Please use"
-   echo "✋   go get golang.org/x/tools/cmd/goimports"
-   echo "✋ to enable import cleanup. Import cleanup skipped."
-else
-   echo "🧽 Format with goimports"
-   goimports -w $(echo $SOURCE_DIRS)
-   # Check if there were uncommited changes.
-   # Ignore comment line changes as sometimes proto gen just updates versions
-   # of the generator
-   git diff -G'(^\s+[^/])' *.go | tee /dev/stderr | (! read)
-   if [ $? -ne 0 ]; then
-      echo "✋ Found uncommited changes after goimports."
-      echo "✋ Commit these changes before merging."
-      exit 1
-   fi
-fi
-set -e
-
-
-echo "🧹 Verify gofmt format"
-set +e
-diff -u <(echo -n) <(gofmt -d -s .)
-git diff -G'(^\s+[^/])' *.go | tee /dev/stderr | (! read)
-if [ $? -ne 0 ]; then
-   echo "✋ Found uncommited changes after gofmt."
-   echo "✋ Commit these changes before merging."
-   exit 1
-fi
-set -e
-
-
-echo "🌌 Go mod verify"
-set +e
-go mod verify
-if [ $? -ne 0 ]; then
-   echo "✋ go mod verify failed."
-   exit 1
-fi
-set -e
-
-# Fail if a dependency was added without the necessary go.mod/go.sum change
-# being part of the commit.
-echo "🌌 Go mod tidy"
-set +e
-OUT="$(go mod tidy 2>&1)"
-if [ $? -ne 0 ]; then
-   echo "✋ Error running go mod tidy, output below"
-   echo ${OUT}
-   echo
-   exit 1
+  echo "✋ Error fetching dependencies"
+  echo "\n\n${OUT}\n\n"
+  exit 1
 fi
 
-git diff go.mod | tee /dev/stderr | (! read)
-if [ $? -ne 0 ]; then
-   echo "✋ Found uncommited go.mod changes after go mod tidy."
-   exit 1
-fi
 
-git diff go.sum | tee /dev/stderr | (! read)
+echo "🌌 Verify and tidy module"
+OUT="$(go mod verify && go mod tidy)"
 if [ $? -ne 0 ]; then
-   echo "✋ Found uncommited go.sum changes after go mod tidy."
-   exit 1
+  echo "✋ Error validating module"
+  echo "\n\n${OUT}\n\n"
+  exit 1
 fi
-set -e
+OUT="$(git diff go.mod)"
+if [ -n "${OUT}" ]; then
+  echo "✋ go.mod is out of sync - run 'go mod tidy'."
+  exit 1
+fi
+OUT="$(git diff go.sum)"
+if [ -n "${OUT}" ]; then
+  echo "✋ go.sum is out of sync - run 'go mod tidy'."
+  exit 1
+fi
 
 
 echo "🧪 Test"
-go test ./... \
-  -coverprofile=coverage.out \
-  -count=1 \
-  -parallel=20 \
-  -timeout=5m \
-  -vet="asmdecl,assign,atomic,bools,buildtag,cgocall,composites,copylocks,errorsas,httpresponse,loopclosure,lostcancel,nilfunc,printf,shift,stdmethods,structtag,tests,unmarshal,unreachable,unsafeptr,unusedresult"
-
-
-echo "🧑‍🔬 Test Coverage"
-go tool cover -func coverage.out | grep total | awk '{print $NF}'
+make test-acc

--- a/testing/enclient/enclient.go
+++ b/testing/enclient/enclient.go
@@ -1,3 +1,19 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package enclient is a client for making requests against the exposure
+// notification server.
 package enclient
 
 import (
@@ -19,8 +35,8 @@ const (
 
 type Interval int32
 
-// Posts requests to the specified url.
-// This methods attempts to serialize data argument as a json.
+// PostRequest requests to the specified url. This methods attempts to serialize
+// data argument as a json.
 func PostRequest(url string, data interface{}) (*http.Response, error) {
 	request := bytes.NewBuffer(JSONRequest(data))
 	r, err := http.NewRequest("POST", url, request)
@@ -47,7 +63,7 @@ func PostRequest(url string, data interface{}) (*http.Response, error) {
 	return resp, nil
 }
 
-// Serializes the given argument to json.
+// JSONRequest serializes the given argument to json.
 func JSONRequest(data interface{}) []byte {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
@@ -56,17 +72,17 @@ func JSONRequest(data interface{}) []byte {
 	return jsonData
 }
 
-// Returns the Interval for the current moment of tme.
+// NowInterval returns the Interval for the current moment of tme.
 func NowInterval() Interval {
 	return NewInterval(time.Now().Unix())
 }
 
-// Creates a new interval for the UNIX epoch given.
+// NewInterval creates a new interval for the UNIX epoch given.
 func NewInterval(time int64) Interval {
 	return Interval(int32(time / 600))
 }
 
-// Creates an exposure key.
+// ExposureKey creates an exposure key.
 func ExposureKey(key string, intervalNumber Interval, intervalCount int32, transmissionRisk int) verifyapi.ExposureKey {
 	return verifyapi.ExposureKey{
 		Key:              key,

--- a/tools/export-generate/main.go
+++ b/tools/export-generate/main.go
@@ -196,7 +196,8 @@ func getSigningKey(fileName string) (*ecdsa.PrivateKey, error) {
 	return ParseECPrivateKeyFromPEM(keyBytes)
 }
 
-// Parse PEM encoded Elliptic Curve Private Key Structure.
+// ParseECPrivateKeyFromPEM parses PEM encoded Elliptic Curve Private Key
+// structure.
 func ParseECPrivateKeyFromPEM(key []byte) (*ecdsa.PrivateKey, error) {
 	ErrNotECPrivateKey := errors.New("key is not a valid ECDSA private key")
 	ErrKeyMustBePEMEncoded := errors.New("invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key")


### PR DESCRIPTION
This makes the presubmit script a bit "dumber" and moves some of the logic into a shared Makefile, giving more flexibility for running locally. It also creates two targets for testing: `test` and `test-acc`. The first target runs the short tests. The second target runs all the integration tests and the race detector. CI uses the `test-acc`.