### PR TITLE
Fix presubmit test bug to surface error message better

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -32,12 +32,11 @@ ${ROOT}/scripts/dev protoc
 
 
 echo "📚 Fetch dependencies"
-OUT="$(go get -t ./... 2>&1)"
-if [ $? -ne 0 ]; then
+OUT="$(go get -t ./... 2>&1)" || {
   echo "✋ Error fetching dependencies"
   echo "\n\n${OUT}\n\n"
   exit 1
-fi
+}
 
 
 echo "🧹 Verify formatting"
@@ -68,12 +67,11 @@ go test -c -tags=performance ./internal/performance/...
 
 
 echo "🌌 Verify and tidy module"
-OUT="$(go mod verify 2>&1 && go mod tidy 2>&1)"
-if [ $? -ne 0 ]; then
+OUT="$(go mod verify 2>&1 && go mod tidy 2>&1)" || {
   echo "✋ Error validating module"
   echo "\n\n${OUT}\n\n"
   exit 1
-fi
+}
 OUT="$(git diff go.mod)"
 if [ -n "${OUT}" ]; then
   echo "✋ go.mod is out of sync - run 'go mod tidy'."


### PR DESCRIPTION
presubmit.sh script already has errexit set, so the script exits right away when the exit code of a command is non-zero. This makes checking exit code such as `$?` afterwards being noop, thus the error message would never get hit. Fixing this so that the error messages are surfaced

An example of this problem: https://oss-prow.knative.dev/view/gs/oss-prow/pr-logs/pull/google_exposure-notifications-server/789/pull-en-server-release-unit/1288924239646167040