### PR TITLE
Early key release

### DIFF
--- a/docs/getting-started/publishing-temporary-exposure-keys.md
+++ b/docs/getting-started/publishing-temporary-exposure-keys.md
@@ -19,7 +19,42 @@ exposed, their keys are shared to the server in order for applications to
 download and [determine if other users interacted with any of the now exposed
 keys](https://blog.google/documents/69/Exposure_Notification_-_Cryptography_Specification_v1.2.1.pdf).
 
-## Publishing Keys
+## The Publish API Call
+
+TEKs are published by sending the appropriate JSON document in the body of
+an HTTP POST request to the `exposure` server.
+
+The structure of the API is defined in [pkg/api/v1alpha1/exposure_types.go](https://github.com/google/exposure-notifications-server/blob/main/pkg/api/v1alpha1/exposure_types.go),
+in the `Publish` type. Please see the documentation in the source file
+for details of the fields themselves.
+
+Here, we point out some non-obvious validation that is applied to the keys.
+
+* All keys must be valid! If there are any validation errors, the entire batch
+  is rejected.
+* Max keys per publish: Default is `20` and can be adjusted with the
+  `MAX_KEYS_ON_PUBLISH` environment variable.
+* Max overlapping keys with same start interval: Default is `3` and can be
+  adjusted with the `MAX_SAME_START_INTERVAL_KEYS` environment variable.
+	In practical terms, this means that if you are obtaining TEK history on a
+	mobile device with >= v1.5 of the device API, it will stop the validity
+	of the current day's TEK and issue a new now. Both keys will have the same
+	start iterval.
+* Max age: How old keys can be. The default is `360h` (15 days) and can be
+  adjusted with the `MAX_INTERVAL_AGE_ON_PUBLISH`. All provided keys must have
+	a `rollingStartNumber` that is >= to the max age.
+* Keys with a future start time (`rollingStartNumber` indicates time > now),
+  are rejected.
+* Keys that are "sill valid" are accepted by the server, but they are embargoed
+  until after they key could no longer be replayed usefully. A stall valid key
+	is one where the `rollingStartNumber` is in the past, but the
+	`rollingStartNumber` + the `rollingPeriod` indicates a future time.
+* When using health authority verification certificates
+  (__strongly recommended__), the TEK data in the publish request and the
+	`hmackey` must be able to be used to calculate the HMAC value as present in
+	the certificate.
+
+## Server Access Configuration
 
 In order for your application to publish keys to the server, the server
 requires the registration of the Application Name (for Android) or the Bundle ID

--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -36,13 +36,15 @@ type Config struct {
 	SecretManager         secrets.Config
 	ObservabilityExporter observability.Config
 
-	Port             string        `env:"PORT, default=8080"`
-	NumExposures     int           `env:"NUM_EXPOSURES_GENERATED, default=10"`
-	KeysPerExposure  int           `env:"KEYS_PER_EXPOSURE, default=14"`
-	MaxKeysOnPublish int           `env:"MAX_KEYS_ON_PUBLISH, default=15"`
-	MaxIntervalAge   time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
-	TruncateWindow   time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
-	DefaultRegion    string        `env:"DEFAULT_REGOIN, default=US"`
+	Port                     string        `env:"PORT, default=8080"`
+	NumExposures             int           `env:"NUM_EXPOSURES_GENERATED, default=10"`
+	KeysPerExposure          int           `env:"KEYS_PER_EXPOSURE, default=14"`
+	MaxKeysOnPublish         int           `env:"MAX_KEYS_ON_PUBLISH, default=15"`
+	MaxSameStartIntervalKeys int           `env:"MAX_SAME_START_INTERVAL_KEYS, default=2"`
+	SimulateSameDayRelease   bool          `env:"SIMULATE_SAME_DAY_RELEASE, default=false"`
+	MaxIntervalAge           time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
+	TruncateWindow           time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
+	DefaultRegion            string        `env:"DEFAULT_REGOIN, default=US"`
 }
 
 func (c *Config) DatabaseConfig() *database.Config {

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -151,10 +151,11 @@ func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client) {
 
 	// Publish
 	publishConfig := &publish.Config{
-		MaxKeysOnPublish:        15,
-		MaxIntervalAge:          360 * time.Hour,
-		TruncateWindow:          1 * time.Second,
-		DebugReleaseSameDayKeys: true,
+		MaxKeysOnPublish:         15,
+		MaxSameStartIntervalKeys: 2,
+		MaxIntervalAge:           360 * time.Hour,
+		TruncateWindow:           1 * time.Second,
+		DebugReleaseSameDayKeys:  true,
 	}
 
 	publishHandler, err := publish.NewHandler(ctx, publishConfig, env)

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -41,12 +41,16 @@ type Config struct {
 	Verification          verification.Config
 	ObservabilityExporter observability.Config
 
-	Port             string        `env:"PORT, default=8080"`
-	MaxKeysOnPublish int           `env:"MAX_KEYS_ON_PUBLISH, default=15"`
-	MaxIntervalAge   time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
-	TruncateWindow   time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
+	Port             string `env:"PORT, default=8080"`
+	MaxKeysOnPublish int    `env:"MAX_KEYS_ON_PUBLISH, default=20"`
+	// Provides compatibility w/ 1.5 release.
+	MaxSameStartIntervalKeys int           `env:"MAX_SAME_START_INTERVAL_KEYS, default=3"`
+	MaxIntervalAge           time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
+	TruncateWindow           time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 
-	// Flags for local development and testing.
+	// Flags for local development and testing. This will cause still valid keys
+	// to not be embargoed.
+	// Normallly "still valid" keys can be accepted, but are embargoed.
 	DebugReleaseSameDayKeys bool `env:"DEBUG_RELEASE_SAME_DAY_KEYS"`
 }
 

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -46,13 +46,17 @@ func NewHandler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (
 		return nil, fmt.Errorf("missing AuthorizedApp provider in server environment")
 	}
 
-	transformer, err := model.NewTransformer(config.MaxKeysOnPublish, config.MaxIntervalAge, config.TruncateWindow, config.DebugReleaseSameDayKeys)
+	transformer, err := model.NewTransformer(config.MaxKeysOnPublish, config.MaxSameStartIntervalKeys, config.MaxIntervalAge, config.TruncateWindow, config.DebugReleaseSameDayKeys)
 	if err != nil {
 		return nil, fmt.Errorf("model.NewTransformer: %w", err)
 	}
 	logger.Infof("max keys per upload: %v", config.MaxKeysOnPublish)
+	logger.Infof("max same start interval keys: %v", config.MaxSameStartIntervalKeys)
 	logger.Infof("max interval start age: %v", config.MaxIntervalAge)
 	logger.Infof("truncate window: %v", config.TruncateWindow)
+	if config.DebugReleaseSameDayKeys {
+		logger.Warnf("SERVER IS IN DEBUG MODE. KEYS MAY BE RELEASED EARLY.")
+	}
 
 	verifier, err := verification.New(verifydb.New(env.Database()), &config.Verification)
 	if err != nil {

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -341,7 +341,8 @@ func TestPublishWithBypass(t *testing.T) {
 			config := Config{}
 			config.AuthorizedApp.CacheDuration = time.Nanosecond
 			config.TruncateWindow = time.Second
-			config.MaxKeysOnPublish = 14
+			config.MaxKeysOnPublish = 20
+			config.MaxSameStartIntervalKeys = 2
 			config.MaxIntervalAge = 14 * 24 * time.Hour
 			aaProvider, err := authorizedapp.NewDatabaseProvider(ctx, testDB, config.AuthorizedAppConfig())
 			if err != nil {

--- a/internal/util/generate.go
+++ b/internal/util/generate.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
-	"github.com/google/exposure-notifications-server/testing/enclient"
 )
 
 const (
@@ -98,7 +97,7 @@ func GenerateExposureKeys(numKeys, tr int, randomInterval bool) []v1alpha1.Expos
 				log.Fatalf("problem with transmission risk: %v", err)
 			}
 		}
-		exposureKeys[i], err = RandomExposureKey(enclient.Interval(intervalNumber), intervalCount, transmissionRisk)
+		exposureKeys[i], err = RandomExposureKey(intervalNumber, intervalCount, transmissionRisk)
 		if err != nil {
 			log.Fatalf("problem creating random exposure key: %v", err)
 		}
@@ -116,7 +115,7 @@ func GenerateExposureKeys(numKeys, tr int, randomInterval bool) []v1alpha1.Expos
 }
 
 // RandomExposureKey creates a random exposure key.
-func RandomExposureKey(intervalNumber enclient.Interval, intervalCount int32, transmissionRisk int) (v1alpha1.ExposureKey, error) {
+func RandomExposureKey(intervalNumber int32, intervalCount int32, transmissionRisk int) (v1alpha1.ExposureKey, error) {
 	key, err := GenerateKey()
 	if err != nil {
 		return v1alpha1.ExposureKey{}, err


### PR DESCRIPTION
* Allow for v1.5+ early key release. Multiple keys can be provided that all have the same start interval
* Add configuration params for this
* Add tests for new pieces. 100% coverage on exposure model transform.
* Add documentation.
* add same day release as an optional feature to the generate server

Fixes #705
Part of #663