### PR TITLE
Work on v1.5

### DIFF
--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/observability"
+	"github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
 )
@@ -28,6 +29,7 @@ import (
 var _ setup.DatabaseConfigProvider = (*Config)(nil)
 var _ setup.SecretManagerConfigProvider = (*Config)(nil)
 var _ setup.ObservabilityExporterConfigProvider = (*Config)(nil)
+var _ model.TransformerConfig = (*Config)(nil)
 
 // Config represents the configuration and associated environment variables for
 // the publish components.
@@ -36,16 +38,40 @@ type Config struct {
 	SecretManager         secrets.Config
 	ObservabilityExporter observability.Config
 
-	Port                     string        `env:"PORT, default=8080"`
-	NumExposures             int           `env:"NUM_EXPOSURES_GENERATED, default=10"`
-	KeysPerExposure          int           `env:"KEYS_PER_EXPOSURE, default=14"`
-	MaxKeysOnPublish         int           `env:"MAX_KEYS_ON_PUBLISH, default=15"`
-	MaxSameStartIntervalKeys int           `env:"MAX_SAME_START_INTERVAL_KEYS, default=2"`
-	SimulateSameDayRelease   bool          `env:"SIMULATE_SAME_DAY_RELEASE, default=false"`
-	MaxIntervalAge           time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
-	MaxSymptomOnsetDays      int           `env:"MAX_SYMPTOM_ONSET_DAYS, default=21"`
-	TruncateWindow           time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
-	DefaultRegion            string        `env:"DEFAULT_REGOIN, default=US"`
+	Port                         string        `env:"PORT, default=8080"`
+	NumExposures                 int           `env:"NUM_EXPOSURES_GENERATED, default=10"`
+	KeysPerExposure              int           `env:"KEYS_PER_EXPOSURE, default=14"`
+	MaxKeysOnPublish             uint          `env:"MAX_KEYS_ON_PUBLISH, default=15"`
+	MaxSameStartIntervalKeys     uint          `env:"MAX_SAME_START_INTERVAL_KEYS, default=2"`
+	SimulateSameDayRelease       bool          `env:"SIMULATE_SAME_DAY_RELEASE, default=false"`
+	MaxIntervalAge               time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
+	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=21"`
+	CreatedAtTruncateWindow      time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
+	DefaultRegion                string        `env:"DEFAULT_REGOIN, default=US"`
+}
+
+func (c *Config) MaxExposureKeys() uint {
+	return c.MaxKeysOnPublish
+}
+
+func (c *Config) MaxSameDayKeys() uint {
+	return c.MaxSameStartIntervalKeys
+}
+
+func (c *Config) MaxIntervalStartAge() time.Duration {
+	return c.MaxIntervalAge
+}
+
+func (c *Config) TruncateWindow() time.Duration {
+	return c.CreatedAtTruncateWindow
+}
+
+func (c *Config) MaxSymptomOnsetDays() uint {
+	return c.MaxMagnitudeSymptomOnsetDays
+}
+
+func (c *Config) DebugReleaseSameDayKeys() bool {
+	return false
 }
 
 func (c *Config) DatabaseConfig() *database.Config {

--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	MaxSameStartIntervalKeys int           `env:"MAX_SAME_START_INTERVAL_KEYS, default=2"`
 	SimulateSameDayRelease   bool          `env:"SIMULATE_SAME_DAY_RELEASE, default=false"`
 	MaxIntervalAge           time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
+	MaxSymptomOnsetDays      int           `env:"MAX_SYMPTOM_ONSET_DAYS, default=21"`
 	TruncateWindow           time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 	DefaultRegion            string        `env:"DEFAULT_REGOIN, default=US"`
 }

--- a/internal/generate/handler.go
+++ b/internal/generate/handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/internal/util"
+	"github.com/google/exposure-notifications-server/internal/verification"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 )
 
@@ -39,7 +40,7 @@ func NewHandler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (
 		return nil, fmt.Errorf("missing database in server environment")
 	}
 
