### PR TITLE
Load test for cleanup exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,13 @@ test-acc:
 		-vet="${VETTERS}" \
 		./...
 .PHONY: test-acc
+
+performance-test:
+	@go test \
+		-count=1 \
+		-timeout 10m \
+		-vet="${VETTERS}" \
+		-v \
+		-tags=performance \
+		./internal/performance
+.PHONY: performance-test

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,7 @@ test-acc:
 performance-test:
 	@go test \
 		-count=1 \
-		-timeout 10m \
-		-vet="${VETTERS}" \
+		-timeout=10m \
 		-v \
 		-tags=performance \
 		./internal/performance

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/sethvargo/go-retry"
 
 	authorizedappmodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
 	exportdatabase "github.com/google/exposure-notifications-server/internal/export/database"
@@ -258,7 +260,7 @@ func testClient(tb testing.TB, srv *server.Server) *http.Client {
 	}
 
 	return &http.Client{
-		Timeout:   5 * time.Second,
+		Timeout:   50 * time.Second,
 		Transport: prt,
 	}
 }
@@ -270,4 +272,26 @@ func randomString() (string, error) {
 	}
 	digest := fmt.Sprintf("%x", sha256.Sum256(b[:]))
 	return digest[:32], nil
+}
+
+// Eventually retries the given function n times, sleeping 1s between each
+// invocation. To mark an error as retryable, wrap it in retry.RetryableError.
+// Non-retryable errors return immediately.
+func Eventually(tb testing.TB, times uint64, f func() error) {
+	ctx := context.Background()
+	b, err := retry.NewConstant(1 * time.Second)
+	if err != nil {
+		tb.Fatalf("failed to create retry: %v", err)
+	}
+	b = retry.WithMaxRetries(times, b)
+
+	if err := retry.Do(ctx, b, func(ctx context.Context) error {
+		return f()
+	}); err != nil {
+		tb.Fatalf("did not return ok after %d retries: %v", times, err)
+	}
+}
+
+func IndexFilePath() string {
+	return path.Join(FileNameRoot, "index.txt")
 }

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -260,6 +260,8 @@ func testClient(tb testing.TB, srv *server.Server) *http.Client {
 	}
 
 	return &http.Client{
+		// Cleaning up 10000 multiple exports takes ~20 seconds, increasing this
+		// so that load test doesn't time out
 		Timeout:   50 * time.Second,
 		Transport: prt,
 	}

