### PR TITLE
Implement ExposureKey revisions

### DIFF
--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -482,7 +482,7 @@ func TestKeysInBatch(t *testing.T) {
 	}
 
 	// Add the keys to the database.
-	if err := publishdb.New(testDB).InsertExposures(ctx, []*publishmodel.Exposure{sek, eek}); err != nil {
+	if _, err := publishdb.New(testDB).InsertAndReviseExposures(ctx, []*publishmodel.Exposure{sek, eek}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/federationin/federationin_test.go
+++ b/internal/federationin/federationin_test.go
@@ -70,9 +70,9 @@ type publishDB struct {
 	exposures []*publishmodel.Exposure
 }
 
-func (idb *publishDB) insertExposures(ctx context.Context, exposures []*publishmodel.Exposure) error {
+func (idb *publishDB) insertExposures(ctx context.Context, exposures []*publishmodel.Exposure) (int, error) {
 	idb.exposures = append(idb.exposures, exposures...)
-	return nil
+	return len(exposures), nil
 }
 
 // syncDB mocks the database, recording start and complete invocations for a sync record.
@@ -293,7 +293,7 @@ func TestFederationPull(t *testing.T) {
 				t.Fatalf("pull returned err=%v, want err=nil", err)
 			}
 
-			if diff := cmp.Diff(tc.wantExposures, idb.exposures, cmpopts.IgnoreFields(publishmodel.Exposure{}, "CreatedAt")); diff != "" {
+			if diff := cmp.Diff(tc.wantExposures, idb.exposures, cmpopts.IgnoreFields(publishmodel.Exposure{}, "CreatedAt"), cmpopts.IgnoreUnexported(publishmodel.Exposure{})); diff != "" {
 				t.Errorf("exposures mismatch (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantTokens, remote.gotTokens); diff != "" {

--- a/internal/generate/handler.go
+++ b/internal/generate/handler.go
@@ -121,7 +121,7 @@ func (h *generateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		err = h.database.InsertExposures(ctx, exposures)
+		n, err := h.database.InsertAndReviseExposures(ctx, exposures)
 		if err != nil {
 			message := fmt.Sprintf("error writing exposure record: %v", err)
 			span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: message})
@@ -129,7 +129,7 @@ func (h *generateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, message)
 			return
 		}
-		logger.Infof("Generated %v exposures", len(exposures))
+		logger.Infof("Generated %v exposures", n)
 	}
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, "Generated exposure keys.")

--- a/internal/integration/publish_test.go
+++ b/internal/integration/publish_test.go
@@ -228,7 +228,7 @@ func alterExposureCreatedAt(t *testing.T, ctx context.Context, db *database.DB,
 			return fmt.Errorf("failed deleting exposure %v: %v", m.ExposureKey, err)
 		}
 		m.CreatedAt = m.CreatedAt.Add(timeDelta)
-		if err := publishdb.New(db).InsertExposures(ctx, []*publishmodel.Exposure{m}); err != nil {
+		if _, err := publishdb.New(db).InsertAndReviseExposures(ctx, []*publishmodel.Exposure{m}); err != nil {
 			return fmt.Errorf("failed inserting exposure %v with updated creation time: %v",
 				m.ExposureKey, err)
 		}

--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -26,13 +26,15 @@ import (
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	pgx "github.com/jackc/pgx/v4"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 var (
-	approxTime = cmp.Options{cmpopts.EquateApproxTime(time.Second)}
+	approxTime               = cmp.Options{cmpopts.EquateApproxTime(time.Second)}
+	ignoreUnexportedExposure = cmpopts.IgnoreUnexported(model.Exposure{})
 )
 
 func TestReadExposures(t *testing.T) {
@@ -62,7 +64,7 @@ func TestReadExposures(t *testing.T) {
 			LocalProvenance: true,
 		},
 	}
-	if err := testPublishDB.InsertExposures(ctx, exposures); err != nil {
+	if _, err := testPublishDB.InsertAndReviseExposures(ctx, exposures); err != nil {
 		t.Fatal(err)
 	}
 
@@ -71,7 +73,12 @@ func TestReadExposures(t *testing.T) {
 		keys = append(keys, e.ExposureKeyBase64())
 	}
 
-	readBack, err := testPublishDB.ReadExposures(ctx, keys)
+	var readBack map[string]*model.Exposure
+	err := testDB.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
+		var err error
+		readBack, err = testPublishDB.ReadExposures(ctx, tx, keys)
+		return err
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +95,7 @@ func TestReadExposures(t *testing.T) {
 		return out
 	})
 
-	if diff := cmp.Diff(exposures, got, approxTime, sorter); diff != "" {
+	if diff := cmp.Diff(exposures, got, approxTime, sorter, ignoreUnexportedExposure); diff != "" {
 		t.Errorf("ReadExposures mismatch (-want, +got):\n%s", diff)
 	}
 }
@@ -136,7 +143,7 @@ func TestExposures(t *testing.T) {
 			LocalProvenance: false,
 		},
 	}
-	if err := testPublishDB.InsertExposures(ctx, exposures); err != nil {
+	if _, err := testPublishDB.InsertAndReviseExposures(ctx, exposures); err != nil {
 		t.Fatal(err)
 	}
 
@@ -186,7 +193,7 @@ func TestExposures(t *testing.T) {
 		for _, i := range test.want {
 			want = append(want, exposures[i])
 		}
-		if diff := cmp.Diff(want, got); diff != "" {
+		if diff := cmp.Diff(want, got, ignoreUnexportedExposure); diff != "" {
 			t.Errorf("%+v: mismatch (-want, +got):\n%s", test.criteria, diff)
 		}
 	}
@@ -204,7 +211,7 @@ func TestExposures(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(exposures[2:], got); diff != "" {
+	if diff := cmp.Diff(exposures[2:], got, ignoreUnexportedExposure); diff != "" {
 		t.Errorf("DeleteExposuresBefore: mismatch (-want, +got):\n%s", diff)
 	}
 }
@@ -242,15 +249,24 @@ func TestReviseExposures(t *testing.T) {
 		ReportType:       verifyapi.ReportTypeClinical,
 	}
 	existingExp.SetDaysSinceSymptomOnset(0)
-	if err := pubDB.InsertExposures(ctx, []*model.Exposure{existingExp}); err != nil {
+	if n, err := pubDB.InsertAndReviseExposures(ctx, []*model.Exposure{existingExp}); err != nil {
 		t.Fatalf("error inserting exposures: %v", err)
+	} else if n != 1 {
+		t.Fatalf("wrong number of changed exposures, want: 1, got: %v", n)
 	}
 
 	// Modify the existing on in place.
-	existingExp.SetRevisedReportType(verifyapi.ReportTypeConfirmed)
-	existingExp.RevisedAt = &revisedAt
-	existingExp.SetRevisedDaysSinceSymptomOnset(0)
-	existingExp.SetRevisedTransmissionRisk(verifyapi.TransmissionRiskConfirmedStandard)
+	revisedExp := &model.Exposure{
+		ExposureKey:      []byte{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4},
+		TransmissionRisk: verifyapi.TransmissionRiskConfirmedStandard,
+		AppPackageName:   "foo.bar",
+		Regions:          []string{"US", "CA", "MX"},
+		IntervalNumber:   100,
+		IntervalCount:    144,
+		CreatedAt:        revisedAt,
+		LocalProvenance:  true,
+		ReportType:       verifyapi.ReportTypeConfirmed,
+	}
 	// Add a new TEK to insert.
 	newExp := &model.Exposure{
 		ExposureKey:      []byte{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5},
@@ -265,14 +281,21 @@ func TestReviseExposures(t *testing.T) {
 	}
 	newExp.SetDaysSinceSymptomOnset(1)
 
-	revisions := []*model.Exposure{existingExp, newExp}
-	if err := pubDB.ReviseExposures(ctx, revisions); err != nil {
+	revisions := []*model.Exposure{revisedExp, newExp}
+	if n, err := pubDB.InsertAndReviseExposures(ctx, revisions); err != nil {
 		t.Fatalf("error revising exposures: %v", err)
+	} else if n != 2 {
+		t.Fatalf("wrong number of changed exposures, want: 2, got: %v", n)
 	}
 
 	// Read back and compare.
 	expectedKeys := []string{existingExp.ExposureKeyBase64(), newExp.ExposureKeyBase64()}
-	got, err := pubDB.ReadExposures(ctx, expectedKeys)
+	var got map[string]*model.Exposure
+	err := testDB.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
+		var err error
+		got, err = pubDB.ReadExposures(ctx, tx, expectedKeys)
+		return err
+	})
 	if err != nil {
 		t.Fatalf("error reading exposures: %v", err)
 	}
@@ -281,16 +304,22 @@ func TestReviseExposures(t *testing.T) {
 		t.Fatalf("didn't read back both exposures, got: %v", l)
 	}
 
-	for _, want := range revisions {
-		if diff := cmp.Diff(want, got[want.ExposureKeyBase64()]); diff != "" {
+	want := []*model.Exposure{existingExp, newExp}
+	// need to modify the exitingExp to match what we expect to get back.
+	existingExp.SetRevisedTransmissionRisk(verifyapi.TransmissionRiskConfirmedStandard)
+	existingExp.SetRevisedAt(revisedAt)
+	existingExp.SetRevisedReportType(verifyapi.ReportTypeConfirmed)
+
+	for i := 0; i <= 1; i++ {
+		if diff := cmp.Diff(want[i], got[want[i].ExposureKeyBase64()], ignoreUnexportedExposure); diff != "" {
 			t.Errorf("mismatch (-want, +got):\n%s", diff)
 		}
 	}
 
 	// Attempt to revise the already revised key.
-	if err := pubDB.ReviseExposures(ctx, []*model.Exposure{existingExp}); err == nil {
+	if _, err := pubDB.InsertAndReviseExposures(ctx, []*model.Exposure{revisedExp}); err == nil {
 		t.Fatalf("expected error on revising already revised key, got nil")
-	} else if !strings.Contains(err.Error(), "invalid key revision request") {
+	} else if !strings.Contains(err.Error(), "key has already been revised ") {
 		t.Fatalf("wrong error, want 'invalid key revision request', got: %v", err)
 	}
 }
@@ -320,7 +349,7 @@ func TestIterateExposuresCursor(t *testing.T) {
 			Regions:        []string{"MX", "CA"},
 		},
 	}
-	if err := testPublishDB.InsertExposures(ctx, exposures); err != nil {
+	if _, err := testPublishDB.InsertAndReviseExposures(ctx, exposures); err != nil {
 		t.Fatal(err)
 	}
 	// Iterate over them, canceling the context in the middle.
@@ -335,7 +364,7 @@ func TestIterateExposuresCursor(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("got %v, wanted context.Canceled", err)
 	}
-	if diff := cmp.Diff(exposures[:2], seen); diff != "" {
+	if diff := cmp.Diff(exposures[:2], seen, ignoreUnexportedExposure); diff != "" {
 		t.Fatalf("exposures mismatch (-want, +got):\n%s", diff)
 	}
 	if want := encodeCursor("2"); cursor != want {
@@ -349,7 +378,7 @@ func TestIterateExposuresCursor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(exposures[2:], seen); diff != "" {
+	if diff := cmp.Diff(exposures[2:], seen, ignoreUnexportedExposure); diff != "" {
 		t.Fatalf("exposures mismatch (-want, +got):\n%s", diff)
 	}
 	if cursor != "" {

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -18,7 +18,6 @@ package model
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -33,10 +32,10 @@ import (
 )
 
 var (
-	ErrorExposureKeyMismatch     = errors.New("attempted to revise a key with a different key")
-	ErrorHealthAuthorityMismatch = errors.New("key revisition attempted by different health authority")
-	ErrorNonLocalProvenance      = errors.New("key not origionally uploaded to this server, cannot revise")
-	ErrorKeyAlreadyRevised       = errors.New("key has already been revised and cannot be revised again")
+	ErrorExposureKeyMismatch     = fmt.Errorf("attempted to revise a key with a different key")
+	ErrorHealthAuthorityMismatch = fmt.Errorf("key revisition attempted by different health authority")
+	ErrorNonLocalProvenance      = fmt.Errorf("key not origionally uploaded to this server, cannot revise")
+	ErrorKeyAlreadyRevised       = fmt.Errorf("key has already been revised and cannot be revised again")
 )
 
 // Exposure represents the record as stored in the database
@@ -62,6 +61,9 @@ type Exposure struct {
 	RevisedAt                    *time.Time
 	RevisedDaysSinceSymptomOnset *int32
 	RevisedTransmissionRisk      *int
+
+	// b64 key
+	base64Key string
 }
 
 // Revise updates the Revised fields of a key
@@ -159,7 +161,10 @@ func (e *Exposure) SetRevisedTransmissionRisk(tr int) {
 
 // ExposureKeyBase64 returns the ExposuerKey property base64 encoded.
 func (e *Exposure) ExposureKeyBase64() string {
-	return base64.StdEncoding.EncodeToString(e.ExposureKey)
+	if e.base64Key == "" {
+		e.base64Key = base64.StdEncoding.EncodeToString(e.ExposureKey)
+	}
+	return e.base64Key
 }
 
 // ApplyTransmissionRiskOverrides modifies the transmission risk values in the publish request

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -18,6 +18,7 @@ package model
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -29,6 +30,13 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+)
+
+var (
+	ErrorExposureKeyMismatch     = errors.New("attempted to revise a key with a different key")
+	ErrorHealthAuthorityMismatch = errors.New("key revisition attempted by different health authority")
+	ErrorNonLocalProvenance      = errors.New("key not origionally uploaded to this server, cannot revise")
+	ErrorKeyAlreadyRevised       = errors.New("key has already been revised and cannot be revised again")
 )
 
 // Exposure represents the record as stored in the database
@@ -45,12 +53,64 @@ type Exposure struct {
 
 	// These fileds are nullable to maintain backwards compatibility with
 	// older versions that predate their existence.
-	HealthAuthorityID            *int64
-	ReportType                   string
-	DaysSinceSymptomOnset        *int32
+	HealthAuthorityID     *int64
+	ReportType            string
+	DaysSinceSymptomOnset *int32
+
+	// Fields to support key revision.
 	RevisedReportType            *string
 	RevisedAt                    *time.Time
-	RevisedDaysSinceSymptomOnset *int
+	RevisedDaysSinceSymptomOnset *int32
+	RevisedTransmissionRisk      *int
+}
+
+// Revise updates the Revised fields of a key
+func (e *Exposure) Revise(in *Exposure) (bool, error) {
+	if e.ExposureKeyBase64() != in.ExposureKeyBase64() {
+		return false, ErrorExposureKeyMismatch
+	}
+	// key doesn't need to be revised if there is no change.
+	if e.ReportType == in.ReportType {
+		return false, nil
+	}
+	if !e.LocalProvenance {
+		return false, ErrorNonLocalProvenance
+	}
+	// make sure key hasn't been revised already.
+	if e.RevisedAt != nil {
+		return false, ErrorKeyAlreadyRevised
+	}
+
+	// Check to see if this is a valid transition.
+	if !(e.ReportType == verifyapi.ReportTypeClinical && (in.ReportType == verifyapi.ReportTypeConfirmed || in.ReportType == verifyapi.ReportTypeNegative)) {
+		return false, fmt.Errorf("invalid report type transition, cannot transition from '%v' to '%v'", e.ReportType, in.ReportType)
+	}
+
+	// Update fields.
+	// Key is potentially revised by a different health authority.
+	e.HealthAuthorityID = in.HealthAuthorityID
+	// If there are new regions in the incoming version, add them to the previous on.
+	// Regions are not removed however.
+	e.AddMissingRegions(in.Regions)
+	e.RevisedReportType = &in.ReportType
+	e.RevisedAt = &in.CreatedAt
+	e.RevisedDaysSinceSymptomOnset = in.DaysSinceSymptomOnset
+	e.RevisedTransmissionRisk = &in.TransmissionRisk
+
+	return true, nil
+}
+
+func (e *Exposure) AddMissingRegions(regions []string) {
+	m := make(map[string]struct{})
+	for _, r := range e.Regions {
+		m[r] = struct{}{}
+	}
+	for _, r := range regions {
+		if _, ok := m[r]; !ok {
+			m[r] = struct{}{}
+			e.Regions = append(e.Regions, r)
+		}
+	}
 }
 
 // HasDaysSinceSymptomOnset returns true if the this key has the days since
@@ -62,10 +122,7 @@ func (e *Exposure) HasDaysSinceSymptomOnset() bool {
 // SetDaysSinceSymptomOnset sets the days since sympton onset field, possibly
 // allocating a new pointer.
 func (e *Exposure) SetDaysSinceSymptomOnset(d int32) {
-	if e.DaysSinceSymptomOnset == nil {
-		e.DaysSinceSymptomOnset = new(int32)
-	}
-	*e.DaysSinceSymptomOnset = d
+	e.DaysSinceSymptomOnset = &d
 }
 
 func (e *Exposure) HasHealthAuthorityID() bool {
@@ -73,10 +130,31 @@ func (e *Exposure) HasHealthAuthorityID() bool {
 }
 
 func (e *Exposure) SetHealthAuthorityID(haID int64) {
-	if e.HealthAuthorityID == nil {
-		e.HealthAuthorityID = new(int64)
+	e.HealthAuthorityID = &haID
+}
+
+func (e *Exposure) HasBeenRevised() bool {
+	return e.RevisedAt != nil
+}
+
+func (e *Exposure) SetRevisedAt(t time.Time) error {
+	if e.RevisedAt != nil {
+		return fmt.Errorf("exposure key has already been revised and cannot be revised again")
 	}
-	*e.HealthAuthorityID = haID
+	e.RevisedAt = &t
+	return nil
+}
+
+func (e *Exposure) SetRevisedReportType(rt string) {
+	e.RevisedReportType = &rt
+}
+
+func (e *Exposure) SetRevisedDaysSinceSymptomOnset(d int32) {
+	e.RevisedDaysSinceSymptomOnset = &d
+}
+
+func (e *Exposure) SetRevisedTransmissionRisk(tr int) {
+	e.RevisedTransmissionRisk = &tr
 }
 
 // ExposureKeyBase64 returns the ExposuerKey property base64 encoded.
@@ -264,11 +342,39 @@ func TransformExposureKey(exposureKey verifyapi.ExposureKey, appPackageName stri
 	}, nil
 }
 
-func (t *Transformer) ReviseKeys(ctx context.Context, existing map[string]*Exposure, incoming []*Exposure) ([]*Exposure, error) {
-	// TODO(mikehelmick): Implement revise keys functionality.
-	// output := make([]*Exposure, 0, len(incoming))
+// ReviseKeys takes a set of existing keys, and a list of keys currently being uploaded.
+// Only keys that need to be revsised or are being created fir the first time
+// are returned in the output set.
+func ReviseKeys(ctx context.Context, existing map[string]*Exposure, incoming []*Exposure) ([]*Exposure, error) {
+	//logger := logging.FromContext(ctx)
+	output := make([]*Exposure, 0, len(incoming))
 
-	return nil, fmt.Errorf("KEY REVISION NOT YET IMPLEMENTED")
+	// Iterate over incoming keys.
+	// If the key already exists
+	//  - determine if it needs to be revised, revise it, put in output.
+	//  - if it doesn't need to be revised (nochange), don't put in putput
+	// New keys, throw it in the output list. Party on.
+	for _, inExposure := range incoming {
+		prevExposure, ok := existing[inExposure.ExposureKeyBase64()]
+		if !ok {
+			output = append(output, inExposure)
+			continue
+		}
+
+		// Attempt to revise this key.
+		keyRevised, err := prevExposure.Revise(inExposure)
+		if err != nil {
+			return nil, err
+		}
+		if !keyRevised {
+			// key hasn't changed, carry on.
+			continue
+		}
+		// Revision worked, add the revised key to the output list.
+		output = append(output, prevExposure)
+	}
+
+	return output, nil
 }
 
 func ReportTypeTransmissionRisk(reportType string, providedTR int) int {

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 const (
@@ -723,7 +724,7 @@ func TestTransform(t *testing.T) {
 				t.Fatalf("TransformPublish returned unexpected error: %v", err)
 			}
 
-			if diff := cmp.Diff(tc.Want, got); diff != "" {
+			if diff := cmp.Diff(tc.Want, got, cmpopts.IgnoreUnexported(Exposure{})); diff != "" {
 				t.Errorf("TransformPublish mismatch (-want +got):\n%v", diff)
 			}
 		})
@@ -1230,7 +1231,7 @@ func TestReviseKeys(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(want, got); diff != "" {
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(Exposure{})); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%s", diff)
 	}
 }
@@ -1348,7 +1349,7 @@ func TestExposureReview(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(tc.want, tc.previous); diff != "" {
+			if diff := cmp.Diff(tc.want, tc.previous, cmpopts.IgnoreUnexported(Exposure{})); diff != "" {
 				t.Errorf("mismatch (-want, +got):\n%s", diff)
 			}
 		})

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -417,9 +417,11 @@ func TestReportTypeToTransmissionRisk(t *testing.T) {
 	}
 }
 
-func int32Ptr(v int32) *int32 { return &v }
-
-func int64Ptr(v int64) *int64 { return &v }
+func intPtr(v int) *int              { return &v }
+func int32Ptr(v int32) *int32        { return &v }
+func int64Ptr(v int64) *int64        { return &v }
+func timePtr(t time.Time) *time.Time { return &t }
+func stringPtr(s string) *string     { return &s }
 
 func TestTransform(t *testing.T) {
 	captureStartTime := time.Date(2020, 2, 29, 11, 15, 1, 0, time.UTC)
@@ -1135,6 +1137,219 @@ func TestDaysFromSymptomOnset(t *testing.T) {
 			got := DaysFromSymptomOnset(tc.onset, tc.check)
 			if tc.want != got {
 				t.Fatalf("wrong day instance between %v and %v, got: %v want: %v", tc.onset, tc.check, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReviseKeys(t *testing.T) {
+	createdAt := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Hour)
+	revisedAt := time.Now().UTC().Truncate(time.Hour)
+
+	allExposures := make([]*Exposure, 4)
+	// The "existing" key that isn't in the revision set.
+	allExposures[0] = &Exposure{
+		ExposureKey: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+	}
+	// Existing key that is in the revision set
+	allExposures[1] = &Exposure{
+		ExposureKey:       []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		TransmissionRisk:  0,
+		Regions:           []string{"US"},
+		IntervalNumber:    7,
+		IntervalCount:     144,
+		CreatedAt:         createdAt,
+		LocalProvenance:   true,
+		HealthAuthorityID: int64Ptr(2),
+		ReportType:        verifyapi.ReportTypeClinical,
+	}
+	// New version of existing key
+	allExposures[2] = &Exposure{
+		ExposureKey:       []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+		TransmissionRisk:  2,
+		Regions:           []string{"US"},
+		IntervalNumber:    7,
+		IntervalCount:     144,
+		CreatedAt:         revisedAt,
+		LocalProvenance:   true,
+		HealthAuthorityID: int64Ptr(2),
+		ReportType:        verifyapi.ReportTypeConfirmed,
+	}
+	// New key not in existing set.
+	allExposures[3] = &Exposure{
+		ExposureKey:       []byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+		TransmissionRisk:  0,
+		Regions:           []string{"US"},
+		IntervalNumber:    8,
+		IntervalCount:     144,
+		CreatedAt:         createdAt,
+		LocalProvenance:   true,
+		HealthAuthorityID: int64Ptr(2),
+		ReportType:        verifyapi.ReportTypeConfirmed,
+	}
+
+	ctx := context.Background()
+	existing := make(map[string]*Exposure)
+	existing[allExposures[0].ExposureKeyBase64()] = allExposures[0]
+	existing[allExposures[1].ExposureKeyBase64()] = allExposures[1]
+
+	incoming := make([]*Exposure, 2)
+	incoming[0] = allExposures[2]
+	incoming[1] = allExposures[3]
+
+	got, err := ReviseKeys(ctx, existing, incoming)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []*Exposure{
+		{
+			ExposureKey:             []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+			TransmissionRisk:        0,
+			Regions:                 []string{"US"},
+			IntervalNumber:          7,
+			IntervalCount:           144,
+			CreatedAt:               createdAt,
+			LocalProvenance:         true,
+			HealthAuthorityID:       int64Ptr(2),
+			ReportType:              verifyapi.ReportTypeClinical,
+			RevisedAt:               &revisedAt,
+			RevisedReportType:       stringPtr(verifyapi.ReportTypeConfirmed),
+			RevisedTransmissionRisk: intPtr(2),
+		},
+		{
+			ExposureKey:       []byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+			TransmissionRisk:  0,
+			Regions:           []string{"US"},
+			IntervalNumber:    8,
+			IntervalCount:     144,
+			CreatedAt:         createdAt,
+			LocalProvenance:   true,
+			HealthAuthorityID: int64Ptr(2),
+			ReportType:        verifyapi.ReportTypeConfirmed,
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestExposureReview(t *testing.T) {
+	createdAt := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Hour)
+	revisedAt := time.Now().UTC().Add(time.Hour).Truncate(time.Hour)
+
+	cases := []struct {
+		name          string
+		previous      *Exposure
+		incoming      *Exposure
+		want          *Exposure
+		needsRevision bool
+		err           string
+	}{
+		{
+			name: "matching_report_type",
+			previous: &Exposure{
+				ReportType: verifyapi.ReportTypeConfirmed,
+			},
+			incoming: &Exposure{
+				ReportType: verifyapi.ReportTypeConfirmed,
+			},
+			needsRevision: false,
+			err:           "",
+		},
+		{
+			name: "invalid_provenance",
+			previous: &Exposure{
+				ReportType: verifyapi.ReportTypeClinical,
+			},
+			incoming: &Exposure{
+				ReportType: verifyapi.ReportTypeConfirmed,
+			},
+			needsRevision: false,
+			err:           ErrorNonLocalProvenance.Error(),
+		},
+		{
+			name: "already_revised",
+			previous: &Exposure{
+				ReportType:      verifyapi.ReportTypeClinical,
+				LocalProvenance: true,
+				RevisedAt:       timePtr(time.Now().UTC()),
+			},
+			incoming: &Exposure{
+				ReportType: verifyapi.ReportTypeConfirmed,
+			},
+			needsRevision: false,
+			err:           ErrorKeyAlreadyRevised.Error(),
+		},
+		{
+			name: "invalid_transition_confirmed_to_clinical",
+			previous: &Exposure{
+				ReportType:      verifyapi.ReportTypeConfirmed,
+				LocalProvenance: true,
+			},
+			incoming: &Exposure{
+				ReportType: verifyapi.ReportTypeClinical,
+			},
+			needsRevision: false,
+			err:           "invalid report type transition, cannot transition from 'confirmed' to 'likely'",
+		},
+		{
+			name: "revise_key",
+			previous: &Exposure{
+				ReportType:            verifyapi.ReportTypeClinical,
+				LocalProvenance:       true,
+				HealthAuthorityID:     int64Ptr(2),
+				Regions:               []string{"US", "CA"},
+				TransmissionRisk:      4,
+				CreatedAt:             createdAt,
+				DaysSinceSymptomOnset: int32Ptr(-1),
+			},
+			incoming: &Exposure{
+				ReportType:            verifyapi.ReportTypeConfirmed,
+				HealthAuthorityID:     int64Ptr(3),
+				Regions:               []string{"MX"},
+				TransmissionRisk:      5,
+				CreatedAt:             revisedAt,
+				DaysSinceSymptomOnset: int32Ptr(0),
+			},
+			want: &Exposure{
+				ReportType:                   verifyapi.ReportTypeClinical,
+				LocalProvenance:              true,
+				HealthAuthorityID:            int64Ptr(3),
+				Regions:                      []string{"US", "CA", "MX"},
+				TransmissionRisk:             4,
+				CreatedAt:                    createdAt,
+				DaysSinceSymptomOnset:        int32Ptr(-1),
+				RevisedReportType:            stringPtr(verifyapi.ReportTypeConfirmed),
+				RevisedAt:                    &revisedAt,
+				RevisedDaysSinceSymptomOnset: int32Ptr(0),
+				RevisedTransmissionRisk:      intPtr(5),
+			},
+			needsRevision: true,
+			err:           "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := tc.previous.Revise(tc.incoming)
+			if result != tc.needsRevision {
+				t.Errorf("revision decision mismatch: want: %v got: %v", tc.needsRevision, result)
+			}
+			if err != nil && tc.err == "" {
+				t.Fatalf("unexpected error: %v", err)
+			} else if err != nil && !strings.Contains(err.Error(), tc.err) {
+				t.Fatalf("wrong error: want '%v', got: '%v'", tc.err, err)
+			} else if err == nil && tc.err != "" {
+				t.Fatalf("expected error: want '%v', got: nil", tc.err)
+			}
+			if tc.err != "" || !tc.needsRevision {
+				return
+			}
+
+			if diff := cmp.Diff(tc.want, tc.previous); diff != "" {
+				t.Errorf("mismatch (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -186,7 +186,7 @@ func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) r
 	if len(existingExposures) == 0 {
 		writeFn = func() error { return h.database.InsertExposures(ctx, exposures) }
 	} else {
-		revised, err := h.transformer.ReviseKeys(ctx, existingExposures, exposures)
+		revised, err := model.ReviseKeys(ctx, existingExposures, exposures)
 		if err != nil {
 			message := fmt.Sprintf("unable to revise keys: %v", err)
 			logger.Errorf(message)

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -486,7 +486,7 @@ func TestPublishWithBypass(t *testing.T) {
 				})
 				ignoreCreatedAt := cmpopts.IgnoreFields(*want[0], "CreatedAt")
 
-				if diff := cmp.Diff(want, got, sorter, ignoreCreatedAt); diff != "" {
+				if diff := cmp.Diff(want, got, sorter, ignoreCreatedAt, cmpopts.IgnoreUnexported(model.Exposure{})); diff != "" {
 					t.Errorf("mismatch (-want, +got):\n%s", diff)
 				}
 			} else {

--- a/migrations/000032_add_revised_transmission_risk.down.sql
+++ b/migrations/000032_add_revised_transmission_risk.down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE exposure
+	DROP COLUMN revised_transmission_risk INT;
+
+END;

--- a/migrations/000032_add_revised_transmission_risk.up.sql
+++ b/migrations/000032_add_revised_transmission_risk.up.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE exposure
+	ADD COLUMN revised_transmission_risk INT;
+
+END;


### PR DESCRIPTION
* Publish API changes
 * Transform still validates the incoming request
 * If any of the uploaded keys have previously been seen, join and figure out changes
 * perform upsert over the new keys

More work on #663