### PR TITLE
feat(secrets-manager): add ability to json-decode secret values and select the value of a map by specifying the key in the secret-name

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -122,6 +122,14 @@ func SetupWith(ctx context.Context, config interface{}, l envconfig.Lookuper) (*
 			}
 		}
 
+		// Enable secret expansion, if enabled.
+		if smConfig.SecretExpansion {
+			sm, err = secrets.WrapJSONExpander(ctx, sm)
+			if err != nil {
+				return nil, fmt.Errorf("unable to create json expander secret manager: %w", err)
+			}
+		}
+
 		// Update the mutators to process secrets.
 		mutatorFuncs = append(mutatorFuncs, secrets.Resolver(sm, smConfig))
 

--- a/pkg/secrets/config.go
+++ b/pkg/secrets/config.go
@@ -34,4 +34,5 @@ type Config struct {
 	SecretManagerType SecretManagerType `env:"SECRET_MANAGER, default=GOOGLE_SECRET_MANAGER"`
 	SecretsDir        string            `env:"SECRETS_DIR, default=/var/run/secrets"`
 	SecretCacheTTL    time.Duration     `env:"SECRET_CACHE_TTL, default=5m"`
+	SecretExpansion   bool              `env:"SECRET_EXPANSION, default=false"`
 }

--- a/pkg/secrets/json_expander.go
+++ b/pkg/secrets/json_expander.go
@@ -1,0 +1,91 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type JSONExpander struct {
+	sm SecretManager
+}
+
+// NewJSONExpander creates a new secret manager that allows secret values to be stored as json.
+// When resolving secrets, if "dot-notation" is provided via the secret-name, the secret value
+// will be json-decoded and the dot-notation will be used to resolve the secret value.
+func NewJSONExpander(ctx context.Context, f SecretManagerFunc) (SecretManager, error) {
+	sm, err := f(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new JSONExpander SecretManager: %w", err)
+	}
+
+	return WrapJSONExpander(ctx, sm)
+}
+
+// WrapJSONExpander wraps an existing SecretManager with json-expansion logic.
+func WrapJSONExpander(ctx context.Context, sm SecretManager) (SecretManager, error) {
+	return &JSONExpander{
+		sm: sm,
+	}, nil
+}
+
+// GetSecretValue implements the SecretManager interface, but allows for json-expansion
+// of the secret-value. If the secret name contains a period, the secret value is expected
+// to be json. The secret name is assumed to come before the period, while the map-key is
+// expected to follow.
+//
+// For example:
+// If a secret with a name of "psqlcreds" has a value of `{"username":"gandalf", "password":"abc"}`
+// When GetSecretValue(ctx, "psqlcreds") is called, the raw json value will be returned.
+// When GetSecretValue(ctx, "psql.username") is called, only "gandalf" (without quotes) will be returned.
+func (sm *JSONExpander) GetSecretValue(ctx context.Context, name string) (string, error) {
+	parts := strings.Split(name, ".")
+	if len(parts) == 1 {
+		return sm.sm.GetSecretValue(ctx, name)
+	}
+	secretName := parts[0]
+	jsonExpansionPath := parts[1:]
+
+	// Get the value from the embdedded secret-manager using what comes before the period.
+	smValue, err := sm.sm.GetSecretValue(ctx, secretName)
+	if err != nil {
+		return "", err
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(smValue), &m); err != nil {
+		return "", err
+	}
+
+	var stringValue string
+	for _, p := range jsonExpansionPath {
+		v, ok := m[p]
+		if !ok {
+			return "", fmt.Errorf("missing key %v", p)
+		}
+		stringValue, ok = v.(string)
+		if !ok {
+			m, ok = v.(map[string]interface{})
+			if !ok {
+				return "", fmt.Errorf("not a string or a nested field: %v", p)
+			}
+		}
+	}
+
+	return stringValue, nil
+}

