### PR TITLE
Setup mako for uploading load test metrics to server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.10.0
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.0
+	github.com/google/mako v0.2.0
 	github.com/hashicorp/go-hclog v0.13.0
 	github.com/hashicorp/go-memdb v1.2.1 // indirect
 	github.com/hashicorp/go-msgpack v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -413,6 +413,7 @@ github.com/golang-migrate/migrate/v4 v4.10.0 h1:76R6UL3BGnDTpYeittMtfpaNvGBH5zMZ
 github.com/golang-migrate/migrate/v4 v4.10.0/go.mod h1:Llx0NRzBKs/zbR/Pc0huEpJA2195sJVkGU5dCyjQ678=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -500,6 +501,8 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/mako v0.2.0 h1:Uz42n/jOU68xJXzvhqAQ4Fny4YZNRDEicfIIaE2Twvg=
+github.com/google/mako v0.2.0/go.mod h1:YzLcVlL+NqWnmUEPuhS1LxDDwGO9WNbVlEXaF4IH35g=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0 h1:pMen7vLs8nvgEYhywH3KDWJIJTeEr2ULsVWHWYHQyBs=

--- a/internal/performance/export_test_benchmark.config
+++ b/internal/performance/export_test_benchmark.config
@@ -14,10 +14,20 @@
 #
 # For assistance using the command line tool see go/mako-help.
 #
+
+# Development benchmark configs. Uncomment lines below and comment lines below
+# `Prod benchmark configs` for debugging.
+# benchmark_name: "Development Export"
+# benchmark_key: "5698752440434688"
+
+# Prod benchmark configs
 benchmark_name: "Export"
+benchmark_key: "4790091207671808"
+
 project_name: "Exposure Notifications Server"
 owner_list: "kgood@google.com"
 owner_list: "chaodai@google.com"
+owner_list: "prow-mako-service-account@oss-prow-build-apollo-server.iam.gserviceaccount.com"
 input_value_info: {
   value_key: "t"
   label: "time"
@@ -27,4 +37,8 @@ metric_info_list: {
   value_key: "m1"
   label: "Time_to_generate_file_ms"
 }
-description: "Exposure Notifications Server's time to generate export file"
+metric_info_list: {
+  value_key: "m2"
+  label: "Time_to_cleanup_export_ms"
+}
+description: "Exposure Notifications Server's time to measure export/cleanup"

--- a/internal/performance/helper.go
+++ b/internal/performance/helper.go
@@ -1,3 +1,5 @@
+// +build performance
+
 // Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +25,10 @@ import (
 	"testing"
 	"time"
 
+	// Warning: package github.com/golang/protobuf/proto is deprecated: Use the
+	// "google.golang.org/protobuf/proto" package instead.  (SA1019).
+	// Use deprecated package as mako isn't compatible with
+	// github.com/golang/protobuf/proto yet
 	"github.com/golang/protobuf/proto"
 	"github.com/google/mako/go/quickstore"
 

--- a/internal/performance/helper.go
+++ b/internal/performance/helper.go
@@ -42,10 +42,7 @@ const (
 
 // setup sets up client used for performance test
 func setup(tb testing.TB) (*quickstore.Quickstore, func(context.Context)) {
-	var (
-		microservice string
-	)
-
+	var microservice string
 	benchmarkConfig := &mpb.BenchmarkInfo{}
 
 	{

--- a/internal/performance/helper.go
+++ b/internal/performance/helper.go
@@ -1,0 +1,95 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package performance
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/mako/go/quickstore"
+
+	qpb "github.com/google/mako/proto/quickstore/quickstore_go_proto"
+	mpb "github.com/google/mako/spec/proto/mako_go_proto"
+)
+
+const (
+	benchmarkConfigFile = "export_test_benchmark.config"
+)
+
+// setup sets up client used for performance test
+func setup(tb testing.TB) (*quickstore.Quickstore, func(context.Context)) {
+	var (
+		microservice string
+	)
+
+	benchmarkConfig := &mpb.BenchmarkInfo{}
+
+	{
+		p := os.Getenv("MAKO_PORT")
+		if p == "" {
+			tb.Fatal("Env var MAKO_PORT is required.")
+		}
+		port, err := strconv.Atoi(p)
+		if err != nil {
+			tb.Fatalf("Could not parse MAKO_PORT env var: %v", err)
+		}
+		microservice = fmt.Sprintf("localhost:%d", port)
+	}
+
+	{
+		data, err := ioutil.ReadFile(benchmarkConfigFile)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		if err = proto.UnmarshalText(string(data), benchmarkConfig); err != nil {
+			tb.Fatal(err)
+		}
+	}
+
+	ctx := context.Background()
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	input := &qpb.QuickstoreInput{
+		BenchmarkKey: proto.String(*benchmarkConfig.BenchmarkKey),
+	}
+
+	q, close, err := quickstore.NewAtAddress(ctxWithTimeout, input, microservice)
+	if err != nil {
+		tb.Fatalf("quickstore.NewAtAddress() = %v", err)
+	}
+	return q, close
+}
+
+func store(tb testing.TB, q *quickstore.Quickstore) {
+	out, err := q.Store()
+	if err != nil {
+		tb.Fatalf("quickstore Store() = %s", err)
+	}
+	switch out.GetStatus() {
+	case qpb.QuickstoreOutput_SUCCESS:
+		tb.Logf("Done! Run can be found at: %s\n", out.GetRunChartLink())
+	case qpb.QuickstoreOutput_ERROR:
+		tb.Fatalf("quickstore Store() output error: %s\n", out.GetSummaryOutput())
+	case qpb.QuickstoreOutput_ANALYSIS_FAIL:
+		tb.Fatalf("Quickstore analysis failure: %s\nRun can be found at: %s\n", out.GetSummaryOutput(), out.GetRunChartLink())
+	}
+}

--- a/scripts/performance.sh
+++ b/scripts/performance.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eEuo pipefail
+
+echo "🌳 Set up environment variables"
+# Docker image build
+# instruction(https://github.com/google/mako/blob/v0.2.0/docs/GUIDE.md#quickstore-microservice-as-a-docker-image)
+# for mako microservice is currently broken according to mako maintainers. This
+# image was craned from gcr.io/knative-tests/test-infra/mako-microservice
+export MAKO_IMAGE="gcr.io/oss-prow-build-apollo-server/test/performance/mako-microservice"
+export MAKO_PORT="9347"
+if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  echo "✋ GOOGLE_APPLICATION_CREDENTIALS must be set"
+  exit 1
+fi
+
+echo "🔨 Start mako microservice"
+docker \
+  run \
+  --rm \
+  -v \
+  ${GOOGLE_APPLICATION_CREDENTIALS}:/root/adc.json \
+  -e \
+  "GOOGLE_APPLICATION_CREDENTIALS=/root/adc.json" \
+  -p \
+  ${MAKO_PORT}:9813 \
+  ${MAKO_IMAGE} \
+  &
+
+echo "🧪 Test"
+make performance-test


### PR DESCRIPTION
This PR injects performance test metrics to https://mako.dev, so that the results can be visualized there as well. 

This had been tested locally and performance metrics was uploaded to mako server, which could be visualized at https://mako.dev/benchmark?benchmark_key=5698752440434688. (Note: for faster turnaround time, the data for this was from 1000 publishes instead of 100000 in real test)

/assign @sethvargo @mikehelmick 
/cc @stati0n 