### PR TITLE
Use KeyVault SDK authorizer, which is more flexible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v42.3.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/go-autorest/autorest v0.10.2
-	github.com/Azure/go-autorest/autorest/adal v0.8.3
+	github.com/Azure/go-autorest/autorest/adal v0.8.3 // indirect
 	github.com/DataDog/datadog-go v3.7.1+incompatible // indirect
 	github.com/Jeffail/gabs/v2 v2.5.0 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect


### PR DESCRIPTION
The SDK provided authorizer used in this PR is a beneficial one to use because of the following:

* It wraps the logic implemented here and therefore will be less of a maintenance overhead
* It provides the ability to authenticate with any of the following methods, with a built in fallback mechanism:
  * Client credentials
  * Client certificate
  * Username password
  * Managed Identity