### PR TITLE
Fixes to export index.txt file creation

### DIFF
--- a/internal/export/database/export.go
+++ b/internal/export/database/export.go
@@ -629,7 +629,7 @@ func (db *ExportDB) FinalizeBatch(ctx context.Context, eb *model.ExportBatch, fi
 }
 
 // LookupExportFiles returns a list of completed and unexpired export files for a specific config.
-func (db *ExportDB) LookupExportFiles(ctx context.Context, configId int64, ttl time.Duration) ([]string, error) {
+func (db *ExportDB) LookupExportFiles(ctx context.Context, configID int64, ttl time.Duration) ([]string, error) {
 	conn, err := db.db.Pool.Acquire(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("acquiring connection: %w", err)
@@ -652,7 +652,7 @@ func (db *ExportDB) LookupExportFiles(ctx context.Context, configId int64, ttl t
 			eb.status = $3
 		ORDER BY
 			ef.filename
-		`, configId, minTime, model.ExportBatchComplete)
+		`, configID, minTime, model.ExportBatchComplete)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/export/database/export.go
+++ b/internal/export/database/export.go
@@ -645,7 +645,7 @@ func (db *ExportDB) LookupExportFiles(ctx context.Context, configId int64, ttl t
 		INNER JOIN
 			ExportBatch eb ON (eb.batch_id = ef.batch_id)
 		WHERE
-		  eb.config_id = $1
+			eb.config_id = $1
 		AND
 			eb.start_timestamp > $2
 		AND

--- a/internal/export/database/export.go
+++ b/internal/export/database/export.go
@@ -628,8 +628,8 @@ func (db *ExportDB) FinalizeBatch(ctx context.Context, eb *model.ExportBatch, fi
 	})
 }
 
-// LookupExportFiles returns a list of completed and unexpired export files.
-func (db *ExportDB) LookupExportFiles(ctx context.Context, ttl time.Duration) ([]string, error) {
+// LookupExportFiles returns a list of completed and unexpired export files for a specific config.
+func (db *ExportDB) LookupExportFiles(ctx context.Context, configId int64, ttl time.Duration) ([]string, error) {
 	conn, err := db.db.Pool.Acquire(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("acquiring connection: %w", err)
@@ -645,12 +645,14 @@ func (db *ExportDB) LookupExportFiles(ctx context.Context, ttl time.Duration) ([
 		INNER JOIN
 			ExportBatch eb ON (eb.batch_id = ef.batch_id)
 		WHERE
-			eb.start_timestamp > $1
+		  eb.config_id = $1
 		AND
-			eb.status = $2
+			eb.start_timestamp > $2
+		AND
+			eb.status = $3
 		ORDER BY
 			ef.filename
-		`, minTime, model.ExportBatchComplete)
+		`, configId, minTime, model.ExportBatchComplete)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -402,7 +402,7 @@ func TestFinalizeBatch(t *testing.T) {
 
 	// Check that files were written.
 	ttl, _ := time.ParseDuration("20h")
-	gotFiles, err := exportDB.LookupExportFiles(ctx, ttl)
+	gotFiles, err := exportDB.LookupExportFiles(ctx, eb.ConfigID, ttl)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
* When generating the files for the index.txt, restrict it to the exportconfig.ID of the batch being processed
* When determining if an empty batch should refresh the index, do this per-configID instead of per /do-work
* Change index file locking to per-config id and not per-batch, better represents the race condition we are guarding against.

Fixes #672