### PR TITLE
Add cleanup test for testing cleanup keys export

### DIFF
--- a/internal/integration/publish_test.go
+++ b/internal/integration/publish_test.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -31,12 +32,19 @@ import (
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
+	"github.com/google/exposure-notifications-server/internal/storage"
 	"github.com/google/exposure-notifications-server/internal/util"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/proto"
+
+	pgx "github.com/jackc/pgx/v4"
+)
+
+const (
+	exportDir = "my-bucket"
 )
 
 func TestCleanupExposure(t *testing.T) {
@@ -88,9 +96,6 @@ func TestCleanupExport(t *testing.T) {
 	enClient := &EnServerClient{client: client}
 
 	exportPeriod := 2 * time.Second
-	criteria := publishdb.IterateExposuresCriteria{
-		OnlyLocalProvenance: false,
-	}
 
 	// Create an authorized app.
 	startAuthorizedApp(ctx, env, t)
@@ -99,22 +104,75 @@ func TestCleanupExport(t *testing.T) {
 	createSignatureInfo(ctx, db, exportPeriod, t)
 
 	firstPayload := newPayloads(3)
-	firstBatchKeys := keysTransformation(t, firstPayload.Keys)
-
 	enClient.PublishKeys(t, firstPayload)
-	// This is one time check to ensure the logic of `keysTransformation` is
-	// consistent with business logic in the server
-	assertKeysTransformation(t, ctx, db, criteria, firstBatchKeys)
-
 	assertExposures(t, ctx, db, 3)
+	exportKeys(t, enClient, exportPeriod)
+	timeAfterFirstExport := time.Now()
+	keyExport := getKeysFromLatestBatch(t, exportDir, ctx, env)
+	got := keyExport
+	wantedKeysMap, wantedExport := wantFromKeys(firstPayload.Keys, 1, 1)
+	assertExports(t, wantedKeysMap, wantedExport, got)
+
+	var firstBatchExportFile *exportmodel.ExportFile
+	firstBatchFiles := getAllBatchesFiles(t, exportDir, ctx, env)
+	firstBatchExportFile, err := exportdatabase.New(db).LookupExportFile(ctx, firstBatchFiles[0])
+	if err != nil {
+		t.Fatalf("Failed to look up exportfile %q: %v", firstBatchFiles[0], err)
+	}
 
 	secondPayload := newPayloads(3)
 	enClient.PublishKeys(t, secondPayload)
 	assertExposures(t, ctx, db, 6)
+	exportKeys(t, enClient, exportPeriod)
+	keyExport = getKeysFromLatestBatch(t, exportDir, ctx, env)
+	wantedKeysMap, wantedExport = wantFromKeys(secondPayload.Keys, 1, 1)
+	assertExports(t, wantedKeysMap, wantedExport, keyExport)
 
-	alterExposureCreatedAt(t, ctx, db, criteria, firstBatchKeys, -366*time.Hour)
-	enClient.CleanupExposures(t)
-	assertExposures(t, ctx, db, 3)
+	// Move the tick of first batch export to be old
+	if err := db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+		UPDATE
+			ExportBatch
+		SET
+			start_timestamp = $1, end_timestamp = $2
+		WHERE
+			batch_id = $3
+		`, timeAfterFirstExport.Add(-367*time.Hour),
+			timeAfterFirstExport.Add(-366*time.Hour),
+			firstBatchExportFile.BatchID,
+		)
+		return err
+	}); err != nil {
+		t.Fatalf("Failed updating batch_id %d: %v", firstBatchExportFile.BatchID, err)
+	}
+
+	// Make sure keys were exported before cleanup
+	exposureKeys := getKeysFromAllBatches(t, exportDir, ctx, env)
+	wantedKeysMap, _ = wantFromKeys(append(firstPayload.Keys, secondPayload.Keys...), 1, 1)
+	assertExportedKeysMatch(t, wantedKeysMap, exposureKeys)
+
+	enClient.CleanupExports(t)
+	assertExposures(t, ctx, db, 6)
+	var exposureKeysAfterCleanup []*export.TemporaryExposureKeyExport
+	exportFiles := getAllBatchesFiles(t, exportDir, ctx, env)
+	for _, exportFile := range exportFiles {
+		e, err := readKeyExportFromBlob(t, exportDir, exportFile, ctx, env)
+		if exportFile == firstBatchExportFile.Filename {
+			if err == nil {
+				t.Fatalf("File %q should have been deleted", exportFile)
+			}
+			if errors.Is(err, storage.ErrNotFound) {
+				continue // This is expected, as the filename of first batch is not cleaned up from "index.txt"
+			}
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		exposureKeysAfterCleanup = append(exposureKeysAfterCleanup, e)
+	}
+	wantedKeysMap, _ = wantFromKeys(secondPayload.Keys, 1, 1)
+	assertExportedKeysMatch(t, wantedKeysMap, exposureKeysAfterCleanup)
+	assertExposures(t, ctx, db, 6)
 }
 
 func TestPublish(t *testing.T) {
@@ -139,6 +197,15 @@ func TestPublish(t *testing.T) {
 	enClient.PublishKeys(t, payload)
 	assertExposures(t, ctx, db, 3)
 
+	exportKeys(t, enClient, exportPeriod)
+	keyExport := getKeysFromLatestBatch(t, exportDir, ctx, env)
+	got := keyExport
+	wantedKeysMap, wantedExport := wantFromKeys(payload.Keys, 1, 1)
+	assertExports(t, wantedKeysMap, wantedExport, got)
+	// TODO: verify signature
+}
+
+func exportKeys(t *testing.T, enClient *EnServerClient, exportPeriod time.Duration) {
 	t.Logf("Waiting %v before export batches", exportPeriod+1*time.Second)
 	time.Sleep(exportPeriod + 1*time.Second)
 	enClient.ExportBatches(t)
@@ -146,19 +213,6 @@ func TestPublish(t *testing.T) {
 	t.Logf("Waiting %v before starting workers", 500*time.Millisecond)
 	time.Sleep(500 * time.Millisecond)
 	enClient.StartExportWorkers(t)
-
-	keyExport := getKeysFromLatestBatch(t, "my-bucket", ctx, env)
-
-	got := keyExport
-	wantedKeysMap, wantedExport := wantFromKeys(payload.Keys, 1, 1)
-	assertExports(t, wantedKeysMap, wantedExport, got)
-	bytes, err := json.MarshalIndent(got, "", "")
-	if err != nil {
-		t.Fatalf("can't marshal json results: %v", err)
-	}
-
-	t.Logf("%v", string(bytes))
-	// TODO: verify signature
 }
 
 // keysTransformation transforms []verifyapi.ExposureKey to string keys, this
@@ -176,7 +230,8 @@ func keysTransformation(t *testing.T, keys []verifyapi.ExposureKey) map[string]b
 	return res
 }
 
-func assertKeysTransformation(t *testing.T, ctx context.Context, db *database.DB, criteria publishdb.IterateExposuresCriteria, generatedKeys map[string]bool) {
+func assertKeysTransformation(t *testing.T, ctx context.Context, db *database.DB,
+	criteria publishdb.IterateExposuresCriteria, generatedKeys map[string]bool) {
 	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
 		if _, ok := generatedKeys[string(m.ExposureKey)]; ok {
 			generatedKeys[string(m.ExposureKey)] = false
@@ -189,7 +244,8 @@ func assertKeysTransformation(t *testing.T, ctx context.Context, db *database.DB
 	}
 }
 
-func alterExposureCreatedAt(t *testing.T, ctx context.Context, db *database.DB, criteria publishdb.IterateExposuresCriteria, keys map[string]bool, timeDelta time.Duration) {
+func alterExposureCreatedAt(t *testing.T, ctx context.Context, db *database.DB,
+	criteria publishdb.IterateExposuresCriteria, keys map[string]bool, timeDelta time.Duration) {
 	// Move the tick of first batch, and make them old
 	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
 		if _, ok := keys[string(m.ExposureKey)]; !ok {
@@ -209,17 +265,20 @@ func alterExposureCreatedAt(t *testing.T, ctx context.Context, db *database.DB, 
 	}
 }
 
-func assertExports(t *testing.T, wantedKeysMap map[string]*export.TemporaryExposureKey, wantExport *export.TemporaryExposureKeyExport, got *export.TemporaryExposureKeyExport) {
-	if *wantExport.BatchSize != *got.BatchSize {
-		t.Errorf("Invalid BatchSize: want: %v, got: %v", *wantExport.BatchSize, *got.BatchSize)
-	}
+func assertExports(t *testing.T, wantedKeysMap map[string]*export.TemporaryExposureKey,
+	wantExport *export.TemporaryExposureKeyExport, got *export.TemporaryExposureKeyExport) {
+	if wantExport != nil {
+		if *wantExport.BatchSize != *got.BatchSize {
+			t.Errorf("Invalid BatchSize: want: %v, got: %v", *wantExport.BatchSize, *got.BatchSize)
+		}
 
-	if *wantExport.BatchNum != *got.BatchNum {
-		t.Errorf("Invalid BatchNum: want: %v, got: %v", *wantExport.BatchNum, *got.BatchNum)
-	}
+		if *wantExport.BatchNum != *got.BatchNum {
+			t.Errorf("Invalid BatchNum: want: %v, got: %v", *wantExport.BatchNum, *got.BatchNum)
+		}
 
-	if *wantExport.Region != *got.Region {
-		t.Errorf("Invalid Region: want: %v, got: %v", *wantExport.BatchSize, *got.BatchSize)
+		if *wantExport.Region != *got.Region {
+			t.Errorf("Invalid Region: want: %v, got: %v", *wantExport.BatchSize, *got.BatchSize)
+		}
 	}
 
 	for _, key := range got.Keys {
@@ -230,9 +289,37 @@ func assertExports(t *testing.T, wantedKeysMap map[string]*export.TemporaryExpos
 			t.Errorf("invalid key value: %v:%v", s, diff)
 		}
 	}
+
+	if _, err := json.MarshalIndent(got, "", ""); err != nil {
+		t.Fatalf("can't marshal json results: %v", err)
+	}
 }
 
-func wantFromKeys(keys []verifyapi.ExposureKey, batchNum, batchSize int32) (map[string]*export.TemporaryExposureKey, *export.TemporaryExposureKeyExport) {
+func assertExportedKeysMatch(t *testing.T, wantedKeysMap map[string]*export.TemporaryExposureKey,
+	got []*export.TemporaryExposureKeyExport) {
+	var gotKeys []*export.TemporaryExposureKey
+	for _, e := range got {
+		gotKeys = append(gotKeys, e.Keys...)
+	}
+	if len(wantedKeysMap) != len(gotKeys) {
+		t.Fatalf("Number of keys mismatch. Want: %d, got %d", len(wantedKeysMap), len(gotKeys))
+	}
+	for _, key := range gotKeys {
+		s := util.ToBase64(key.KeyData)
+		wantedKey := wantedKeysMap[s]
+		diff := cmp.Diff(wantedKey, key, cmpopts.IgnoreUnexported(export.TemporaryExposureKey{}))
+		if diff != "" {
+			t.Errorf("invalid key value: %v:%v", s, diff)
+		}
+	}
+
+	if _, err := json.MarshalIndent(got, "", ""); err != nil {
+		t.Fatalf("can't marshal json results: %v", err)
+	}
+}
+
+func wantFromKeys(keys []verifyapi.ExposureKey, batchNum, batchSize int32) (map[string]*export.TemporaryExposureKey,
+	*export.TemporaryExposureKeyExport) {
 	wantedKeysMap := make(map[string]*export.TemporaryExposureKey)
 	for _, key := range keys {
 		wantedKeysMap[key.Key] = &export.TemporaryExposureKey{
@@ -281,7 +368,7 @@ func createSignatureInfo(ctx context.Context, db *database.DB, exportPeriod time
 
 	// Create an export config.
 	ec := &exportmodel.ExportConfig{
-		BucketName:       "my-bucket",
+		BucketName:       exportDir,
 		Period:           exportPeriod,
 		OutputRegion:     "TEST",
 		From:             time.Now().Add(-2 * time.Second),
@@ -324,13 +411,18 @@ func assertExposures(t *testing.T, ctx context.Context, db *database.DB, want in
 	}
 }
 
+// getKeysFromAllBatches gets all exported keys, unless the filename is
+// explicitly listed in excluded
 func getKeysFromAllBatches(t *testing.T, exportDir string, ctx context.Context, env *serverenv.ServerEnv) []*export.TemporaryExposureKeyExport {
 	var res []*export.TemporaryExposureKeyExport
 	exportFiles := getAllBatchesFiles(t, exportDir, ctx, env)
 	t.Log("all files:", exportFiles)
 
 	for _, exportFile := range exportFiles {
-		e := readKeyExportFromBlob(t, exportDir, exportFile, ctx, env)
+		e, err := readKeyExportFromBlob(t, exportDir, exportFile, ctx, env)
+		if err != nil {
+			t.Fatalf("cannot read file %q: %v", exportFile, err)
+		}
 		res = append(res, e)
 	}
 	return res
@@ -340,27 +432,31 @@ func getKeysFromLatestBatch(t *testing.T, exportDir string, ctx context.Context,
 	files := getAllBatchesFiles(t, exportDir, ctx, env)
 	exportFile := getLatestFile(files)
 	t.Log("latest:", exportFile)
-	return readKeyExportFromBlob(t, exportDir, exportFile, ctx, env)
+	res, err := readKeyExportFromBlob(t, exportDir, exportFile, ctx, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res
 }
 
-func readKeyExportFromBlob(t *testing.T, exportDir, exportFile string, ctx context.Context, env *serverenv.ServerEnv) *export.TemporaryExposureKeyExport {
+func readKeyExportFromBlob(t *testing.T, exportDir, exportFile string, ctx context.Context, env *serverenv.ServerEnv) (*export.TemporaryExposureKeyExport, error) {
 	if exportFile == "" {
-		t.Fatalf("Can't find export files in blobstore: %q", exportDir)
+		return nil, fmt.Errorf("Can't find export files in blobstore: %q", exportDir)
 	}
 
 	t.Logf("Reading keys data from: %q", exportFile)
 
 	blob, err := env.Blobstore().GetObject(ctx, exportDir, exportFile)
 	if err != nil {
-		t.Fatalf("can't marshal json results: %v", err)
+		return nil, fmt.Errorf("can't open file from %q in dir %q: %w", exportFile, exportDir, err)
 	}
 
 	keyExport, err := exportapi.UnmarshalExportFile(blob)
 	if err != nil {
-		t.Fatalf("can't extract export data: %v", err)
+		return nil, fmt.Errorf("can't extract export data: %w", err)
 	}
 
-	return keyExport
+	return keyExport, nil
 }
 
 func getLatestFile(files []string) string {


### PR DESCRIPTION
Add an integration test for cleanup exports scenario:

1. First batch export
1. Ensure keys are exported
1. Second batch export
1. Ensure only second batch keys exist in latest
1. Inspect all exports, ensure both batches exist
1. Clean up export
1. Inspect all exports, ensure only second batch exist

Fixes: #640 