### PR TITLE
Verification claims adjustments

### DIFF
--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -48,7 +48,7 @@ func ApplyTransmissionRiskOverrides(p *verifyapi.Publish, overrides verifyapi.Tr
 		// Advance the overrideIdx until the current key is covered or we exhaust the
 		// override index.
 		for overrideIdx < len(overrides) &&
-			eKey.IntervalNumber+eKey.IntervalCount <= overrides[overrideIdx].SinceRollingPeriod {
+			eKey.IntervalNumber+eKey.IntervalCount <= overrides[overrideIdx].SinceRollingInterval {
 			overrideIdx++
 		}
 
@@ -59,7 +59,7 @@ func ApplyTransmissionRiskOverrides(p *verifyapi.Publish, overrides verifyapi.Tr
 
 		// Check to see if this key is in the current override.
 		// If the key was EVERY valid during the SinceRollingPeriod then the override applies.
-		if eKey.IntervalNumber+eKey.IntervalCount >= overrides[overrideIdx].SinceRollingPeriod {
+		if eKey.IntervalNumber+eKey.IntervalCount >= overrides[overrideIdx].SinceRollingInterval {
 			p.Keys[i].TransmissionRisk = overrides[overrideIdx].TranismissionRisk
 			// don't advance overrideIdx, there might be additional keys in this override.
 		}

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -578,16 +578,16 @@ func TestApplyOverrides(t *testing.T) {
 			},
 			Overrides: []verifyapi.TransmissionRiskOverride{
 				{
-					SinceRollingPeriod: 5,
-					TranismissionRisk:  5,
+					SinceRollingInterval: 5,
+					TranismissionRisk:    5,
 				},
 				{
-					SinceRollingPeriod: 3,
-					TranismissionRisk:  3,
+					SinceRollingInterval: 3,
+					TranismissionRisk:    3,
 				},
 				{
-					SinceRollingPeriod: 0,
-					TranismissionRisk:  0,
+					SinceRollingInterval: 0,
+					TranismissionRisk:    0,
 				},
 			},
 			Want: []verifyapi.ExposureKey{
@@ -637,12 +637,12 @@ func TestApplyOverrides(t *testing.T) {
 			},
 			Overrides: []verifyapi.TransmissionRiskOverride{
 				{
-					SinceRollingPeriod: 4,
-					TranismissionRisk:  5, // anything effective at time >= 4 gets TR 5.
+					SinceRollingInterval: 4,
+					TranismissionRisk:    5, // anything effective at time >= 4 gets TR 5.
 				},
 				{
-					SinceRollingPeriod: 0,
-					TranismissionRisk:  2, // 2 since beginning of time.
+					SinceRollingInterval: 0,
+					TranismissionRisk:    2, // 2 since beginning of time.
 				},
 			},
 			Want: []verifyapi.ExposureKey{
@@ -680,8 +680,8 @@ func TestApplyOverrides(t *testing.T) {
 			},
 			Overrides: []verifyapi.TransmissionRiskOverride{
 				{
-					SinceRollingPeriod: 4,
-					TranismissionRisk:  5, // anything effective at time >= 4 gets TR 5.
+					SinceRollingInterval: 4,
+					TranismissionRisk:    5, // anything effective at time >= 4 gets TR 5.
 				},
 			},
 			Want: []verifyapi.ExposureKey{

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -266,8 +266,8 @@ func TestPublishWithBypass(t *testing.T) {
 			},
 			Overrides: []verifyapi.TransmissionRiskOverride{
 				{
-					TranismissionRisk:  8,
-					SinceRollingPeriod: 0,
+					TranismissionRisk:    8,
+					SinceRollingInterval: 0,
 				},
 			},
 			WantTRAdjustment: []int{8, 8}, // 2 entries, both override to 8


### PR DESCRIPTION
* remove free form pha claims
* introduce v1.5 fields to verification claims
* clairfy naming
* mark transmission risk overrides as deprecated, but still used

Part of #680
Part of #663