### PR TITLE
Added variable for vpc_access_connector max_throughput

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,11 +75,12 @@ resource "google_service_networking_connection" "private_vpc_connection" {
 }
 
 resource "google_vpc_access_connector" "connector" {
-  project       = data.google_project.project.project_id
-  name          = "serverless-vpc-connector"
-  region        = var.network_location
-  network       = "default"
-  ip_cidr_range = "10.8.0.0/28"
+  project        = data.google_project.project.project_id
+  name           = "serverless-vpc-connector"
+  region         = var.network_location
+  network        = "default"
+  ip_cidr_range  = "10.8.0.0/28"
+  max_throughput = var.vpc_access_connector_max_throughput
 
   depends_on = [
     google_project_service.services["compute.googleapis.com"],

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -114,6 +114,13 @@ variable "service_environment" {
   description = "Per-service environment overrides."
 }
 
+variable "vpc_access_connector_max_throughput" {
+  type    = number
+  default = 1000
+
+  description = "Maximum provisioned traffic throughput in Mbps"
+}
+
 terraform {
   required_providers {
     google      = "~> 3.24"


### PR DESCRIPTION
Fixes: https://github.com/google/exposure-notifications-server/issues/639

Add the following to terraform.tfvars
```
vpc_access_connector_max_throughput = 300
```