### PR TITLE
Install gcloud in presubmit test image, use gcloud authenticating with docker

### DIFF
--- a/docker/presubmit-test.dockerfile
+++ b/docker/presubmit-test.dockerfile
@@ -19,6 +19,21 @@ FROM golang:1.14
 # Install sudo
 RUN apt-get update -yqq && apt-get install -yqq sudo
 
+# Install gcloud
+ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
+    tar xzf google-cloud-sdk.tar.gz -C / && \
+    rm google-cloud-sdk.tar.gz && \
+    /google-cloud-sdk/install.sh \
+        --disable-installation-options \
+        --bash-completion=false \
+        --path-update=false \
+        --usage-reporting=false && \
+    gcloud components install alpha beta kubectl && \
+    gcloud info | tee /workspace/gcloud-info.txt
+
 #
 # BEGIN: DOCKER IN DOCKER SETUP
 #

--- a/scripts/performance.sh
+++ b/scripts/performance.sh
@@ -29,6 +29,9 @@ if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
 fi
 
 echo "🔨 Start mako microservice"
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+gcloud auth configure-docker
+
 docker \
   run \
   --rm \


### PR DESCRIPTION
Mako microservice image used for performance test needs authentication to be pulled from GCR, this PR adds steps for authenticating with GCR.

Like the docker-in-docker setup steps, gcloud installation command also comes out of https://github.com/kubernetes/test-infra/blob/2388ca759f423413495bd7ab42b20f9f39ec7700/images/bootstrap/Dockerfile#L54. 

/assign @sethvargo 
/cc @stati0n 