### PR TITLE
Treat empty reportType as likely for purposes of key revision.

### DIFF
--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -86,7 +86,11 @@ func (e *Exposure) Revise(in *Exposure) (bool, error) {
 	}
 
 	// Check to see if this is a valid transition.
-	if !(e.ReportType == verifyapi.ReportTypeClinical && (in.ReportType == verifyapi.ReportTypeConfirmed || in.ReportType == verifyapi.ReportTypeNegative)) {
+	eReportType := e.ReportType
+	if eReportType == "" {
+		eReportType = verifyapi.ReportTypeClinical
+	}
+	if !(eReportType == verifyapi.ReportTypeClinical && (in.ReportType == verifyapi.ReportTypeConfirmed || in.ReportType == verifyapi.ReportTypeNegative)) {
 		return false, fmt.Errorf("invalid report type transition, cannot transition from '%v' to '%v'", e.ReportType, in.ReportType)
 	}
 
@@ -99,7 +103,8 @@ func (e *Exposure) Revise(in *Exposure) (bool, error) {
 	e.RevisedReportType = &in.ReportType
 	e.RevisedAt = &in.CreatedAt
 	e.RevisedDaysSinceSymptomOnset = in.DaysSinceSymptomOnset
-	e.RevisedTransmissionRisk = &in.TransmissionRisk
+	tr := ReportTypeTransmissionRisk(in.ReportType, in.TransmissionRisk)
+	e.RevisedTransmissionRisk = &tr
 
 	return true, nil
 }

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -1312,6 +1312,37 @@ func TestExposureReview(t *testing.T) {
 			err:           "invalid report type transition, cannot transition from 'confirmed' to 'likely'",
 		},
 		{
+			name: "invalid_transition_from_empty_report_type",
+			previous: &Exposure{
+				ReportType:      "",
+				LocalProvenance: true,
+			},
+			incoming: &Exposure{
+				ReportType: verifyapi.ReportTypeClinical,
+			},
+			needsRevision: false,
+			err:           "invalid report type transition, cannot transition from '' to 'likely'",
+		},
+		{
+			name: "valid_transition_from_empty_report_type",
+			previous: &Exposure{
+				ReportType:      "",
+				LocalProvenance: true,
+			},
+			incoming: &Exposure{
+				ReportType: verifyapi.ReportTypeConfirmed,
+				CreatedAt:  revisedAt,
+			},
+			want: &Exposure{
+				ReportType:              "",
+				LocalProvenance:         true,
+				RevisedReportType:       stringPtr(verifyapi.ReportTypeConfirmed),
+				RevisedAt:               &revisedAt,
+				RevisedTransmissionRisk: intPtr(verifyapi.TransmissionRiskConfirmedStandard),
+			},
+			needsRevision: true,
+		},
+		{
 			name: "revise_key",
 			previous: &Exposure{
 				ReportType:            verifyapi.ReportTypeClinical,


### PR DESCRIPTION
Fixes #738