### PR TITLE
feat(observability): use envconfig to manage configuration for the observability exporter

### DIFF
--- a/internal/cleanup/config.go
+++ b/internal/cleanup/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/observability"
 	"github.com/google/exposure-notifications-server/internal/secrets"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/internal/storage"
@@ -27,13 +28,15 @@ import (
 var _ setup.BlobstoreConfigProvider = (*Config)(nil)
 var _ setup.DatabaseConfigProvider = (*Config)(nil)
 var _ setup.SecretManagerConfigProvider = (*Config)(nil)
+var _ setup.ObservabilityExporterConfigProvider = (*Config)(nil)
 
 // Config represents the configuration and associated environment variables for
 // the cleanup components.
 type Config struct {
-	Database      database.Config
-	SecretManager secrets.Config
-	Storage       storage.Config
+	Database              database.Config
+	SecretManager         secrets.Config
+	Storage               storage.Config
+	ObservabilityExporter observability.Config
 
 	Port    string        `env:"PORT, default=8080"`
 	Timeout time.Duration `env:"CLEANUP_TIMEOUT, default=10m"`
@@ -50,4 +53,8 @@ func (c *Config) DatabaseConfig() *database.Config {
 
 func (c *Config) SecretManagerConfig() *secrets.Config {
 	return &c.SecretManager
+}
+
+func (c *Config) ObservabilityExporterConfig() *observability.Config {
+	return &c.ObservabilityExporter
 }

--- a/internal/export/config.go
+++ b/internal/export/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/observability"
 	"github.com/google/exposure-notifications-server/internal/secrets"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/internal/signing"
@@ -30,14 +31,16 @@ var _ setup.BlobstoreConfigProvider = (*Config)(nil)
 var _ setup.DatabaseConfigProvider = (*Config)(nil)
 var _ setup.KeyManagerConfigProvider = (*Config)(nil)
 var _ setup.SecretManagerConfigProvider = (*Config)(nil)
+var _ setup.ObservabilityExporterConfigProvider = (*Config)(nil)
 
 // Config represents the configuration and associated environment variables for
 // the export components.
 type Config struct {
-	Database      database.Config
-	KeyManager    signing.Config
-	SecretManager secrets.Config
-	Storage       storage.Config
+	Database              database.Config
+	KeyManager            signing.Config
+	SecretManager         secrets.Config
+	Storage               storage.Config
+	ObservabilityExporter observability.Config
 
 	Port           string        `env:"PORT, default=8080"`
 	CreateTimeout  time.Duration `env:"CREATE_BATCHES_TIMEOUT, default=5m"`
@@ -64,4 +67,8 @@ func (c *Config) KeyManagerConfig() *signing.Config {
 
 func (c *Config) SecretManagerConfig() *secrets.Config {
 	return &c.SecretManager
+}
+
+func (c *Config) ObservabilityExporterConfig() *observability.Config {
+	return &c.ObservabilityExporter
 }

--- a/internal/federationin/config.go
+++ b/internal/federationin/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/observability"
 	"github.com/google/exposure-notifications-server/internal/secrets"
 	"github.com/google/exposure-notifications-server/internal/setup"
 )
@@ -38,11 +39,13 @@ var (
 // Compile-time check to assert this config matches requirements.
 var _ setup.DatabaseConfigProvider = (*Config)(nil)
 var _ setup.SecretManagerConfigProvider = (*Config)(nil)
+var _ setup.ObservabilityExporterConfigProvider = (*Config)(nil)
 
 // Config is the configuration for federation-pull components (data pulled from other servers).
 type Config struct {
-	Database      database.Config
-	SecretManager secrets.Config
+	Database              database.Config
+	SecretManager         secrets.Config
+	ObservabilityExporter observability.Config
 
 	Port           string        `env:"PORT, default=8080"`
 	Timeout        time.Duration `env:"RPC_TIMEOUT, default=10m"`
@@ -69,4 +72,8 @@ func (c *Config) DatabaseConfig() *database.Config {
 
 func (c *Config) SecretManagerConfig() *secrets.Config {
 	return &c.SecretManager
+}
+
+func (c *Config) ObservabilityExporterConfig() *observability.Config {
+	return &c.ObservabilityExporter
 }

--- a/internal/federationout/config.go
+++ b/internal/federationout/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/observability"
 	"github.com/google/exposure-notifications-server/internal/secrets"
 	"github.com/google/exposure-notifications-server/internal/setup"
 )
@@ -25,11 +26,13 @@ import (
 // Compile-time check to assert this config matches requirements.
 var _ setup.DatabaseConfigProvider = (*Config)(nil)
 var _ setup.SecretManagerConfigProvider = (*Config)(nil)
+var _ setup.ObservabilityExporterConfigProvider = (*Config)(nil)
 
 // Config is the configuration for the federation components (data sent to other servers).
 type Config struct {
-	Database      database.Config
-	SecretManager secrets.Config
+	Database              database.Config
+	SecretManager         secrets.Config
+	ObservabilityExporter observability.Config
 
 	Port           string        `env:"PORT, default=8080"`
 	Timeout        time.Duration `env:"RPC_TIMEOUT, default=5m"`
@@ -53,4 +56,8 @@ func (c *Config) DatabaseConfig() *database.Config {
 
 func (c *Config) SecretManagerConfig() *secrets.Config {
 	return &c.SecretManager
+}
+
+func (c *Config) ObservabilityExporterConfig() *observability.Config {
+	return &c.ObservabilityExporter
 }

--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/observability"
 	"github.com/google/exposure-notifications-server/internal/secrets"
 	"github.com/google/exposure-notifications-server/internal/setup"
 )
@@ -26,12 +27,14 @@ import (
 // Compile-time check to assert this config matches requirements.
 var _ setup.DatabaseConfigProvider = (*Config)(nil)
 var _ setup.SecretManagerConfigProvider = (*Config)(nil)
+var _ setup.ObservabilityExporterConfigProvider = (*Config)(nil)
 
 // Config represents the configuration and associated environment variables for
 // the publish components.
 type Config struct {
-	Database      database.Config
-	SecretManager secrets.Config
+	Database              database.Config
+	SecretManager         secrets.Config
+	ObservabilityExporter observability.Config
 
 	Port             string        `env:"PORT, default=8080"`
 	NumExposures     int           `env:"NUM_EXPOSURES_GENERATED, default=10"`
@@ -48,4 +51,8 @@ func (c *Config) DatabaseConfig() *database.Config {
 
 func (c *Config) SecretManagerConfig() *secrets.Config {
 	return &c.SecretManager
+}
+
+func (c *Config) ObservabilityExporterConfig() *observability.Config {
+	return &c.ObservabilityExporter
 }

--- a/internal/observability/config.go
+++ b/internal/observability/config.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package observability sets up and configures observability tools.
+package observability
+
+// ExporterType represents a type of observability exporter.
+type ExporterType string
+
+const (
+	ExporterStackdriver ExporterType = "STACKDRIVER"
+	ExporterPrometheus  ExporterType = "PROMETHEUS"
+	ExporterOCAgent     ExporterType = "OCAGENT"
+	ExporterNoop        ExporterType = "NOOP"
+)
+
+// Config holds all of the configuration options for the observability exporter
+type Config struct {
+	ExporterType ExporterType `env:"OBSERVABILITY_EXPORTER, default=STACKDRIVER"`
+
+	OpenCensusConfig
+	StackdriverConfig
+	OCAgentConfig
+}
+
+// OpenCensusConfig holds the configuration options for the open census exporter
+type OpenCensusConfig struct {
+	TraceProbabilitySampleRate float64 `env:"TRACE_PROBABILITY, default=0.40"`
+}
+
+// StackdriverConfig holds the configuration options for the stackdriver exporter
+type StackdriverConfig struct {
+	ProjectID string `env:"PROJECT_ID, default:$GOOGLE_CLOUD_PROJECT"`
+}
+
+// OCAgentConfig holds the configuration options for the default opencensus exporter
+type OCAgentConfig struct {
+	Insecure bool   `env:"OCAGENT_INSECURE, default=true"`
+	Endpoint string `env:"OCAGENT_TRACE_EXPORTER_ENDPOINT"`
+}

--- a/internal/observability/generic.go
+++ b/internal/observability/generic.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package observability sets up and configures observability tools.
+package observability
+
+import (
+	"sync"
+
+	"go.opencensus.io/plugin/ocgrpc"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/trace"
+)
+
+// Compile-time check to verify implements interface.
+var _ Exporter = (*GenericExporter)(nil)
+
+var initExporterOnce sync.Once
+
+type traceAndViewExporter interface {
+	trace.Exporter
+	view.Exporter
+}
+
+// GenericExporter is a standard implementation of an exporter that wraps the opencensus interfaces
+// with custom configuration
+type GenericExporter struct {
+	exporter   traceAndViewExporter
+	sampleRate float64
+}
+
+func (g *GenericExporter) InitExportOnce() {
+	initExporterOnce.Do(g.initExporter)
+}
+
+func (g *GenericExporter) initExporter() {
+	if g.exporter == nil {
+		return
+	}
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.ProbabilitySampler(g.sampleRate),
+	})
+	trace.RegisterExporter(g.exporter)
+	view.RegisterExporter(g.exporter)
+
+	// Record the various HTTP view to collect metrics.
+	httpViews := append(ochttp.DefaultServerViews, ochttp.DefaultClientViews...)
+	if err := view.Register(httpViews...); err != nil {
+		panic(err)
+	}
+	// Register the various gRPC views to collect metrics.
+	gRPCViews := append(ocgrpc.DefaultServerViews, ocgrpc.DefaultClientViews...)
+	if err := view.Register(gRPCViews...); err != nil {
+		panic(err)
+	}
+}

--- a/internal/observability/noop.go
+++ b/internal/observability/noop.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package observability sets up and configures observability tools.
+package observability
+
+// Compile-time check to verify implements interface.
+var _ Exporter = (*NoopExporter)(nil)
+
+// NoopExporter is an observability exporter that does nothing.
+type NoopExporter struct{}
+
+func (g *NoopExporter) InitExportOnce() {}

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/internal/authorizedapp"
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/observability"
 	"github.com/google/exposure-notifications-server/internal/secrets"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/internal/verification"
@@ -29,14 +30,16 @@ import (
 var _ setup.AuthorizedAppConfigProvider = (*Config)(nil)
 var _ setup.DatabaseConfigProvider = (*Config)(nil)
 var _ setup.SecretManagerConfigProvider = (*Config)(nil)
+var _ setup.ObservabilityExporterConfigProvider = (*Config)(nil)
 
 // Config represents the configuration and associated environment variables for
 // the publish components.
 type Config struct {
-	AuthorizedApp authorizedapp.Config
-	Database      database.Config
-	SecretManager secrets.Config
-	Verification  verification.Config
+	AuthorizedApp         authorizedapp.Config
+	Database              database.Config
+	SecretManager         secrets.Config
+	Verification          verification.Config
+	ObservabilityExporter observability.Config
 
 	Port               string        `env:"PORT, default=8080"`
 	MinRequestDuration time.Duration `env:"TARGET_REQUEST_DURATION, default=5s"`
@@ -59,4 +62,8 @@ func (c *Config) DatabaseConfig() *database.Config {
 
 func (c *Config) SecretManagerConfig() *secrets.Config {
 	return &c.SecretManager
+}
+
+func (c *Config) ObservabilityExporterConfig() *observability.Config {
+	return &c.ObservabilityExporter
 }

--- a/internal/serverenv/env.go
+++ b/internal/serverenv/env.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/authorizedapp"
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/metrics"
+	"github.com/google/exposure-notifications-server/internal/observability"
 	"github.com/google/exposure-notifications-server/internal/secrets"
 	"github.com/google/exposure-notifications-server/internal/signing"
 	"github.com/google/exposure-notifications-server/internal/storage"
@@ -39,6 +40,7 @@ type ServerEnv struct {
 	exporter              metrics.ExporterFromContext
 	keyManager            signing.KeyManager
 	secretManager         secrets.SecretManager
+	observabilityExporter observability.Exporter
 }
 
 // Option defines function types to modify the ServerEnv on creation.
@@ -108,6 +110,14 @@ func WithBlobStorage(sto storage.Blobstore) Option {
 	}
 }
 
+// WithObservabilityExporter creates an Option to install a specific observability exporter system.
+func WithObservabilityExporter(oe observability.Exporter) Option {
+	return func(s *ServerEnv) *ServerEnv {
+		s.observabilityExporter = oe
+		return s
+	}
+}
+
 func (s *ServerEnv) SecretManager() secrets.SecretManager {
 	return s.secretManager
 }
@@ -126,6 +136,10 @@ func (s *ServerEnv) AuthorizedAppProvider() authorizedapp.Provider {
 
 func (s *ServerEnv) Database() *database.DB {
 	return s.database
+}
+
+func (s *ServerEnv) ObservabilityExporter() observability.Exporter {
+	return s.observabilityExporter
 }
 
 // GetSignerForKey returns the crypto.Singer implementation to use based on the installed KeyManager.


### PR DESCRIPTION
1. Switches the observability exporter configuration to use envconfig
2. Adds an interface for ObservabilityExporter with a single GenericExporter implementation
3. Adds a configuration option to the OCAGENT exporter to set the exporter endpoint and control insecure ssl.
4. Completed a "todo" in the code to make the sample probability rate configurable.
5. Added a NOOP observability exporter to be the default exporter if none are provided and to aid the testing in setup package (the default is still stackdriver due to the envconfig struct tag).


I started this PR by simply adding the single configuration option to set the exporter endpoint, then things kinda spiraled out of control from there. I wanted to keep it simple, but as I dug in to make things configurable, it started to make sense to treat the observability exporter similarly to other providers and interface it out. Happy to hear suggestions on how this could be improved.

This unblocks sending trace data from OpenCensus to Azure Application Insights by way of the "local forwarder". More information on that is available here: https://opencensus.io/exporters/supported-exporters/go/applicationinsights/ and https://github.com/microsoft/ApplicationInsights-LocalForwarder