### PR TITLE
Add keyvault specific authorizer for Azure signing client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,8 @@ require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.1
 	github.com/Azure/azure-sdk-for-go v42.3.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.8.0
-	github.com/Azure/go-autorest/autorest v0.10.2 // indirect
-	github.com/Azure/go-autorest/autorest/adal v0.8.3 // indirect
-	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
+	github.com/Azure/go-autorest/autorest v0.10.2
+	github.com/Azure/go-autorest/autorest/adal v0.8.3
 	github.com/DataDog/datadog-go v3.7.1+incompatible // indirect
 	github.com/Jeffail/gabs/v2 v2.5.0 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect

--- a/internal/azurekeyvault/authorizer.go
+++ b/internal/azurekeyvault/authorizer.go
@@ -1,0 +1,81 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package azurekeyvault provides shared functionality between the
+// signing and secret clients for KeyVault
+package azurekeyvault
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Authorizer provides a mutex for working with the Key Vault auhtorizer
+type Authorizer struct {
+	lock sync.Mutex
+	auth autorest.Authorizer
+}
+
+var keyvaultAuthorizer *Authorizer
+
+// GetKeyVaultAuthorizer prepares a specifc authorizer for keyvault use
+func GetKeyVaultAuthorizer() (autorest.Authorizer, error) {
+	keyvaultAuthorizer.lock.Lock()
+	defer keyvaultAuthorizer.lock.Unlock()
+
+	if keyvaultAuthorizer.auth != nil {
+		return keyvaultAuthorizer.auth, nil
+	}
+
+	var a autorest.Authorizer
+	azureEnv, _ := azure.EnvironmentFromName("AzurePublicCloud")
+	vaultEndpoint := strings.TrimSuffix(azureEnv.KeyVaultEndpoint, "/")
+	tenant := os.Getenv("AZURE_TENANT_ID")
+	clientID := os.Getenv("AZURE_CLIENT_ID")
+	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+
+	alternateEndpoint, err := url.Parse(
+		"https://login.windows.net/" + tenant + "/oauth2/token",
+	)
+	if err != nil {
+		return a, fmt.Errorf("failed parsing Azure Key Vault endpoint: %v", err)
+	}
+
+	oauthconfig, err := adal.NewOAuthConfig(azureEnv.ActiveDirectoryEndpoint, tenant)
+	if err != nil {
+		return a, fmt.Errorf("failed creating OAuth config for Azure Key Vault: %v", err)
+	}
+	oauthconfig.AuthorizeEndpoint = *alternateEndpoint
+
+	token, err := adal.NewServicePrincipalToken(
+		*oauthconfig,
+		clientID,
+		clientSecret,
+		vaultEndpoint,
+	)
+	if err != nil {
+		return a, fmt.Errorf("failed requesting access token for Azure Key Vault: %v", err)
+	}
+
+	keyvaultAuthorizer.auth = autorest.NewBearerAuthorizer(token)
+
+	return keyvaultAuthorizer.auth, err
+}

--- a/internal/secrets/azure_keyvault.go
+++ b/internal/secrets/azure_keyvault.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/keyvault/keyvault"
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
+	"github.com/google/exposure-notifications-server/internal/azurekeyvault"
 )
 
 // Compile-time check to verify implements interface.
@@ -33,7 +33,7 @@ type AzureKeyVault struct {
 
 // NewAzureKeyVault creates a new KeyVault that can interact fetch secrets.
 func NewAzureKeyVault(ctx context.Context) (SecretManager, error) {
-	authorizer, err := auth.NewAuthorizerFromEnvironment()
+	authorizer, err := azurekeyvault.GetKeyVaultAuthorizer()
 	if err != nil {
 		return nil, fmt.Errorf("secrets.NewAzureKeyVault: auth: %w", err)
 	}

--- a/internal/signing/azure_keyvault.go
+++ b/internal/signing/azure_keyvault.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/google/exposure-notifications-server/internal/azurekeyvault"
 	"github.com/google/exposure-notifications-server/internal/base64util"
 )
 
@@ -43,7 +43,7 @@ type AzureKeyVault struct {
 
 // NewAzureKeyVault creates a new KeyVault key manager instance.
 func NewAzureKeyVault(ctx context.Context) (KeyManager, error) {
-	authorizer, err := auth.NewAuthorizerFromEnvironment()
+	authorizer, err := azurekeyvault.GetKeyVaultAuthorizer()
 	if err != nil {
 		return nil, fmt.Errorf("secrets.NewAzureKeyVault: auth: %w", err)
 	}


### PR DESCRIPTION
During some investigation with @ultimateboy we stumbled on a bug in the Azure Keyvault client where the generic Azure authorizer is being used rather than a Keyvault specific one. This change allows the client to work as intended.

Happy to adjust the way the env vars are handled!