--- a/internal/performance/cleanup_test.go
+++ b/internal/performance/cleanup_test.go
@@ -1,0 +1,226 @@
+// +build performance
+
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	exportapi "github.com/google/exposure-notifications-server/internal/export"
+	exportdb "github.com/google/exposure-notifications-server/internal/export/database"
+	exportmodel "github.com/google/exposure-notifications-server/internal/export/model"
+	"github.com/google/exposure-notifications-server/internal/integration"
+	"github.com/google/exposure-notifications-server/internal/storage"
+	"github.com/google/exposure-notifications-server/internal/util"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	"github.com/sethvargo/go-retry"
+)
+
+func TestBatchCleanupBenchmark(t *testing.T) {
+	// 1. Publish keys
+	const (
+		keysPerBatch = 3
+		// If consider batching every 10 seconds, 10000 batches is 100000
+		// seconds ~= 27 hours worth of exports
+		batchCount = 10000
+	)
+	var (
+		err          error
+		ctx          = context.Background()
+		exportPeriod = 2 * time.Second
+		// Tracking time used for each phase
+		// TODO: remove this once mako starts collecting metrics
+		timeTracker time.Time
+		reportTime  = func(t *testing.T, ts time.Time, msg string) time.Time {
+			t.Logf("Spent '%d ms' on %q", time.Now().Sub(ts).Milliseconds(), msg)
+			return time.Now()
+		}
+	)
+
+	timeTracker = time.Now()
+
+	// 1.1 Export first batch
+	env, client, db := integration.NewTestServer(t, exportPeriod)
+	payload := &verifyapi.Publish{
+		Keys:           util.GenerateExposureKeys(3, -1, false),
+		Regions:        []string{"TEST"},
+		AppPackageName: "com.example.app",
+
+		// TODO: hook up verification
+		VerificationPayload: "TODO",
+	}
+	if err = client.PublishKeys(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	var firstBatchExportFile *exportmodel.ExportFile
+	integration.Eventually(t, 30, func() error {
+		time.Sleep(2 * time.Second)
+		// Trigger an export
+		if err := client.ExportBatches(); err != nil {
+			return err
+		}
+
+		// Start export workers
+		if err := client.StartExportWorkers(); err != nil {
+			return err
+		}
+
+		var firstBatchFiles []string
+		index, err := env.Blobstore().GetObject(ctx, integration.ExportDir,
+			path.Join(integration.FileNameRoot, "index.txt"))
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return retry.RetryableError(err)
+			}
+			return err
+		} else if c := strings.TrimSpace(string(index)); c == "" {
+			return retry.RetryableError(errors.New("index file is empty"))
+		}
+		// Find the latest file in the index
+		firstBatchFiles = strings.Split(string(index), "\n")
+		if l := len(firstBatchFiles); l != 1 {
+			return fmt.Errorf("exported batches. Want: %d, got: %d", 1, l)
+		}
+		firstBatchExportFile, err = exportdb.New(db).LookupExportFile(ctx, firstBatchFiles[0])
+		if err != nil {
+			return fmt.Errorf("failed to look up exportfile %q: %w", firstBatchFiles[0], err)
+		}
+		return nil
+	})
+
+	// 1.2 Proliferate exports based on first batch export
+	firstBatchExport, err := exportdb.New(db).LookupExportBatch(ctx, firstBatchExportFile.BatchID)
+	if err != nil {
+		t.Fatalf("Failed looking up the first export: %v", err)
+	}
+	exportContent, err := env.Blobstore().GetObject(ctx, integration.ExportDir, firstBatchExportFile.Filename)
+	if err != nil {
+		t.Fatalf("Failed reading exported file %s from %s: %v", firstBatchExportFile.Filename, integration.ExportDir, err)
+	}
+	createTime := firstBatchExport.StartTimestamp.Add(-366 * time.Hour)
+	endTime := firstBatchExport.EndTimestamp.Add(-366 * time.Hour)
+	for i := 0; i < batchCount; i++ {
+		// For all other batches, copying from first batch
+		createTime = createTime.Add(10 * time.Second)
+		endTime = endTime.Add(10 * time.Second)
+		firstBatchExport.BatchID = firstBatchExport.BatchID + 1
+		firstBatchExport.StartTimestamp = createTime
+		firstBatchExport.EndTimestamp = endTime
+		exportdb.New(db).AddExportBatches(ctx, []*exportmodel.ExportBatch{firstBatchExport})
+
+		fn := fmt.Sprintf("%s/%d-%d.zip", firstBatchExport.FilenameRoot, createTime.Unix(), endTime.Unix())
+		// Note: all exported files have identical contents, as:
+		// Cleanup exports function works based on what's stored in
+		// database, and maps with exportd files only by filenames, so it
+		// doesn't really matter what's inside the  exported file.
+		if err := env.Blobstore().CreateObject(ctx, integration.ExportDir, fn, exportContent, true); err != nil {
+			t.Fatalf("creating file %s in bucket %s: %v", fn, integration.ExportDir, err)
+		}
+		// Add index file
+		contents, err := env.Blobstore().GetObject(ctx, integration.ExportDir, integration.IndexFilePath())
+		if err != nil {
+			t.Fatalf("Failed reading %s in bucket %s: %v", integration.ExportDir, integration.IndexFilePath(), err)
+		}
+		contents = []byte(string(contents) + "\n" + fn)
+		if err := env.Blobstore().CreateObject(ctx, integration.ExportDir, integration.IndexFilePath(), contents, false); err != nil {
+			t.Fatalf("creating file %s in bucket %s: %v", integration.IndexFilePath(), integration.ExportDir, err)
+		}
+		// FinalizeBatch helps with writing to database table `ExportFile`
+		if err := exportdb.New(db).FinalizeBatch(ctx, firstBatchExport, []string{fn}, 1); err != nil {
+			t.Fatalf("Failed finalizing new batch: %v", err)
+		}
+	}
+
+	// 2. Ensure all keys are there
+	integration.Eventually(t, 30, func() error {
+		index, err := env.Blobstore().GetObject(ctx, integration.ExportDir,
+			path.Join(integration.FileNameRoot, "index.txt"))
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return retry.RetryableError(fmt.Errorf("Can not find index file %q: %v", integration.IndexFilePath(), err))
+			}
+			return err
+		}
+		// Find the latest file in the index
+		lines := strings.Split(string(index), "\n")
+		if len(lines) != batchCount+1 {
+			return fmt.Errorf("exported batches. Want: %d, got: %d", batchCount, len(lines))
+		}
+		for _, f := range lines {
+			data, err := env.Blobstore().GetObject(ctx, integration.ExportDir, f)
+			if err != nil {
+				return fmt.Errorf("failed to open %s/%s: %w", integration.ExportDir, f, err)
+			}
+
+			// Process contents as an export
+			key, err := exportapi.UnmarshalExportFile(data)
+			if err != nil {
+				return fmt.Errorf("failed to extract export data: %w", err)
+			}
+			if l := len(key.Keys); l != keysPerBatch {
+				return fmt.Errorf("exported keys. Want: %d keys. Got: %d keys", keysPerBatch, l)
+			}
+		}
+		return nil
+	})
+
+	timeTracker = reportTime(t, timeTracker, "Create workload")
+
+	// [TODO]3. Set up mako
+
+	// 4. Cleanup and capture metrics
+	if err = client.CleanupExports(); err != nil {
+		t.Fatal(err)
+	}
+	timeTracker = reportTime(t, timeTracker, "Invoke Cleanup")
+
+	var remainings []string
+	integration.Eventually(t, 30, func() error {
+		index, err := env.Blobstore().GetObject(ctx, integration.ExportDir,
+			path.Join(integration.FileNameRoot, "index.txt"))
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return retry.RetryableError(fmt.Errorf("Can not find index file: %v", err))
+			}
+			return err
+		}
+		// Find the latest file in the index
+		remainings := strings.Split(string(index), "\n")
+		if l := len(remainings); l != batchCount+1 {
+			return fmt.Errorf("exported batches. Want: %d, got: %d", batchCount, l)
+		}
+		return nil
+	})
+	for _, r := range remainings {
+		if r == firstBatchExportFile.Filename {
+			continue
+		}
+		_, err := env.Blobstore().GetObject(ctx, integration.ExportDir, r)
+		if err == nil {
+			t.Fatalf("Should have been cleaned up %q: %v", r, err)
+		}
+		if !errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("Failed reading blob %q: %v", r, err)
+		}
+	}
+}


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-server/issues/250 and https://github.com/google/exposure-notifications-server/issues/243

This PR adds load test for cleanup exports. Worth noting that:
- Exports were "generated" slightly differently from a standard procedure(a.k.a. `/export` endpoint)
- Only added a single test scenario of 10000 exports + 3 keys in each
- The new functions in `integration.go` were copy/pasted from their old locations

/cc @stati0n 
