### PR TITLE
Fix performance test package, prevent future breakages by compiling in presubmit test

### DIFF
--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -136,7 +136,8 @@ func TestExport(t *testing.T) {
 			m.ExposureKey, _ = base64util.DecodeString(newKey.Key)
 			revisedExposures = append(revisedExposures, &m)
 		}
-		updated, err := publishdb.New(db).InsertAndReviseExposures(ctx, revisedExposures)
+		updated, err := publishdb.New(db).InsertAndReviseExposures(ctx, revisedExposures,
+			nil, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -63,6 +63,8 @@ make spellcheck || {
 
 echo "🔨 Building"
 go build ./...
+# Compiling *_test.go files with performance tag
+go test -c -tags=performance ./internal/performance/...
 
 
 echo "🌌 Verify and tidy module"


### PR DESCRIPTION
Performance test package was broken due to #771 , this PR fixes the API usage and adds a step in presubmit test for verifying that performance test package can compile