### PR TITLE
Fix dockerfile for presubmit-test by adding missing path

### DIFF
--- a/docker/presubmit-test.dockerfile
+++ b/docker/presubmit-test.dockerfile
@@ -20,6 +20,9 @@ FROM golang:1.14
 RUN apt-get update -yqq && apt-get install -yqq sudo
 
 # Install gcloud
+WORKDIR /workspace
+RUN mkdir -p /workspace
+
 ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
     CLOUDSDK_CORE_DISABLE_PROMPTS=1
 


### PR DESCRIPTION
Fixing a missing path from https://github.com/google/exposure-notifications-server/pull/772