### PR TITLE
Adding integration test for cleanup published exposures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,5 +78,4 @@ require (
 	gopkg.in/ini.v1 v1.56.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	honnef.co/go/tools v0.0.1-2020.1.4
-	k8s.io/apimachinery v0.0.0-20190409092423-760d1845f48b
 )

--- a/go.mod
+++ b/go.mod
@@ -78,4 +78,5 @@ require (
 	gopkg.in/ini.v1 v1.56.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	honnef.co/go/tools v0.0.1-2020.1.4
+	k8s.io/apimachinery v0.0.0-20190409092423-760d1845f48b
 )

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -78,7 +78,7 @@ func (h *exposureCleanupHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	timeoutCtx, cancel := context.WithTimeout(ctx, h.config.Timeout)
 	defer cancel()
 
-	count, err := h.database.DeleteExposures(timeoutCtx, cutoff)
+	count, err := h.database.DeleteExposuresBefore(timeoutCtx, cutoff)
 	if err != nil {
 		message := fmt.Sprintf("Failed deleting exposures: %v", err)
 		logger.Error(message)

--- a/internal/integration/en_api.go
+++ b/internal/integration/en_api.go
@@ -71,6 +71,22 @@ func (server EnServerClient) PublishKeys(t *testing.T, request verifyapi.Publish
 	t.Logf("Publish request is sent to %v", "/publish")
 }
 
+func (server EnServerClient) CleanupExposures(t *testing.T) {
+	resp, err := server.getRequest("/cleanup-exposure")
+	if err != nil {
+		t.Fatalf("request failed: %v, %v", err, resp)
+	}
+	t.Logf("Cleanup exposures request is sent to /cleanup-exposure")
+}
+
+func (server EnServerClient) CleanupExports(t *testing.T) {
+	resp, err := server.getRequest("/cleanup-export")
+	if err != nil {
+		t.Fatalf("request failed: %v, %v", err, resp)
+	}
+	t.Logf("Cleanup exports request is sent to /cleanup-export")
+}
+
 func (server EnServerClient) ExportBatches(t *testing.T) {
 	resp, err := server.getRequest("/export/create-batches")
 	if err != nil {
@@ -94,7 +110,7 @@ func unwrapResponse(resp *http.Response) (*http.Response, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to copy error body (%d): %w", resp.StatusCode, err)
 		}
-		return resp, fmt.Errorf("request failed with status: %v\n%v", resp.StatusCode, body)
+		return resp, fmt.Errorf("request failed with status: %v\n%v", resp.StatusCode, string(body))
 	}
 	return resp, nil
 }

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/storage"
 )
 
+// testServer sets up mocked local servers for running tests
 func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client) {
 	tb.Helper()
 

--- a/internal/integration/publish_test.go
+++ b/internal/integration/publish_test.go
@@ -75,8 +75,7 @@ func TestCleanup(t *testing.T) {
 
 	// Move the tick of first batch, and make them old
 	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
-		keyStr := string(m.ExposureKey)
-		if _, ok := firstBatchKeys[keyStr]; !ok {
+		if _, ok := firstBatchKeys[string(m.ExposureKey)]; !ok {
 			return nil
 		}
 		if _, err := publishdb.New(db).DeleteExposure(ctx, m.ExposureKey); err != nil {
@@ -246,18 +245,6 @@ func assertExposures(t *testing.T, ctx context.Context, db *database.DB, want in
 	if want != got {
 		t.Errorf("Want: %d, got: %d", want, got)
 	}
-}
-
-func getKeysFromAllBatches(t *testing.T, exportDir string, ctx context.Context, env *serverenv.ServerEnv) []*export.TemporaryExposureKeyExport {
-	var res []*export.TemporaryExposureKeyExport
-	exportFiles := getAllBatchesFiles(t, exportDir, ctx, env)
-	t.Log("all files:", exportFiles)
-
-	for _, exportFile := range exportFiles {
-		e := readKeyExportFromBlob(t, exportDir, exportFile, ctx, env)
-		res = append(res, e)
-	}
-	return res
 }
 
 func getKeysFromLatestBatch(t *testing.T, exportDir string, ctx context.Context, env *serverenv.ServerEnv) *export.TemporaryExposureKeyExport {

--- a/internal/integration/publish_test.go
+++ b/internal/integration/publish_test.go
@@ -17,11 +17,13 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	authorizedappmodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
+	"github.com/google/exposure-notifications-server/internal/database"
 	exportapi "github.com/google/exposure-notifications-server/internal/export"
 	exportdatabase "github.com/google/exposure-notifications-server/internal/export/database"
 	exportmodel "github.com/google/exposure-notifications-server/internal/export/model"
@@ -34,7 +36,66 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/proto"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
+
+func TestCleanup(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	env, client := testServer(t)
+	db := env.Database()
+	enClient := &EnServerClient{client: client}
+
+	exportPeriod := 2 * time.Second
+	criteria := publishdb.IterateExposuresCriteria{
+		OnlyLocalProvenance: false,
+	}
+
+	// Create an authorized app.
+	startAuthorizedApp(ctx, env, t)
+
+	// Create a signature info.
+	createSignatureInfo(ctx, db, exportPeriod, t)
+
+	firstPayload := newPayloads(3)
+	enClient.PublishKeys(t, firstPayload)
+	assertExposures(t, ctx, db, 3)
+	firstBatchKeys := sets.NewString()
+	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
+		firstBatchKeys.Insert(string(m.ExposureKey))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	secondPayload := newPayloads(3)
+	enClient.PublishKeys(t, secondPayload)
+	assertExposures(t, ctx, db, 6)
+
+	// Move the tick of first batch, and make them old
+	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
+		keyStr := string(m.ExposureKey)
+		if !firstBatchKeys.Has(keyStr) {
+			return nil
+		}
+		if _, err := publishdb.New(db).DeleteExposure(ctx, m.ExposureKey); err != nil {
+			return fmt.Errorf("failed deleting exposure %v: %v", m.ExposureKey, err)
+		}
+		m.CreatedAt = m.CreatedAt.Add(-366 * time.Hour)
+		if err := publishdb.New(db).InsertExposures(ctx, []*publishmodel.Exposure{m}); err != nil {
+			return fmt.Errorf("failed inserting exposure %v with updated creation time: %v",
+				m.ExposureKey, err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	enClient.CleanupExposures(t)
+	assertExposures(t, ctx, db, 3)
+}
 
 func TestPublish(t *testing.T) {
 	t.Parallel()
@@ -45,74 +106,18 @@ func TestPublish(t *testing.T) {
 	db := env.Database()
 	enClient := &EnServerClient{client: client}
 
-	// Create an authorized app.
-	aa := env.AuthorizedAppProvider()
-	if err := aa.Add(ctx, &authorizedappmodel.AuthorizedApp{
-		AppPackageName: "com.example.app",
-		AllowedRegions: map[string]struct{}{
-			"TEST": {},
-		},
-		AllowedHealthAuthorityIDs: map[int64]struct{}{
-			12345: {},
-		},
+	exportPeriod := 2 * time.Second
 
-		// TODO: hook up verification, and disable
-		BypassHealthAuthorityVerification: true,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	// Create an authorized app.
+	startAuthorizedApp(ctx, env, t)
 
 	// Create a signature info.
-	si := &exportmodel.SignatureInfo{
-		SigningKey:        "signer",
-		SigningKeyVersion: "v1",
-		SigningKeyID:      "US",
-	}
-	if err := exportdatabase.New(db).AddSignatureInfo(ctx, si); err != nil {
-		t.Fatal(err)
-	}
+	createSignatureInfo(ctx, db, exportPeriod, t)
 
-	// Create an export config.
-	exportPeriod := 2 * time.Second
-	ec := &exportmodel.ExportConfig{
-		BucketName:       "my-bucket",
-		Period:           exportPeriod,
-		OutputRegion:     "TEST",
-		From:             time.Now().Add(-2 * time.Second),
-		Thru:             time.Now().Add(1 * time.Hour),
-		SignatureInfoIDs: []int64{},
-	}
-	if err := exportdatabase.New(db).AddExportConfig(ctx, ec); err != nil {
-		t.Fatal(err)
-	}
-
-	payload := verifyapi.Publish{
-		Keys:           util.GenerateExposureKeys(3, -1, false),
-		Regions:        []string{"TEST"},
-		AppPackageName: "com.example.app",
-
-		// TODO: hook up verification
-		VerificationPayload: "TODO",
-	}
+	payload := newPayloads(3)
 
 	enClient.PublishKeys(t, payload)
-
-	// Look up the exposures in the database.
-	criteria := publishdb.IterateExposuresCriteria{
-		OnlyLocalProvenance: false,
-	}
-
-	var exposures []*publishmodel.Exposure
-	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
-		exposures = append(exposures, m)
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	if got, want := len(exposures), 3; got != want {
-		t.Errorf("expected %v to be %v: %#v", got, want, exposures)
-	}
+	assertExposures(t, ctx, db, 3)
 
 	t.Logf("Waiting %v before export batches", exportPeriod+1*time.Second)
 	time.Sleep(exportPeriod + 1*time.Second)
@@ -171,22 +176,109 @@ func TestPublish(t *testing.T) {
 	// TODO: verify signature
 }
 
+func startAuthorizedApp(ctx context.Context, env *serverenv.ServerEnv, t *testing.T) {
+	aa := env.AuthorizedAppProvider()
+	if err := aa.Add(ctx, &authorizedappmodel.AuthorizedApp{
+		AppPackageName: "com.example.app",
+		AllowedRegions: map[string]struct{}{
+			"TEST": {},
+		},
+		AllowedHealthAuthorityIDs: map[int64]struct{}{
+			12345: {},
+		},
+
+		// TODO: hook up verification, and disable
+		BypassHealthAuthorityVerification: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createSignatureInfo(ctx context.Context, db *database.DB, exportPeriod time.Duration, t *testing.T) {
+	si := &exportmodel.SignatureInfo{
+		SigningKey:        "signer",
+		SigningKeyVersion: "v1",
+		SigningKeyID:      "US",
+	}
+	if err := exportdatabase.New(db).AddSignatureInfo(ctx, si); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an export config.
+	exportPeriod := 2 * time.Second
+	ec := &exportmodel.ExportConfig{
+		BucketName:       "my-bucket",
+		Period:           exportPeriod,
+		OutputRegion:     "TEST",
+		From:             time.Now().Add(-2 * time.Second),
+		Thru:             time.Now().Add(1 * time.Hour),
+		SignatureInfoIDs: []int64{},
+	}
+	if err := exportdatabase.New(db).AddExportConfig(ctx, ec); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newPayloads(n int) verifyapi.Publish {
+	return verifyapi.Publish{
+		Keys:           util.GenerateExposureKeys(3, -1, false),
+		Regions:        []string{"TEST"},
+		AppPackageName: "com.example.app",
+
+		// TODO: hook up verification
+		VerificationPayload: "TODO",
+	}
+}
+
+func assertExposures(t *testing.T, ctx context.Context, db *database.DB, want int) {
+	// Look up the exposures in the database.
+	criteria := publishdb.IterateExposuresCriteria{
+		OnlyLocalProvenance: false,
+	}
+
+	var exposures []*publishmodel.Exposure
+	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
+		exposures = append(exposures, m)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := len(exposures)
+	if want != got {
+		t.Errorf("Want: %d, got: %d", want, got)
+	}
+}
+
+func getKeysFromAllBatches(t *testing.T, exportDir string, ctx context.Context, env *serverenv.ServerEnv) []*export.TemporaryExposureKeyExport {
+	var res []*export.TemporaryExposureKeyExport
+	exportFiles := getAllBatchesFiles(t, exportDir, ctx, env)
+	t.Log("all files:", exportFiles)
+
+	for _, exportFile := range exportFiles {
+		e := readKeyExportFromBlob(t, exportDir, exportFile, ctx, env)
+		res = append(res, e)
+	}
+	return res
+}
+
 func getKeysFromLatestBatch(t *testing.T, exportDir string, ctx context.Context, env *serverenv.ServerEnv) *export.TemporaryExposureKeyExport {
-	readmeBlob, err := env.Blobstore().GetObject(ctx, exportDir, "index.txt")
-	if err != nil {
-		t.Fatalf("Can't file index.txt in blobstore: %v", err)
-	}
+	files := getAllBatchesFiles(t, exportDir, ctx, env)
+	exportFile := getLatestFile(files)
+	t.Log("latest:", exportFile)
+	return readKeyExportFromBlob(t, exportDir, exportFile, ctx, env)
+}
 
-	exportFile := getLatestFile(readmeBlob)
+func readKeyExportFromBlob(t *testing.T, exportDir, exportFile string, ctx context.Context, env *serverenv.ServerEnv) *export.TemporaryExposureKeyExport {
 	if exportFile == "" {
-		t.Fatalf("Can't find export files in blobstore: %v", exportDir)
+		t.Fatalf("Can't find export files in blobstore: %q", exportDir)
 	}
 
-	t.Logf("Reading keys data from: %v", exportFile)
+	t.Logf("Reading keys data from: %q", exportFile)
 
 	blob, err := env.Blobstore().GetObject(ctx, exportDir, exportFile)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("can't marshal json results: %v", err)
 	}
 
 	keyExport, err := exportapi.UnmarshalExportFile(blob)
@@ -197,9 +289,7 @@ func getKeysFromLatestBatch(t *testing.T, exportDir string, ctx context.Context,
 	return keyExport
 }
 
-func getLatestFile(indexBlob []byte) string {
-	files := strings.Split(string(indexBlob), "\n")
-
+func getLatestFile(files []string) string {
 	latestFileName := ""
 	for _, fileName := range files {
 		if strings.HasSuffix(fileName, "zip") {
@@ -214,4 +304,13 @@ func getLatestFile(indexBlob []byte) string {
 	}
 
 	return latestFileName
+}
+
+func getAllBatchesFiles(t *testing.T, exportDir string, ctx context.Context, env *serverenv.ServerEnv) []string {
+	readmeBlob, err := env.Blobstore().GetObject(ctx, exportDir, "index.txt")
+	if err != nil {
+		t.Fatalf("Can't file index.txt in blobstore: %v", err)
+	}
+	t.Log("index.txt: ", string(readmeBlob))
+	return strings.Split(string(readmeBlob), "\n")
 }

--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -126,20 +126,20 @@ func TestExposures(t *testing.T) {
 	}
 
 	// Delete some exposures.
-	gotN, err := testPublishDB.DeleteExposures(ctx, exposures[2].CreatedAt)
+	gotN, err := testPublishDB.DeleteExposuresBefore(ctx, exposures[2].CreatedAt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantN := int64(2) // The DeleteExposures time is exclusive, so we expect only the first two were deleted.
+	wantN := int64(2) // The DeleteExposuresBefore time is exclusive, so we expect only the first two were deleted.
 	if gotN != wantN {
-		t.Errorf("DeleteExposures: deleted %d, want %d", gotN, wantN)
+		t.Errorf("DeleteExposuresBefore: deleted %d, want %d", gotN, wantN)
 	}
 	got, err := listExposures(ctx, testPublishDB, IterateExposuresCriteria{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if diff := cmp.Diff(exposures[2:], got); diff != "" {
-		t.Errorf("DeleteExposures: mismatch (-want, +got):\n%s", diff)
+		t.Errorf("DeleteExposuresBefore: mismatch (-want, +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
This is the first half of #640, creating an integration test for testing cleanup scenario of published exposures, testing exposure DB cleanup. 

It's planned to have a following PR testing the scenario of export cleanup, if needed I can add it in this PR as well