### PR TITLE
Remove test date from verification claims.

### DIFF
--- a/pkg/api/v1alpha1/verification_types.go
+++ b/pkg/api/v1alpha1/verification_types.go
@@ -79,14 +79,12 @@ func (a TransmissionRiskVector) Swap(i, j int) {
 // This data is used to set data on the uploaded TEKs and will be reflected on export. See the export file format:
 // https://github.com/google/exposure-notifications-server/blob/main/internal/pb/export/export.proto#L73
 type VerificationClaims struct {
+	// ReportType is one of 'confirmed', 'likely', or 'negative' as defined by the constants in this file.
 	ReportType string `json:"reportType"`
 	// SymptomOnsetInterval uses the same 10 minute interval timing as TEKs use. If an interval is provided that isn not the
 	// start of a UTC day, then it will be rounded down to the beginning of that UTC day. And from there the days +/- symptom
 	// onset will be calculated.
 	SymptomOnsetInterval uint32 `json:"symptomOnsetInterval"`
-	// TestDateInterval also uses the 10 mninute intervals and has the same rounding
-	// rules as SymptomOnsetInterval
-	TestDateInterval uint32 `json:"testDateInterval"`
 
 	// Deprecated, but not scheduled for removal.
 	// TransmissionRisks will continue to be supported. On newer versions of the device software,

--- a/tools/example-verification-signing/main.go
+++ b/tools/example-verification-signing/main.go
@@ -112,7 +112,6 @@ func main() {
 		// Here, we show an example of a confirmed lab test, conducted yesterday (-1 day),
 		// with symptom onset occurring 2 days before the test (-3 days from now).
 		claims.ReportType = v1alpha1.ReportTypeConfirmed
-		claims.TestDateInterval = uint32(model.IntervalNumber(now.Add(-1 * oneDay).Truncate(oneDay)))
 		claims.SymptomOnsetInterval = uint32(model.IntervalNumber(now.Add(-3 * oneDay).Truncate(oneDay)))
 
 		// optionally add transmission risks


### PR DESCRIPTION
Confirmed that only report type and symptom onset date are needed.

Test date was never used in the system.