-	transformer, err := model.NewTransformer(config.MaxKeysOnPublish, config.MaxSameStartIntervalKeys, config.MaxIntervalAge, config.TruncateWindow, false)
+	transformer, err := model.NewTransformer(config.MaxKeysOnPublish, config.MaxSameStartIntervalKeys, config.MaxIntervalAge, config.TruncateWindow, config.MaxSymptomOnsetDays, false)
 	if err != nil {
 		return nil, fmt.Errorf("model.NewTransformer: %w", err)
 	}
@@ -78,12 +79,8 @@ func (h *generateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for i := 0; i < h.config.NumExposures; i++ {
 		logger.Infof("Generating exposure %v of %v", i+1, h.config.NumExposures)
 
-		tr, err := util.RandomTransmissionRisk()
-		if err != nil {
-			tr = 0
-		}
 		publish := verifyapi.Publish{
-			Keys:           util.GenerateExposureKeys(h.config.KeysPerExposure, tr, false),
+			Keys:           util.GenerateExposureKeys(h.config.KeysPerExposure, 0, false),
 			Regions:        regions,
 			AppPackageName: "generated.data",
 		}
@@ -101,7 +98,12 @@ func (h *generateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		exposures, err := h.transformer.TransformPublish(ctx, &publish, batchTime)
+		claims := verification.VerifiedClaims{
+			ReportType:           util.RandomReportType(),
+			SymptomOnsetInterval: uint32(publish.Keys[0].IntervalNumber),
+		}
+
+		exposures, err := h.transformer.TransformPublish(ctx, &publish, &claims, batchTime)
 		if err != nil {
 			message := fmt.Sprintf("Error transforming generated exposures: %v", err)
 			span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: message})

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -154,8 +154,8 @@ func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client) {
 		MaxKeysOnPublish:         15,
 		MaxSameStartIntervalKeys: 2,
 		MaxIntervalAge:           360 * time.Hour,
-		TruncateWindow:           1 * time.Second,
-		DebugReleaseSameDayKeys:  true,
+		CreatedAtTruncateWindow:  1 * time.Second,
+		ReleaseSameDayKeys:       true,
 	}
 
 	publishHandler, err := publish.NewHandler(ctx, publishConfig, env)

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	// Provides compatibility w/ 1.5 release.
 	MaxSameStartIntervalKeys int           `env:"MAX_SAME_START_INTERVAL_KEYS, default=3"`
 	MaxIntervalAge           time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
+	MaxSymptomOnsetDays      int           `env:"MAX_SYMPTOM_ONSET_DAYS, default=21"`
 	TruncateWindow           time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 
 	// Flags for local development and testing. This will cause still valid keys

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/authorizedapp"
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/observability"
+	"github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/internal/verification"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
@@ -31,6 +32,7 @@ var _ setup.AuthorizedAppConfigProvider = (*Config)(nil)
 var _ setup.DatabaseConfigProvider = (*Config)(nil)
 var _ setup.SecretManagerConfigProvider = (*Config)(nil)
 var _ setup.ObservabilityExporterConfigProvider = (*Config)(nil)
+var _ model.TransformerConfig = (*Config)(nil)
 
 // Config represents the configuration and associated environment variables for
 // the publish components.
@@ -42,17 +44,41 @@ type Config struct {
 	ObservabilityExporter observability.Config
 
 	Port             string `env:"PORT, default=8080"`
-	MaxKeysOnPublish int    `env:"MAX_KEYS_ON_PUBLISH, default=20"`
+	MaxKeysOnPublish uint   `env:"MAX_KEYS_ON_PUBLISH, default=20"`
 	// Provides compatibility w/ 1.5 release.
-	MaxSameStartIntervalKeys int           `env:"MAX_SAME_START_INTERVAL_KEYS, default=3"`
-	MaxIntervalAge           time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
-	MaxSymptomOnsetDays      int           `env:"MAX_SYMPTOM_ONSET_DAYS, default=21"`
-	TruncateWindow           time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
+	MaxSameStartIntervalKeys     uint          `env:"MAX_SAME_START_INTERVAL_KEYS, default=3"`
+	MaxIntervalAge               time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
+	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=21"`
+	CreatedAtTruncateWindow      time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 
 	// Flags for local development and testing. This will cause still valid keys
 	// to not be embargoed.
 	// Normally "still valid" keys can be accepted, but are embargoed.
-	DebugReleaseSameDayKeys bool `env:"DEBUG_RELEASE_SAME_DAY_KEYS"`
+	ReleaseSameDayKeys bool `env:"DEBUG_RELEASE_SAME_DAY_KEYS"`
+}
+
+func (c *Config) MaxExposureKeys() uint {
+	return c.MaxKeysOnPublish
+}
+
+func (c *Config) MaxSameDayKeys() uint {
+	return c.MaxSameStartIntervalKeys
+}
+
+func (c *Config) MaxIntervalStartAge() time.Duration {
+	return c.MaxIntervalAge
+}
+
+func (c *Config) TruncateWindow() time.Duration {
+	return c.CreatedAtTruncateWindow
+}
+
+func (c *Config) MaxSymptomOnsetDays() uint {
+	return c.MaxMagnitudeSymptomOnsetDays
+}
+
+func (c *Config) DebugReleaseSameDayKeys() bool {
+	return c.ReleaseSameDayKeys
 }
 
 func (c *Config) AuthorizedAppConfig() *authorizedapp.Config {

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -1134,7 +1134,7 @@ func TestDaysFromSymptomOnset(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := DaysFromSymptomOnset(tc.onset, tc.check)
 			if tc.want != got {
-				t.Fatalf("wrong day instance between %v and %v, want: %v got: %v", tc.onset, tc.check, tc.want, got)
+				t.Fatalf("wrong day instance between %v and %v, got: %v want: %v", tc.onset, tc.check, got, tc.want)
 			}
 		})
 	}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -46,7 +46,7 @@ func NewHandler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (
 		return nil, fmt.Errorf("missing AuthorizedApp provider in server environment")
 	}
 
