### PR TITLE
Return error from secret cacher

### DIFF
--- a/pkg/secrets/cacher.go
+++ b/pkg/secrets/cacher.go
@@ -68,9 +68,9 @@ func (sm *Cacher) GetSecretValue(ctx context.Context, name string) (string, erro
 
 	cacheVal, err := sm.cache.WriteThruLookup(name, lookup)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	plaintext := cacheVal.(string)
-	return plaintext, err
+	return plaintext, nil
 }


### PR DESCRIPTION
Only lost a few hours debugging this 😄 

The cacher silently drops the error, meaning the value is `""`.

/assign @crwilcox 