### PR TITLE
Fix Cache-Control header

### DIFF
--- a/internal/storage/google_cloud_storage.go
+++ b/internal/storage/google_cloud_storage.go
@@ -52,7 +52,7 @@ func (s *GoogleCloudStorage) CreateObject(ctx context.Context, bucket, objectNam
 
 	wc := s.client.Bucket(bucket).Object(objectName).NewWriter(ctx)
 	wc.CacheControl = cacheControl
-    
+
 	if _, err := wc.Write(contents); err != nil {
 		return fmt.Errorf("storage.Writer.Write: %w", err)
 	}

--- a/internal/storage/google_cloud_storage.go
+++ b/internal/storage/google_cloud_storage.go
@@ -51,9 +51,8 @@ func (s *GoogleCloudStorage) CreateObject(ctx context.Context, bucket, objectNam
 	}
 
 	wc := s.client.Bucket(bucket).Object(objectName).NewWriter(ctx)
-	wc.Metadata = map[string]string{
-		"Cache-Control": cacheControl,
-	}
+	wc.CacheControl = cacheControl
+    
 	if _, err := wc.Write(contents); err != nil {
 		return fmt.Errorf("storage.Writer.Write: %w", err)
 	}


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-go/commit/16dbcc9af7869d37fa7c8625733aab6628b7c2e4

`Metadata` sets the "x-goog-meta-Cache-Control" and _not_ the "Cache-Control" header.