-	transformer, err := model.NewTransformer(config.MaxKeysOnPublish, config.MaxSameStartIntervalKeys, config.MaxIntervalAge, config.TruncateWindow, config.MaxSymptomOnsetDays, config.DebugReleaseSameDayKeys)
+	transformer, err := model.NewTransformer(config)
 	if err != nil {
 		return nil, fmt.Errorf("model.NewTransformer: %w", err)
 	}
@@ -54,7 +54,7 @@ func NewHandler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (
 	logger.Infof("max same start interval keys: %v", config.MaxSameStartIntervalKeys)
 	logger.Infof("max interval start age: %v", config.MaxIntervalAge)
 	logger.Infof("truncate window: %v", config.TruncateWindow)
-	if config.DebugReleaseSameDayKeys {
+	if config.DebugReleaseSameDayKeys() {
 		logger.Warnf("SERVER IS IN DEBUG MODE. KEYS MAY BE RELEASED EARLY.")
 	}
 

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -340,7 +340,7 @@ func TestPublishWithBypass(t *testing.T) {
 			// And set up publish handler up front.
 			config := Config{}
 			config.AuthorizedApp.CacheDuration = time.Nanosecond
-			config.TruncateWindow = time.Second
+			config.CreatedAtTruncateWindow = time.Second
 			config.MaxKeysOnPublish = 20
 			config.MaxSameStartIntervalKeys = 2
 			config.MaxIntervalAge = 14 * 24 * time.Hour

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -215,7 +215,7 @@ func TestPublishWithBypass(t *testing.T) {
 			Error: "unable to validate diagnosis verification: token contains an invalid number of segments",
 		},
 		{
-			Name:       "valid HA certificate",
+			Name:       "valid_HA_certificate",
 			SigningKey: newSigningKey(t),
 			HealthAuthority: &vermodel.HealthAuthority{
 				Issuer:   "doh.my.gov",
@@ -241,7 +241,7 @@ func TestPublishWithBypass(t *testing.T) {
 			Code: http.StatusOK,
 		},
 		{
-			Name:       "valid HA certificate with overrides",
+			Name:       "valid_HA_certificate_with_overrides",
 			SigningKey: newSigningKey(t),
 			HealthAuthority: &vermodel.HealthAuthority{
 				Issuer:   "doh.my.gov",
@@ -266,7 +266,7 @@ func TestPublishWithBypass(t *testing.T) {
 			},
 			Overrides: []verifyapi.TransmissionRiskOverride{
 				{
-					TranismissionRisk:    8,
+					TransmissionRisk:     8,
 					SinceRollingInterval: 0,
 				},
 			},
@@ -454,17 +454,21 @@ func TestPublishWithBypass(t *testing.T) {
 					if key, err := base64util.DecodeString(k.Key); err != nil {
 						t.Fatal(err)
 					} else {
-						want = append(want,
-							&model.Exposure{
-								ExposureKey:      key,
-								AppPackageName:   tc.Publish.AppPackageName,
-								TransmissionRisk: k.TransmissionRisk,
-								IntervalNumber:   k.IntervalNumber,
-								IntervalCount:    k.IntervalCount,
-								Regions:          tc.Publish.Regions,
-								LocalProvenance:  true,
-								FederationSyncID: 0,
-							})
+						next := model.Exposure{
+							ExposureKey:      key,
+							AppPackageName:   tc.Publish.AppPackageName,
+							TransmissionRisk: k.TransmissionRisk,
+							IntervalNumber:   k.IntervalNumber,
+							IntervalCount:    k.IntervalCount,
+							Regions:          tc.Publish.Regions,
+							LocalProvenance:  true,
+							FederationSyncID: 0,
+						}
+						if tc.HealthAuthority != nil {
+							next.SetHealthAuthorityID(tc.HealthAuthority.ID)
+						}
+
+						want = append(want, &next)
 					}
 				}
 

--- a/internal/util/generate.go
+++ b/internal/util/generate.go
@@ -59,17 +59,20 @@ func RandomIntWithMin(min, max int) (int, error) {
 	return int(n.Int64()) + min, nil
 }
 
-func RandomReportType() string {
-	n, _ := RandomInt(3)
+func RandomReportType() (string, error) {
+	n, err := RandomInt(3)
+	if err != nil {
+		return "", err
+	}
 	switch n {
 	case 0:
-		return v1alpha1.ReportTypeConfirmed
+		return v1alpha1.ReportTypeConfirmed, nil
 	case 1:
-		return v1alpha1.ReportTypeClinical
+		return v1alpha1.ReportTypeClinical, nil
 	case 2:
-		return v1alpha1.ReportTypeNegative
+		return v1alpha1.ReportTypeNegative, nil
 	}
-	return v1alpha1.ReportTypeConfirmed
+	return v1alpha1.ReportTypeConfirmed, nil
 }
 
 // RandomTransmissionRisk produces a random transmission risk score.

--- a/internal/util/generate.go
+++ b/internal/util/generate.go
@@ -59,6 +59,19 @@ func RandomIntWithMin(min, max int) (int, error) {
 	return int(n.Int64()) + min, nil
 }
 
+func RandomReportType() string {
+	n, _ := RandomInt(3)
+	switch n {
+	case 0:
+		return v1alpha1.ReportTypeConfirmed
+	case 1:
+		return v1alpha1.ReportTypeClinical
+	case 2:
+		return v1alpha1.ReportTypeNegative
+	}
+	return v1alpha1.ReportTypeConfirmed
+}
+
 // RandomTransmissionRisk produces a random transmission risk score.
 func RandomTransmissionRisk() (int, error) {
 	n, err := RandomInt(v1alpha1.MaxTransmissionRisk)

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -184,7 +184,7 @@ func TestVerifyCertificate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			overrides, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish)
+			verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish)
 			if err != nil {
 				if !strings.Contains(err.Error(), tc.Error) {
 					t.Fatalf("wanted error '%v', got error '%v'", tc.Error, err.Error())
@@ -192,8 +192,10 @@ func TestVerifyCertificate(t *testing.T) {
 			} else if tc.Error != "" {
 				t.Fatalf("wanted error '%v', but got nil", tc.Error)
 			}
-			if len(overrides) != 0 {
-				t.Errorf("wanted no overrides, got %v", overrides)
+			if verifiedClaims != nil {
+				if len(verifiedClaims.TransmissionRisks) != 0 {
+					t.Errorf("wanted no overrides, got %v", verifiedClaims.TransmissionRisks)
+				}
 			}
 		})
 	}

--- a/migrations/000031_Addv1dot5Columns.down.sql
+++ b/migrations/000031_Addv1dot5Columns.down.sql
@@ -1,0 +1,27 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+DROP INDEX exposure_revised_at_idx;
+
+ALTER TABLE exposure
+  DROP COLUMN health_authority_id,
+	DROP COLUMN report_type,
+	DROP COLUMN days_since_symptom_onset,
+	DROP COLUMN revised_report_type,
+	DROP COLUMN revised_at,
+  DROP COLUMN revised_days_since_symptom_onset;
+
+END;

--- a/migrations/000031_Addv1dot5Columns.up.sql
+++ b/migrations/000031_Addv1dot5Columns.up.sql
@@ -16,12 +16,12 @@ BEGIN;
 
 -- health_authority_id is nullable to preserve backwards compatibility.
 ALTER TABLE exposure
-  ADD COLUMN health_authority_id INT REFERENCES HealthAuthority(id),
+	ADD COLUMN health_authority_id INT REFERENCES HealthAuthority(id),
 	ADD COLUMN report_type VARCHAR(20) DEFAULT '' NOT NULL,
 	ADD COLUMN days_since_symptom_onset INT,
 	ADD COLUMN revised_report_type VARCHAR(20),
 	ADD COLUMN revised_at TIMESTAMPTZ,
-  ADD COLUMN revised_days_since_symptom_onset INT;
+	ADD COLUMN revised_days_since_symptom_onset INT;
 
 CREATE INDEX exposure_revised_at_idx ON exposure USING BRIN(revised_at);
 

--- a/migrations/000031_Addv1dot5Columns.up.sql
+++ b/migrations/000031_Addv1dot5Columns.up.sql
@@ -1,0 +1,28 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- health_authority_id is nullable to preserve backwards compatibility.
+ALTER TABLE exposure
+  ADD COLUMN health_authority_id INT REFERENCES HealthAuthority(id),
+	ADD COLUMN report_type VARCHAR(20) DEFAULT '' NOT NULL,
+	ADD COLUMN days_since_symptom_onset INT,
+	ADD COLUMN revised_report_type VARCHAR(20),
+	ADD COLUMN revised_at TIMESTAMPTZ,
+  ADD COLUMN revised_days_since_symptom_onset INT;
+
+CREATE INDEX exposure_revised_at_idx ON exposure USING BRIN(revised_at);
+
+END;

--- a/pkg/api/v1alpha1/verification_types.go
+++ b/pkg/api/v1alpha1/verification_types.go
@@ -45,6 +45,11 @@ const (
 	ReportTypeClinical = "likely"
 	// ReportTypeNegative is allowed by the verification flow. These keys are not saved in the system.
 	ReportTypeNegative = "negative"
+
+	TransmissionRiskUnknown           = 0
+	TransmissionRiskConfirmedStandard = 2
+	TransmissionRiskClinical          = 4
+	TransmissionRiskNegative          = 6
 )
 
 // TransmissionRiskVector is an additional set of claims that can be
@@ -52,12 +57,12 @@ const (
 // from a trusted public health authority.
 type TransmissionRiskVector []TransmissionRiskOverride
 
-// Compile time check that TranismissionRiskVector implements the sort interface.
+// Compile time check that TransmissionRiskVector implements the sort interface.
 var _ sort.Interface = TransmissionRiskVector{}
 
 // TransmissionRiskOverride is an indvidual transmission risk override.
 type TransmissionRiskOverride struct {
-	TranismissionRisk    int   `json:"tr"`
+	TransmissionRisk     int   `json:"tr"`
 	SinceRollingInterval int32 `json:"sinceRollingInterval"`
 }
 


### PR DESCRIPTION
* Add key revision columns to exposure table
* This includes capturing the health authority ID (if provided)
  * Keys can only be revised by the same health authority ID
* Implement setting of Exposure fields based on the claims from the verification certificate
  * If a ReportType is present, set it in the Exposure.ReportType
  * Optionally, backfill the transmission risk, based on the report type
* Calculate the days +/- sypmtom onset
  * the symptom onset interval can be provided in the API or from the verification certificate
* stub out key revision
  * existing keys are read from the DB if they match the input
  * TODO: merge existing and input keys
  * TODO: implement transactional key revision
* IterateExposures
  * add ability to select revised keys

More work on #663