### PR TITLE
Fix typo in internal server implementation

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,7 +39,7 @@ type Server struct {
 
 // New creates a new server listening on the provided address that responds to
 // the http.Handler. It starts the listener, but does not start the server. If
-// an empty port is given, the server randombly chooses one.
+// an empty port is given, the server randomly chooses one.
 func New(port string) (*Server, error) {
 	// Create the net listener first, so the connection ready when we return. This
 	// guarantees that it can accept requests.


### PR DESCRIPTION
Typo was 'randombly', changed to 'randomly'