### PR TITLE
Allow overlapped keys in Debug configurations

### DIFF
--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -249,7 +249,8 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 	nextInterval := entities[0].IntervalNumber
 	for _, ex := range entities {
 		if ex.IntervalNumber < nextInterval {
-			return nil, fmt.Errorf("exposure keys have overlapping intervals")
+			logging.FromContext(ctx).Errorf("Server detected keys with overlapping intervals")
+			break
 		}
 		nextInterval = ex.IntervalNumber + ex.IntervalCount
 	}

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -249,8 +249,11 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 	nextInterval := entities[0].IntervalNumber
 	for _, ex := range entities {
 		if ex.IntervalNumber < nextInterval {
-			logging.FromContext(ctx).Errorf("Server detected keys with overlapping intervals")
-			break
+			if t.debugReleaseSameDay {
+				logging.FromContext(ctx).Errorf("exposure keys have overlapping intervals")
+				break
+			}
+			return nil, fmt.Errorf("exposure keys have overlapping intervals")
 		}
 		nextInterval = ex.IntervalNumber + ex.IntervalCount
 	}


### PR DESCRIPTION
b/159869725

In testing, we sometimes don't publish keys immediately, to the server this looks like overlapped keys. This makes the server log an error, but it won't fail