### PR TITLE
Use JWT 'kid' header to identify public key

### DIFF
--- a/docs/design/verification_protocol.md
+++ b/docs/design/verification_protocol.md
@@ -8,7 +8,7 @@ diagnosis certifications from public health authorities.
 
 The actual process of issuing these certificates is not covered in this
 document, but will be at a later date. A simple example of certificate signing
-is available in [tools/example-verification-signing](https://github.com/google/exposure-notifications-server/tree/master/tools/example-verification-signing) 
+is available in [tools/example-verification-signing](https://github.com/google/exposure-notifications-server/tree/master/tools/example-verification-signing)
 
 ## Motivation
 
@@ -79,7 +79,9 @@ save the `phadata`
 * `trisk` : Contains an array of transmission risk overrides to enact when
 importing the associated keys. If data is present in this field, it will
 override the data in the upload from the device.
-* `keyVersion` : The version of the public key to use for verification.
+
+The verification server can indicate a specific key ID to use by setting the
+`kid` header attribute in the JWT.
 
 ### Transmission Risk Overrides
 

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -113,10 +113,10 @@ func issueJWT(t *testing.T, cfg jwtConfig) (jwtText, hmacKey string) {
 	claims.IssuedAt = time.Now().Add(cfg.JWTWarp).Unix()
 	claims.ExpiresAt = time.Now().Add(cfg.JWTWarp).Add(5 * time.Minute).Unix()
 	claims.SignedMAC = hmac
-	claims.KeyVersion = cfg.HealthAuthorityKey.Version
 	claims.TransmissionRisks = cfg.Overrides
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header[verifyapi.KeyIDHeader] = cfg.HealthAuthorityKey.Version
 	jwtText, err = token.SignedString(cfg.Key)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -166,10 +166,10 @@ func TestVerifyCertificate(t *testing.T) {
 			claims.IssuedAt = time.Now().Add(tc.Warp).Unix()
 			claims.ExpiresAt = time.Now().Add(tc.Warp).Add(5 * time.Minute).Unix()
 			claims.SignedMAC = tc.MacAdjustment + base64.StdEncoding.EncodeToString(hmac) // would be generated on the client and passed through.
-			claims.KeyVersion = "v1"                                                      // matches the key configured above.
 			// leaves PHAClaims and transmission risk overrides out of it.
 
 			token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+			token.Header["kid"] = "v1" // matches the key configured above.
 			jwtText, err := token.SignedString(privateKey)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/api/v1alpha1/verification_types.go
+++ b/pkg/api/v1alpha1/verification_types.go
@@ -27,7 +27,7 @@ const (
 	ExposureKeyHMACClaim          = "tekmac"
 	HealthAuthorityDataClaim      = "phadata"
 	TransmissionRiskOverrideClaim = "trisk"
-	KeyVersionClaim               = "keyVersion"
+	KeyIDHeader                   = "kid"
 )
 
 // TransmissionRiskVector is an additional set of claims that can be
@@ -62,7 +62,6 @@ type VerificationClaims struct {
 	PHAClaims         map[string]string      `json:"phadata"`
 	TransmissionRisks TransmissionRiskVector `json:"trisk"`
 	SignedMAC         string                 `json:"tekmac"`
-	KeyVersion        string                 `json:"keyVersion"`
 	jwt.StandardClaims
 }
 

--- a/tools/example-verification-signing/main.go
+++ b/tools/example-verification-signing/main.go
@@ -108,7 +108,6 @@ func main() {
 		claims.PHAClaims["testkit"] = "55-HH-A7"
 		// optionally add transmission risks
 		claims.SignedMAC = request.HMAC
-		claims.KeyVersion = cfg.KeyVersion
 		// Add in the standard claims.
 		claims.StandardClaims.Audience = cfg.Audience
 		claims.StandardClaims.Issuer = cfg.Issuer
@@ -117,6 +116,9 @@ func main() {
 		claims.StandardClaims.NotBefore = now.Add(-1 * time.Second).Unix()
 
 		token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+		// The key version goes in the JWT header, not the claims.
+		token.Header[v1alpha1.KeyIDHeader] = cfg.KeyVersion
+
 		signingString, err := token.SigningString()
 		if err != nil {
 			response.Error = err.Error()


### PR DESCRIPTION
* Update design doc
* Update public API for custom claims set
* Update verificaiton + tests
* Update example certificate issuer

/fixes #593