--- a/pkg/secrets/json_expander_test.go
+++ b/pkg/secrets/json_expander_test.go
@@ -1,0 +1,143 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+import (
+	"context"
+	"testing"
+)
+
+func TestJSONExpander_GetSecretValue(t *testing.T) {
+	ctx := context.Background()
+
+	testSM := &testSecretManager{}
+
+	sm, err := WrapJSONExpander(ctx, testSM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testSM.value = "test"
+	testCases := []struct {
+		testName      string
+		secretName    string
+		secretValue   string
+		expectedValue string
+		err           bool
+	}{
+		{
+			testName:      "simple name and simple value",
+			secretName:    "psqlcreds",
+			secretValue:   "abc-123",
+			expectedValue: "abc-123",
+			err:           false,
+		},
+		{
+			testName:      "simple name and json value",
+			secretName:    "psqlcreds",
+			secretValue:   "{\"username\":\"gandalf\", \"password\":\"abc-123\"}",
+			expectedValue: "{\"username\":\"gandalf\", \"password\":\"abc-123\"}",
+			err:           false,
+		},
+		{
+			testName:      "unknown expansion key and json value",
+			secretName:    "psqlcreds.unknown",
+			secretValue:   "{\"username\":\"gandalf\", \"password\":\"abc-123\"}",
+			expectedValue: "",
+			err:           true,
+		},
+		{
+			testName:      "json expansion name and json value",
+			secretName:    "psqlcreds.username",
+			secretValue:   "{\"username\":\"gandalf\", \"password\":\"abc-123\"}",
+			expectedValue: "gandalf",
+			err:           false,
+		},
+		{
+			testName:      "json expansion name second value and json value",
+			secretName:    "psqlcreds.password",
+			secretValue:   "{\"username\":\"gandalf\", \"password\":\"abc-123\"}",
+			expectedValue: "abc-123",
+			err:           false,
+		},
+		{
+			testName:      "json expansion name and simple value",
+			secretName:    "psqlcreds.password",
+			secretValue:   "abc-123",
+			expectedValue: "",
+			err:           true,
+		},
+		{
+			testName:      "simple name and invalid json",
+			secretName:    "psqlcreds",
+			secretValue:   "{\"invalid!\"",
+			expectedValue: "{\"invalid!\"",
+			err:           false,
+		},
+		{
+			testName:      "json expansion name and invalid json",
+			secretName:    "psqlcreds.username",
+			secretValue:   "{\"invalid!\"",
+			expectedValue: "",
+			err:           true,
+		},
+		{
+			testName:      "json expansion name and non string in json value",
+			secretName:    "psqlcreds.username",
+			secretValue:   "{\"username\":5}",
+			expectedValue: "",
+			err:           true,
+		},
+		{
+			testName:      "nested json expansion name",
+			secretName:    "psqlcreds.creds.username",
+			secretValue:   "{\"creds\":{\"username\":\"gandalf\"}}",
+			expectedValue: "gandalf",
+			err:           false,
+		},
+		{
+			testName:      "nested json unknown key",
+			secretName:    "psqlcreds.creds.password",
+			secretValue:   "{\"creds\":{\"username\":\"gandalf\"}}",
+			expectedValue: "",
+			err:           true,
+		},
+		{
+			testName:      "nested json expansion name and non string in json value",
+			secretName:    "psqlcreds.creds.username",
+			secretValue:   "{\"creds\":{\"username\":5}}",
+			expectedValue: "",
+			err:           true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			testSM.value = tt.secretValue
+			actualValue, err := sm.GetSecretValue(ctx, tt.secretName)
+			if err != nil {
+				if !tt.err {
+					t.Errorf("got error: %w, did not expect one", err)
+				}
+			}
+			if tt.err && err == nil {
+				t.Errorf("expected to error, but did not, actualValue: %s", actualValue)
+			}
+			if tt.expectedValue != actualValue {
+				t.Errorf("expected %s, got %s", tt.expectedValue, actualValue)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Adds a configuration option "SECRET_EXPANSION" (defaults to false) which enables arbitrary json decoding of secret values to select the value from a map.

For example:
If a secret with a name of "psqlcreds" has a json value of `{"username":"gandalf", "password":"abc"}`
When `GetSecretValue(ctx, "psqlcreds")` is called, the raw json value will be returned.
When `GetSecretValue(ctx, "psqlcreds.username")` is called, only "gandalf" (without quotes) will be returned.

This also works for nested values. For example:
If a secret with a name of "psqlcreds" has a json value of `{"creds": {"username":"gandalf", "password":"abc"}}`
When `GetSecretValue(ctx, "psqlcreds.creds.username")` is called, only "gandalf" (without quotes) will be returned.


This simplifies the use of every other secrets-managers in that all of the connection details can be provided in a single secret. For the database, this is especially handy as there are a number of different fields needed. Attempting to use the cloud-provider secrets-managers without this requires a lot of individual secrets to be created in the store.
