### PR TITLE
V1api

### DIFF
--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -51,25 +51,16 @@ func realMain(ctx context.Context) error {
 	}
 	defer env.Close(ctx)
 
-	if !(config.EnableV1API || config.EnableV1Alpha1API) {
-		return fmt.Errorf("no APIs enabled, must set one or more of ENABLE_V1_API, ENABLE_V1ALPHA1_API")
-	}
-
 	mux := http.NewServeMux()
+	handler, err := publish.NewHandler(ctx, &config, env)
+	if err != nil {
+		return fmt.Errorf("publish.NewHandler: %w", err)
+	}
+	// Serving of v1alpha1 is on by default, but can be disabled through env var.
 	if config.EnableV1Alpha1API {
-		handler, err := publish.NewV1Alpha1Handler(ctx, &config, env)
-		if err != nil {
-			return fmt.Errorf("publish.NewHandler: %w", err)
-		}
-		mux.Handle("/", handler)
+		mux.Handle("/", handler.HandleV1Alpha1())
 	}
-	if config.EnableV1API {
-		handler, err := publish.NewV1Handler(ctx, &config, env)
-		if err != nil {
-			return fmt.Errorf("publish.NewHandler: %w", err)
-		}
-		mux.Handle("/v1/publish", handler)
-	}
+	mux.Handle("/v1/publish", handler.Handle())
 
 	srv, err := server.New(config.Port)
 	if err != nil {

--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -51,13 +51,25 @@ func realMain(ctx context.Context) error {
 	}
 	defer env.Close(ctx)
 
-	handler, err := publish.NewHandler(ctx, &config, env)
-	if err != nil {
-		return fmt.Errorf("publish.NewHandler: %w", err)
+	if !(config.EnableV1API || config.EnableV1Alpha1API) {
+		return fmt.Errorf("no APIs enabled, must set one or more of ENABLE_V1_API, ENABLE_V1ALPHA1_API")
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/", handler)
+	if config.EnableV1Alpha1API {
+		handler, err := publish.NewV1Alpha1Handler(ctx, &config, env)
+		if err != nil {
+			return fmt.Errorf("publish.NewHandler: %w", err)
+		}
+		mux.Handle("/", handler)
+	}
+	if config.EnableV1API {
+		handler, err := publish.NewV1Handler(ctx, &config, env)
+		if err != nil {
+			return fmt.Errorf("publish.NewHandler: %w", err)
+		}
+		mux.Handle("/v1/publish", handler)
+	}
 
 	srv, err := server.New(config.Port)
 	if err != nil {

--- a/internal/admin/authorizedapps/save.go
+++ b/internal/admin/authorizedapps/save.go
@@ -68,7 +68,7 @@ func (h *saveController) Execute(c *gin.Context) {
 		if len(errors) > 0 {
 			m.AddErrors(errors...)
 			m["app"] = authApp
-			// Load the health authorities.
+			// Load the health authorities into m for display on the edit form.
 			if err := addHealthAuthorityInfo(ctx, verdb.New(h.env.Database()), authApp, m); err != nil {
 				admin.ErrorPage(c, err.Error())
 				return

--- a/internal/admin/authorizedapps/save.go
+++ b/internal/admin/authorizedapps/save.go
@@ -68,6 +68,11 @@ func (h *saveController) Execute(c *gin.Context) {
 		if len(errors) > 0 {
 			m.AddErrors(errors...)
 			m["app"] = authApp
+			// Load the health authorities.
+			if err := addHealthAuthorityInfo(ctx, verdb.New(h.env.Database()), authApp, m); err != nil {
+				admin.ErrorPage(c, err.Error())
+				return
+			}
 			c.HTML(http.StatusOK, "authorizedapp", m)
 			return
 		}

--- a/internal/admin/authorizedapps/view.go
+++ b/internal/admin/authorizedapps/view.go
@@ -62,7 +62,7 @@ func (h *viewController) Execute(c *gin.Context) {
 	authorizedApp := model.NewAuthorizedApp()
 
 	if appID == "" {
-		m.AddJumbotron("Authorized Applications", "Create New Authorized Application")
+		m.AddJumbotron("Authorized Health Authorities", "Create New Authorized Health Authority")
 		m["new"] = true
 	} else {
 		aadb := database.New(h.env.Database())
@@ -72,7 +72,7 @@ func (h *viewController) Execute(c *gin.Context) {
 			admin.ErrorPage(c, err.Error())
 			return
 		}
-		m.AddJumbotron("Authorized Applications", fmt.Sprintf("Edit: `%v`", authorizedApp.AppPackageName))
+		m.AddJumbotron("Authorized Health Authorities", fmt.Sprintf("Edit: `%v`", authorizedApp.AppPackageName))
 	}
 
 	// Load the health authorities.

--- a/internal/authorizedapp/model/authorized_app_model.go
+++ b/internal/authorizedapp/model/authorized_app_model.go
@@ -66,7 +66,10 @@ func (c *AuthorizedApp) AllAllowedHealthAuthorityIDs() []int64 {
 func (c *AuthorizedApp) Validate() []string {
 	errors := make([]string, 0)
 	if c.AppPackageName == "" {
-		errors = append(errors, "AppPackageName cannot be empty")
+		errors = append(errors, "Health Authority ID cannot be empty")
+	}
+	if len(c.AllowedRegions) == 0 {
+		errors = append(errors, "Regions list cannot be empty")
 	}
 	return errors
 }

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -118,7 +118,7 @@ func (s *Server) exportBatch(ctx context.Context, eb *model.ExportBatch, emitInd
 		UntilTimestamp:      eb.EndTimestamp,
 		IncludeRegions:      eb.EffectiveInputRegions(),
 		OnlyLocalProvenance: false, // include federated ids
-		RevisedKeys:         false,
+		OnlyRevisedKeys:     false,
 	}
 
 	// Build up groups of exposures in memory. We need to use memory so we can
@@ -143,7 +143,7 @@ func (s *Server) exportBatch(ctx context.Context, eb *model.ExportBatch, emitInd
 	}
 
 	// go get the revised keys.
-	criteria.RevisedKeys = true
+	criteria.OnlyRevisedKeys = true
 	_, err = publishdatabase.New(db).IterateExposures(ctx, criteria, func(exp *publishmodel.Exposure) error {
 		nextGroup.revised = append(nextGroup.revised, exp)
 		totalRevisedKeys++

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
 
 // Client provides Exposure Notifications API client to support

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -31,22 +31,28 @@ type Client struct {
 	client *http.Client
 }
 
-func (c *Client) PublishKeys(payload *verifyapi.Publish) error {
+func (c *Client) PublishKeys(payload *verifyapi.Publish) (*verifyapi.PublishResponse, error) {
 	j, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("failed to marshal json: %w", err)
+		return nil, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	resp, err := c.client.Post("/publish", "application/json", bytes.NewReader(j))
 	if err != nil {
-		return fmt.Errorf("failed to POST /publish: %w", err)
+		return nil, fmt.Errorf("failed to POST /publish: %w", err)
 	}
 
 	body, err := checkResp(resp)
 	if err != nil {
-		return fmt.Errorf("failed to POST /publish: %w: %s", err, body)
+		return nil, fmt.Errorf("failed to POST /publish: %w: %s", err, body)
 	}
-	return nil
+
+	var pubResponse verifyapi.PublishResponse
+	if err := json.Unmarshal(body, &pubResponse); err != nil {
+		return nil, fmt.Errorf("bad publish response")
+	}
+
+	return &pubResponse, nil
 }
 
 func (c *Client) CleanupExposures() error {

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -230,11 +230,11 @@ func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client) {
 		RevisionKeyCacheDuration: time.Second,
 	}
 
-	publishHandler, err := publish.NewV1Handler(ctx, publishConfig, env)
+	publishHandler, err := publish.NewHandler(ctx, publishConfig, env)
 	if err != nil {
 		tb.Fatal(err)
 	}
-	mux.Handle("/publish", publishHandler)
+	mux.Handle("/publish", publishHandler.Handle())
 
 	srv, err := server.New("")
 	if err != nil {

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -230,7 +230,7 @@ func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client) {
 		RevisionKeyCacheDuration: time.Second,
 	}
 
-	publishHandler, err := publish.NewHandler(ctx, publishConfig, env)
+	publishHandler, err := publish.NewV1Handler(ctx, publishConfig, env)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -31,7 +31,7 @@ import (
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/storage"
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-server/pkg/util"
 	"github.com/google/go-cmp/cmp"
@@ -54,9 +54,8 @@ func TestIntegration(t *testing.T) {
 
 	// Publish 3 keys
 	payload := &verifyapi.Publish{
-		Keys:           util.GenerateExposureKeys(3, -1, false),
-		Regions:        []string{"TEST"},
-		AppPackageName: "com.example.app",
+		Keys:              util.GenerateExposureKeys(3, -1, false),
+		HealthAuthorityID: "com.example.app",
 
 		// TODO: hook up verification
 		VerificationPayload: "TODO",

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -60,8 +60,10 @@ func TestIntegration(t *testing.T) {
 		// TODO: hook up verification
 		VerificationPayload: "TODO",
 	}
-	if err := client.PublishKeys(payload); err != nil {
+	if resp, err := client.PublishKeys(payload); err != nil {
 		t.Fatal(err)
+	} else {
+		t.Logf("response: %+v", resp)
 	}
 
 	// Assert there are 3 exposures in the database
@@ -204,8 +206,10 @@ func TestIntegration(t *testing.T) {
 
 	// Publish some new keys so we can generate a new batch
 	payload.Keys = util.GenerateExposureKeys(3, -1, false)
-	if err := client.PublishKeys(payload); err != nil {
+	if resp, err := client.PublishKeys(payload); err != nil {
 		t.Fatal(err)
+	} else {
+		t.Logf("response: %+v", resp)
 	}
 
 	// Assert there are 5 exposures in the database

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -30,7 +30,7 @@ import (
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/storage"
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-server/pkg/util"
 	pgx "github.com/jackc/pgx/v4"
@@ -62,9 +62,8 @@ func TestExport(t *testing.T) {
 
 	env, client, db := integration.NewTestServer(t, exportPeriod)
 	payload := &verifyapi.Publish{
-		Keys:           util.GenerateExposureKeys(keysPerPublish, -1, false),
-		Regions:        []string{"TEST"},
-		AppPackageName: "com.example.app",
+		Keys:              util.GenerateExposureKeys(keysPerPublish, -1, false),
+		HealthAuthorityID: "com.example.app",
 
 		// TODO: hook up verification
 		VerificationPayload: "TODO: ",

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -68,7 +68,7 @@ func TestExport(t *testing.T) {
 		// TODO: hook up verification
 		VerificationPayload: "TODO: ",
 	}
-	if err := client.PublishKeys(payload); err != nil {
+	if _, err := client.PublishKeys(payload); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -58,6 +58,14 @@ type Config struct {
 
 	RevisionKeyCacheDuration time.Duration `env:"REVISION_KEY_CACHE_DURATION, default=1m"`
 
+	// API Versions.
+	EnableV1Alpha1API bool `env:"ENABLE_V1ALPHA1_API, default=true"`
+	EnableV1API       bool `env:"ENABLE_V1_API, default=true"`
+
+	// If set and if a publish request has no regions. This default will be assumed.
+	// Should only be set if a server is being operated in a single region.
+	DefaultRegion string `env:"DEFAULT_REGION"`
+
 	// Flags for local development and testing. This will cause still valid keys
 	// to not be embargoed.
 	// Normally "still valid" keys can be accepted, but are embargoed.

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -60,9 +60,10 @@ type Config struct {
 
 	// API Versions.
 	EnableV1Alpha1API bool `env:"ENABLE_V1ALPHA1_API, default=true"`
-	EnableV1API       bool `env:"ENABLE_V1_API, default=true"`
 
-	// If set and if a publish request has no regions. This default will be assumed.
+	// If set and if a publish request has no regions (v1alpha1) and the health authority
+	// has no regions configured, then this default will be assumed.
+	// This is present for an upgrade edgecase where empty region list used to mean "all regions"
 	// Should only be set if a server is being operated in a single region.
 	DefaultRegion string `env:"DEFAULT_REGION"`
 

--- a/internal/publish/database/exposure.go
+++ b/internal/publish/database/exposure.go
@@ -51,12 +51,14 @@ func New(db *database.DB) *PublishDB {
 
 // IterateExposuresCriteria is criteria to iterate exposures.
 type IterateExposuresCriteria struct {
-	IncludeRegions []string
-	ExcludeRegions []string
-	SinceTimestamp time.Time
-	UntilTimestamp time.Time
-	LastCursor     string
-	RevisedKeys    bool // If true, only revised keys that match will be selected.
+	IncludeRegions   []string
+	IncludeTravelers bool // Include records in the IncludeRegions OR travallers
+	OnlyTravelers    bool // Only includes records marked as travelers.
+	ExcludeRegions   []string
+	SinceTimestamp   time.Time
+	UntilTimestamp   time.Time
+	LastCursor       string
+	RevisedKeys      bool // If true, only revised keys that match will be selected.
 
 	// OnlyLocalProvenance indicates that only exposures with LocalProvenance=true will be returned.
 	OnlyLocalProvenance bool
@@ -113,9 +115,9 @@ func (db *PublishDB) IterateExposures(ctx context.Context, criteria IterateExpos
 			var m model.Exposure
 			var encodedKey string
 			var syncID *int64
-			if err := rows.Scan(&encodedKey, &m.TransmissionRisk, &m.AppPackageName, &m.Regions, &m.IntervalNumber,
-				&m.IntervalCount, &m.CreatedAt, &m.LocalProvenance, &syncID, &m.HealthAuthorityID, &m.ReportType,
-				&m.DaysSinceSymptomOnset, &m.RevisedReportType, &m.RevisedAt, &m.RevisedDaysSinceSymptomOnset); err != nil {
+			if err := rows.Scan(&encodedKey, &m.TransmissionRisk, &m.AppPackageName, &m.Regions, &m.Traveler,
+				&m.IntervalNumber, &m.IntervalCount, &m.CreatedAt, &m.LocalProvenance, &syncID, &m.HealthAuthorityID,
+				&m.ReportType, &m.DaysSinceSymptomOnset, &m.RevisedReportType, &m.RevisedAt, &m.RevisedDaysSinceSymptomOnset); err != nil {
 				return fmt.Errorf("failed to parse: %w", err)
 			}
 
@@ -145,7 +147,8 @@ func generateExposureQuery(criteria IterateExposuresCriteria) (string, []interfa
 	var args []interface{}
 	q := `
 		SELECT
-			exposure_key, transmission_risk, LOWER(app_package_name), regions, interval_number, interval_count,
+			exposure_key, transmission_risk, LOWER(app_package_name), regions, traveler,
+			interval_number, interval_count,
 			created_at, local_provenance, sync_id, health_authority_id, report_type,
 			days_since_symptom_onset, revised_report_type, revised_at, revised_days_since_symptom_onset
 		FROM
@@ -154,8 +157,14 @@ func generateExposureQuery(criteria IterateExposuresCriteria) (string, []interfa
 	`
 
 	if len(criteria.IncludeRegions) == 1 {
-		args = append(args, criteria.IncludeRegions)
-		q += fmt.Sprintf(" AND (regions && $%d)", len(args)) // Operation "&&" means "array overlaps / intersects"
+		if criteria.IncludeTravelers {
+			args = append(args, criteria.IncludeRegions)
+			args = append(args, true)
+			q += fmt.Sprintf(" AND ((regions && $%d) OR traveler = $%d)", len(args)-1, len(args)) // Operation "&&" means "array overlaps / intersects"
+		} else {
+			args = append(args, criteria.IncludeRegions)
+			q += fmt.Sprintf(" AND (regions && $%d)", len(args)) // Operation "&&" means "array overlaps / intersects"
+		}
 	}
 
 	if len(criteria.ExcludeRegions) == 1 {
@@ -189,7 +198,16 @@ func generateExposureQuery(criteria IterateExposuresCriteria) (string, []interfa
 		q += fmt.Sprintf(" AND local_provenance = $%d", len(args))
 	}
 
-	q += " ORDER BY created_at"
+	if criteria.OnlyTravelers {
+		args = append(args, true)
+		q += fmt.Sprintf(" AND traveler = $%d", len(args))
+	}
+
+	if criteria.RevisedKeys {
+		q += " ORDER BY revised_at"
+	} else {
+		q += " ORDER BY created_at"
+	}
 
 	if criteria.LastCursor != "" {
 		decoded, err := decodeCursor(criteria.LastCursor)
@@ -214,7 +232,7 @@ func (db *PublishDB) ReadExposures(ctx context.Context, tx pgx.Tx, b64keys []str
 	if err := db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT
-				exposure_key, transmission_risk, app_package_name, regions,
+				exposure_key, transmission_risk, app_package_name, regions, traveler,
 				interval_number, interval_count, created_at, local_provenance, sync_id,
 				health_authority_id, report_type, days_since_symptom_onset,
 				revised_report_type, revised_at, revised_days_since_symptom_onset,
@@ -240,7 +258,7 @@ func (db *PublishDB) ReadExposures(ctx context.Context, tx pgx.Tx, b64keys []str
 			var exposure model.Exposure
 			if err := rows.Scan(
 				&encodedKey, &exposure.TransmissionRisk, &exposure.AppPackageName,
-				&exposure.Regions, &exposure.IntervalNumber, &exposure.IntervalCount,
+				&exposure.Regions, &exposure.Traveler, &exposure.IntervalNumber, &exposure.IntervalCount,
 				&exposure.CreatedAt, &exposure.LocalProvenance, &syncID,
 				&exposure.HealthAuthorityID, &exposure.ReportType, &exposure.DaysSinceSymptomOnset,
 				&exposure.RevisedReportType, &exposure.RevisedAt, &exposure.RevisedDaysSinceSymptomOnset,
@@ -275,10 +293,10 @@ func prepareInsertExposure(ctx context.Context, tx pgx.Tx) (string, error) {
 	_, err := tx.Prepare(ctx, stmtName, `
 		INSERT INTO
 			Exposure
-				(exposure_key, transmission_risk, app_package_name, regions, interval_number, interval_count,
+				(exposure_key, transmission_risk, app_package_name, regions, traveler, interval_number, interval_count,
 				 created_at, local_provenance, sync_id, health_authority_id, report_type, days_since_symptom_onset)
 		VALUES
-			($1, $2, LOWER($3), $4, $5, $6, $7, $8, $9, $10, $11, $12)
+			($1, $2, LOWER($3), $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 		ON CONFLICT (exposure_key) DO NOTHING
 	`)
 	return stmtName, err
@@ -290,7 +308,7 @@ func executeInsertExposure(ctx context.Context, tx pgx.Tx, stmtName string, exp 
 		syncID = &exp.FederationSyncID
 	}
 	_, err := tx.Exec(ctx, stmtName, encodeExposureKey(exp.ExposureKey), exp.TransmissionRisk,
-		exp.AppPackageName, exp.Regions, exp.IntervalNumber, exp.IntervalCount,
+		exp.AppPackageName, exp.Regions, exp.Traveler, exp.IntervalNumber, exp.IntervalCount,
 		exp.CreatedAt, exp.LocalProvenance, syncID,
 		exp.HealthAuthorityID, exp.ReportType, exp.DaysSinceSymptomOnset)
 	if err != nil {

--- a/internal/publish/database/exposure.go
+++ b/internal/publish/database/exposure.go
@@ -52,13 +52,13 @@ func New(db *database.DB) *PublishDB {
 // IterateExposuresCriteria is criteria to iterate exposures.
 type IterateExposuresCriteria struct {
 	IncludeRegions   []string
-	IncludeTravelers bool // Include records in the IncludeRegions OR travallers
+	IncludeTravelers bool // Include records in the IncludeRegions OR travalers
 	OnlyTravelers    bool // Only includes records marked as travelers.
 	ExcludeRegions   []string
 	SinceTimestamp   time.Time
 	UntilTimestamp   time.Time
 	LastCursor       string
-	RevisedKeys      bool // If true, only revised keys that match will be selected.
+	OnlyRevisedKeys  bool // If true, only revised keys that match will be selected.
 
 	// OnlyLocalProvenance indicates that only exposures with LocalProvenance=true will be returned.
 	OnlyLocalProvenance bool
@@ -175,7 +175,7 @@ func generateExposureQuery(criteria IterateExposuresCriteria) (string, []interfa
 	}
 
 	timeField := "created_at"
-	if criteria.RevisedKeys {
+	if criteria.OnlyRevisedKeys {
 		q += " AND revised_at IS NOT NULL"
 		timeField = "revised_at"
 	}
@@ -205,7 +205,7 @@ func generateExposureQuery(criteria IterateExposuresCriteria) (string, []interfa
 		q += fmt.Sprintf(" AND traveler = $%d", len(args))
 	}
 
-	if criteria.RevisedKeys {
+	if criteria.OnlyRevisedKeys {
 		q += " ORDER BY revised_at"
 	} else {
 		q += " ORDER BY created_at"

--- a/internal/publish/database/exposure.go
+++ b/internal/publish/database/exposure.go
@@ -158,6 +158,8 @@ func generateExposureQuery(criteria IterateExposuresCriteria) (string, []interfa
 
 	if len(criteria.IncludeRegions) == 1 {
 		if criteria.IncludeTravelers {
+			// If the query has include ragions and include travelers set - we want the union of the specified regions and
+			// all "traveler" keys that this server knows about.
 			args = append(args, criteria.IncludeRegions)
 			args = append(args, true)
 			q += fmt.Sprintf(" AND ((regions && $%d) OR traveler = $%d)", len(args)-1, len(args)) // Operation "&&" means "array overlaps / intersects"

--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -54,6 +54,7 @@ func TestReadExposures(t *testing.T) {
 			IntervalCount:   144,
 			CreatedAt:       createdAt,
 			LocalProvenance: true,
+			Traveler:        true,
 		},
 		{
 			ExposureKey:     []byte("DEF456"),
@@ -62,6 +63,7 @@ func TestReadExposures(t *testing.T) {
 			IntervalCount:   144,
 			CreatedAt:       createdAt,
 			LocalProvenance: true,
+			Traveler:        true,
 		},
 	}
 	if _, err := testPublishDB.InsertAndReviseExposures(ctx, exposures, nil, true); err != nil {
@@ -121,6 +123,7 @@ func TestExposures(t *testing.T) {
 		{
 			ExposureKey:     []byte("DEF"),
 			Regions:         []string{"CA"},
+			Traveler:        true,
 			IntervalNumber:  118,
 			IntervalCount:   1,
 			CreatedAt:       batchTime.Add(1 * time.Hour),
@@ -140,6 +143,7 @@ func TestExposures(t *testing.T) {
 			IntervalCount:   3,
 			CreatedAt:       batchTime.Add(3 * time.Hour),
 			Regions:         []string{"US"},
+			Traveler:        true,
 			LocalProvenance: false,
 		},
 	}
@@ -183,6 +187,18 @@ func TestExposures(t *testing.T) {
 				SinceTimestamp: exposures[2].CreatedAt,
 			},
 			nil,
+		},
+		{
+			IterateExposuresCriteria{OnlyTravelers: true},
+			[]int{1, 3},
+		},
+		{
+			IterateExposuresCriteria{IncludeRegions: []string{"CA"}, IncludeTravelers: true},
+			[]int{0, 1, 2, 3},
+		},
+		{
+			IterateExposuresCriteria{OnlyLocalProvenance: true, OnlyTravelers: true},
+			[]int{1},
 		},
 	} {
 		got, err := listExposures(ctx, testPublishDB, test.criteria)

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -46,6 +46,7 @@ type Exposure struct {
 	TransmissionRisk int
 	AppPackageName   string
 	Regions          []string
+	Traveler         bool
 	IntervalNumber   int32
 	IntervalCount    int32
 	CreatedAt        time.Time
@@ -505,6 +506,7 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 				exposure.SetDaysSinceSymptomOnset(daysSince)
 			}
 		}
+		exposure.Traveler = inData.Traveler
 		entities = append(entities, exposure)
 	}
 

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -18,7 +18,6 @@ package publish
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -27,7 +26,6 @@ import (
 	"go.opencensus.io/trace"
 
 	"github.com/google/exposure-notifications-server/internal/authorizedapp"
-	"github.com/google/exposure-notifications-server/internal/jsonutil"
 	"github.com/google/exposure-notifications-server/internal/logging"
 	"github.com/google/exposure-notifications-server/internal/pb"
 	"github.com/google/exposure-notifications-server/internal/publish/database"
@@ -37,13 +35,15 @@ import (
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/internal/verification"
 	verifydb "github.com/google/exposure-notifications-server/internal/verification/database"
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/mikehelmick/go-chaff"
 )
 
-// NewHandler creates the HTTP handler for the TTK publishing API.
-func NewHandler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (http.Handler, error) {
+// newProcessor creates common API handler for the publish API.
+// This uses the latest version of the API and it is the responsibility of the
+// specific version handler to upgrade requests and downgrade responses.
+func newProcessor(ctx context.Context, config *Config, env *serverenv.ServerEnv) (*publishHandler, error) {
 	logger := logging.FromContext(ctx)
 
 	if env.Database() == nil {
@@ -114,40 +114,50 @@ type publishHandler struct {
 
 type response struct {
 	status      int
-	pubResponse *verifyapi.PublishResponse
+	pubResponse *v1.PublishResponse
 	metric      string
 	count       int // metricCount
 }
 
-func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) response {
-	ctx, span := trace.StartSpan(r.Context(), "(*publish.publishHandler).handleRequest")
+// versionBridge closes the gap in up-leveling v1alpha1 to v1 API.
+type versionBridge struct {
+	AdditionalRegions []string
+}
+
+func newVersionBridge(regions []string) *versionBridge {
+	b := versionBridge{
+		AdditionalRegions: make([]string, len(regions)),
+	}
+	copy(b.AdditionalRegions, regions)
+	return &b
+}
+
+// process runs the publish business logic over a "v1" version of the publish request
+// and knows how to join in data from previous versions (the provided versionBridge)
+func (h *publishHandler) process(ctx context.Context, data *v1.Publish, bridge *versionBridge) response {
+	ctx, span := trace.StartSpan(ctx, "(*publish.publishHandler).process")
 	defer span.End()
 
 	logger := logging.FromContext(ctx)
 	metrics := h.serverenv.MetricsExporter(ctx)
 
-	var data verifyapi.Publish
-	code, err := jsonutil.Unmarshal(w, r, &data)
-	if err != nil {
-		message := fmt.Sprintf("error unmarshaling API call, code: %v: %v", code, err)
-		span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: message})
-		return response{
-			status:      http.StatusBadRequest,
-			pubResponse: &verifyapi.PublishResponse{Error: message},
-			metric:      "publish-bad-json", count: 1}
-	}
-
-	appConfig, err := h.authorizedAppProvider.AppConfig(ctx, data.AppPackageName)
+	appConfig, err := h.authorizedAppProvider.AppConfig(ctx, data.HealthAuthorityID)
 	if err != nil {
 		// Config loaded, but app with that name isn't registered. This can also
 		// happen if the app was recently registered but the cache hasn't been
 		// refreshed.
 		if errors.Is(err, authorizedapp.ErrAppNotFound) {
-			message := fmt.Sprintf("unauthorized app: %v", data.AppPackageName)
+			message := fmt.Sprintf("unauthorized health authority: %v", data.HealthAuthorityID)
 			span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: message})
-			return response{status: http.StatusUnauthorized,
-				pubResponse: &verifyapi.PublishResponse{Error: message},
-				metric:      "publish-app-not-authorized", count: 1}
+			return response{
+				status: http.StatusUnauthorized,
+				pubResponse: &v1.PublishResponse{
+					ErrorMessage: message,
+					ErrorCode:    v1.ErrorUnknownHealthAuthorityID,
+				},
+				metric: "publish-health-authority-not-authorized",
+				count:  1,
+			}
 		}
 
 		// A higher-level configuration error occurred, likely while trying to read
@@ -155,58 +165,89 @@ func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) r
 		// isn't transient.
 		// This message (and logging) will only contain the AppPkgName from the request
 		// and no other data from the request.
-		message := fmt.Sprintf("no AuthorizedApp, dropping data: %v", err)
+		message := fmt.Sprintf("error loading health authority config: %v", err)
 		span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: message})
 		return response{
-			status:      http.StatusUnauthorized,
-			pubResponse: &verifyapi.PublishResponse{Error: message},
-			metric:      "publish-error-loading-authorizedapp",
-			count:       1,
+			status: http.StatusNotFound,
+			pubResponse: &v1.PublishResponse{
+				ErrorMessage: message,
+				ErrorCode:    v1.ErrorUnableToLoadHealthAuthority,
+			},
+			metric: "publish-error-loading-authorizedapp",
+			count:  1,
 		}
 	}
 
-	// Verify the request is from a permitted region.
-	if len(data.Regions) == 0 {
-		message := "no regions provided on publish request"
-		span.SetStatus(trace.Status{Code: trace.StatusCodePermissionDenied, Message: message})
-		return response{
-			status:      http.StatusBadRequest,
-			pubResponse: &verifyapi.PublishResponse{Error: message},
-			metric:      "publish-region-not-specified",
-			count:       1,
+	// In the v1 API - regions aren't passed. They may be passed from v1Apha1
+	var regions []string
+	if bridge != nil && len(bridge.AdditionalRegions) > 0 {
+		regions = bridge.AdditionalRegions
+		// Authorized regions only need to checked if they are coming in from the
+		// v1alpha1 version of the API.
+		for _, r := range regions {
+			if !appConfig.IsAllowedRegion(r) {
+				err := fmt.Errorf("app %v tried to write to unauthorized region %v", appConfig.AppPackageName, r)
+				message := fmt.Sprintf("verifying allowed regions: %v", err)
+				span.SetStatus(trace.Status{Code: trace.StatusCodePermissionDenied, Message: message})
+				return response{
+					status: http.StatusUnauthorized,
+					pubResponse: &v1.PublishResponse{
+						ErrorMessage: message, // Error code omitted, since this isn't in the v1 path.
+					},
+					metric: "publish-region-not-authorized",
+					count:  1,
+				}
+			}
 		}
 	}
-	for _, r := range data.Regions {
-		if !appConfig.IsAllowedRegion(r) {
-			err := fmt.Errorf("app %v tried to write to unauthorized region %v", appConfig.AppPackageName, r)
-			message := fmt.Sprintf("verifying allowed regions: %v", err)
-			span.SetStatus(trace.Status{Code: trace.StatusCodePermissionDenied, Message: message})
-			return response{
-				status:      http.StatusUnauthorized,
-				pubResponse: &verifyapi.PublishResponse{Error: message},
-				metric:      "publish-region-not-authorized",
-				count:       1,
-			}
+	// If regions is still empty (normal for v1 request), copy the regions from
+	// the authorized app config.
+	if len(regions) == 0 {
+		regions = appConfig.AllAllowedRegions()
+	}
+	// And - worse case, still no regions and server default set.
+	if len(regions) == 0 && h.config.DefaultRegion != "" {
+		regions = append(regions, h.config.DefaultRegion)
+	}
+
+	// Verify that there is at least one region set by API call or by one of the
+	// generous defaults. If there isn't a region set, then the TEKs
+	// won't be retrievable, so we ensure there is something set.
+	if len(regions) == 0 {
+		message := fmt.Sprintf("unknown health authority regions for %v", data.HealthAuthorityID)
+		span.SetStatus(trace.Status{Code: trace.StatusCodePermissionDenied, Message: message})
+		return response{
+			status: http.StatusBadRequest,
+			pubResponse: &v1.PublishResponse{
+				ErrorMessage: message,
+				ErrorCode:    v1.ErrorHealthAuthorityMissingRegionConfiguration,
+			},
+			metric: "publish-region-not-specified",
+			count:  1,
 		}
 	}
 
 	// Perform health authority certificate verification.
-	verifiedClaims, err := h.verifier.VerifyDiagnosisCertificate(ctx, appConfig, &data)
+	verifiedClaims, err := h.verifier.VerifyDiagnosisCertificate(ctx, appConfig, data)
 	if err != nil {
 		if appConfig.BypassHealthAuthorityVerification {
-			logger.Warnf("bypassing health authority certificate verification for app: %v", appConfig.AppPackageName)
+			logger.Warnf("bypassing health authority certificate verification health authority: %v", appConfig.AppPackageName)
 			metrics.WriteInt("publish-health-authority-verification-bypassed", true, 1)
 		} else {
 			message := fmt.Sprintf("unable to validate diagnosis verification: %v", err)
+			logger.Error(message)
 			span.SetStatus(trace.Status{Code: trace.StatusCodeInvalidArgument, Message: message})
 			return response{
-				status:      http.StatusUnauthorized,
-				pubResponse: &verifyapi.PublishResponse{Error: message},
-				metric:      "publish-bad-verification", count: 1}
+				status: http.StatusUnauthorized,
+				pubResponse: &v1.PublishResponse{
+					ErrorMessage: message,
+					ErrorCode:    v1.ErrorVerificationCertificateInvalid,
+				},
+				metric: "publish-bad-verification", count: 1}
 		}
 	}
 
-	// Examine the revision token.
+	// Examine the revision token. It is expected that it is missing in most cases.
 	var token *pb.RevisionTokenData
 	if len(data.RevisionToken) != 0 {
 		encryptedToken, err := base64util.DecodeString(data.RevisionToken)
@@ -222,26 +263,32 @@ func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) r
 	}
 
 	batchTime := time.Now()
-	exposures, err := h.transformer.TransformPublish(ctx, &data, verifiedClaims, batchTime)
+	exposures, err := h.transformer.TransformPublish(ctx, data, regions, verifiedClaims, batchTime)
 	if err != nil {
 		message := fmt.Sprintf("unable to read request data: %v", err)
-		logger.Errorf(message)
+		logger.Error(message)
 		span.SetStatus(trace.Status{Code: trace.StatusCodeInvalidArgument, Message: message})
 		return response{
-			status:      http.StatusBadRequest,
-			pubResponse: &verifyapi.PublishResponse{Error: message},
-			metric:      "publish-transform-fail", count: 1}
+			status: http.StatusBadRequest,
+			pubResponse: &v1.PublishResponse{
+				ErrorMessage: message,
+				ErrorCode:    v1.ErrorBadRequest,
+			},
+			metric: "publish-transform-fail", count: 1}
 	}
 
 	n, err := h.database.InsertAndReviseExposures(ctx, exposures, token, !appConfig.BypassRevisionToken)
 	if err != nil {
 		message := fmt.Sprintf("error writing exposure record: %v", err)
-		logger.Errorf(message)
+		logger.Error(message)
 		span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: message})
 		return response{
-			status:      http.StatusInternalServerError,
-			pubResponse: &verifyapi.PublishResponse{Error: http.StatusText(http.StatusInternalServerError)},
-			metric:      "publish-db-write-error", count: 1}
+			status: http.StatusInternalServerError,
+			pubResponse: &v1.PublishResponse{
+				ErrorMessage: http.StatusText(http.StatusInternalServerError),
+				ErrorCode:    v1.ErrorInternalError,
+			},
+			metric: "publish-db-write-error", count: 1}
 	}
 
 	// Build the new revision token. Union of existing token take + new exposures.
@@ -257,7 +304,10 @@ func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) r
 	}
 	newToken, err := h.tokenManager.MakeRevisionToken(ctx, &keep, exposures, h.tokenAAD)
 	if err != nil {
+		// In this case, an empty revision token is returned. The rest of the request
+		// was handled correctly.
 		logger.Errorf("unable to make new revision token: %v", err)
+		newToken = make([]byte, 0)
 	}
 
 	message := fmt.Sprintf("Inserted %d exposures.", n)
@@ -265,35 +315,11 @@ func (h *publishHandler) handleRequest(w http.ResponseWriter, r *http.Request) r
 	logger.Info(message)
 	return response{
 		status: http.StatusOK,
-		pubResponse: &verifyapi.PublishResponse{
+		pubResponse: &v1.PublishResponse{
 			RevisionToken:     base64.StdEncoding.EncodeToString(newToken),
 			InsertedExposures: n,
 		},
 		metric: "publish-exposures-written",
 		count:  n,
 	}
-}
-
-// ServeHTTP handles the publish event. It tracks requests and can handle chaff
-// requests when provided a request with the X-Chaff header.
-func (h *publishHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.tracker.HandleTrack(chaff.HeaderDetector("X-Chaff"),
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			response := h.handleRequest(w, r)
-
-			if response.metric != "" {
-				ctx := r.Context()
-				metrics := h.serverenv.MetricsExporter(ctx)
-				metrics.WriteInt(response.metric, true, response.count)
-			}
-
-			data, err := json.Marshal(response.pubResponse)
-			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprintf(w, "{\"error\": \"%v\"}", err.Error())
-				return
-			}
-			w.WriteHeader(response.status)
-			fmt.Fprintf(w, "%s", data)
-		})).ServeHTTP(w, r)
 }

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -196,7 +196,7 @@ func TestPublishWithBypass(t *testing.T) {
 		SkipVersions       map[version]bool
 	}{
 		{
-			Name:       "successful insert, bypass HA verification",
+			Name:       "successful_insert_bypass_ha_verification",
 			TestRegion: regions.next(),
 			AuthorizedApp: func() *aamodel.AuthorizedApp {
 				authApp := aamodel.NewAuthorizedApp()
@@ -209,7 +209,7 @@ func TestPublishWithBypass(t *testing.T) {
 				Keys:              util.GenerateExposureKeys(2, 5, false),
 				HealthAuthorityID: names.current(),
 			},
-			Regions: []string{"US"},
+			Regions: []string{regions.current()},
 			Code:    http.StatusOK,
 		},
 		{
@@ -584,7 +584,7 @@ func TestPublishWithBypass(t *testing.T) {
 					if resp.StatusCode == http.StatusOK {
 						// For success requests, verify that the exposures were inserted.
 						criteria := pubdb.IterateExposuresCriteria{
-							IncludeRegions: []string{"US"},
+							IncludeRegions: []string{tc.TestRegion},
 							SinceTimestamp: time.Now().Add(-1 * time.Minute),
 							UntilTimestamp: time.Now().Add(time.Minute),
 						}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -291,6 +291,7 @@ func TestPublishWithBypass(t *testing.T) {
 			Publish: verifyapi.Publish{
 				Keys:                util.GenerateExposureKeys(2, 5, false),
 				Regions:             []string{regions.current()},
+				Traveler:            true,
 				AppPackageName:      names.current(),
 				VerificationPayload: "totally not a JWT",
 			},
@@ -552,6 +553,7 @@ func TestPublishWithBypass(t *testing.T) {
 							IntervalNumber:   k.IntervalNumber,
 							IntervalCount:    k.IntervalCount,
 							Regions:          tc.Publish.Regions,
+							Traveler:         tc.Publish.Traveler,
 							LocalProvenance:  true,
 							FederationSyncID: 0,
 						}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -50,7 +50,8 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/util"
 
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
+	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 	utils "github.com/google/exposure-notifications-server/pkg/verification"
 
 	"github.com/dgrijalva/jwt-go"
@@ -65,6 +66,17 @@ type signingKey struct {
 	Key       *ecdsa.PrivateKey
 	PublicKey string
 }
+
+type version int
+
+const (
+	useV1 = iota
+	useV1Alpha1
+)
+
+var (
+	versions = []version{useV1, useV1Alpha1}
+)
 
 func newSigningKey(t *testing.T) *signingKey {
 	t.Helper()
@@ -88,12 +100,13 @@ func newSigningKey(t *testing.T) *signingKey {
 }
 
 type jwtConfig struct {
-	HealthAuthority    *vermodel.HealthAuthority
-	HealthAuthorityKey *vermodel.HealthAuthorityKey
-	Publish            *verifyapi.Publish
-	Key                *ecdsa.PrivateKey
-	JWTWarp            time.Duration
-	Overrides          verifyapi.TransmissionRiskVector
+	HealthAuthority      *vermodel.HealthAuthority
+	HealthAuthorityKey   *vermodel.HealthAuthorityKey
+	Publish              *verifyapi.Publish
+	Key                  *ecdsa.PrivateKey
+	JWTWarp              time.Duration
+	ReportType           string
+	SymptomOnsetInterval uint32
 }
 
 // Based on the publish request, generate a JWT as if it came from the
@@ -119,7 +132,12 @@ func issueJWT(t *testing.T, cfg jwtConfig) (jwtText, hmacKey string) {
 	claims.IssuedAt = time.Now().Add(cfg.JWTWarp).Unix()
 	claims.ExpiresAt = time.Now().Add(cfg.JWTWarp).Add(5 * time.Minute).Unix()
 	claims.SignedMAC = hmac
-	claims.TransmissionRisks = cfg.Overrides
+	if cfg.ReportType != "" {
+		claims.ReportType = cfg.ReportType
+	}
+	if cfg.SymptomOnsetInterval > 0 {
+		claims.SymptomOnsetInterval = cfg.SymptomOnsetInterval
+	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
 	token.Header[verifyapi.KeyIDHeader] = cfg.HealthAuthorityKey.Version
@@ -168,11 +186,14 @@ func TestPublishWithBypass(t *testing.T) {
 		HealthAuthorityKey *vermodel.HealthAuthorityKey // Automatically linked to SigningKey
 		AuthorizedApp      *aamodel.AuthorizedApp       // Automatically linked to health authorities.
 		Publish            verifyapi.Publish
+		Regions            []string
 		JWTTiming          time.Duration
-		Overrides          verifyapi.TransmissionRiskVector
+		ReportType         string
 		WantTRAdjustment   []int
 		Code               int
 		Error              string
+		ErrorCode          string
+		SkipVersions       map[version]bool
 	}{
 		{
 			Name:       "successful insert, bypass HA verification",
@@ -185,11 +206,11 @@ func TestPublishWithBypass(t *testing.T) {
 				return authApp
 			}(),
 			Publish: verifyapi.Publish{
-				Keys:           util.GenerateExposureKeys(2, 5, false),
-				Regions:        []string{regions.current()},
-				AppPackageName: names.current(),
+				Keys:              util.GenerateExposureKeys(2, 5, false),
+				HealthAuthorityID: names.current(),
 			},
-			Code: http.StatusOK,
+			Regions: []string{"US"},
+			Code:    http.StatusOK,
 		},
 		{
 			Name:        "invalid content type",
@@ -198,7 +219,7 @@ func TestPublishWithBypass(t *testing.T) {
 			Error:       "content-type is not application/json",
 		},
 		{
-			Name:       "missing_regions",
+			Name:       "defaulted_regions",
 			TestRegion: regions.next(),
 			AuthorizedApp: func() *aamodel.AuthorizedApp {
 				authApp := aamodel.NewAuthorizedApp()
@@ -208,15 +229,14 @@ func TestPublishWithBypass(t *testing.T) {
 				return authApp
 			}(),
 			Publish: verifyapi.Publish{
-				Keys:           util.GenerateExposureKeys(2, 5, false),
-				Regions:        []string{},
-				AppPackageName: names.current(),
+				Keys:              util.GenerateExposureKeys(2, 5, false),
+				HealthAuthorityID: names.current(),
 			},
-			Code:  http.StatusBadRequest,
-			Error: "no regions provided",
+			Regions: []string{},
+			Code:    http.StatusOK,
 		},
 		{
-			Name:       "bad app package name",
+			Name:       "bad_health_authority_id",
 			TestRegion: regions.next(),
 			AuthorizedApp: func() *aamodel.AuthorizedApp {
 				authApp := aamodel.NewAuthorizedApp()
@@ -226,15 +246,16 @@ func TestPublishWithBypass(t *testing.T) {
 				return authApp
 			}(),
 			Publish: verifyapi.Publish{
-				Keys:           util.GenerateExposureKeys(2, 5, false),
-				Regions:        []string{regions.current()},
-				AppPackageName: names.current() + "WRONG",
+				Keys:              util.GenerateExposureKeys(2, 5, false),
+				HealthAuthorityID: names.current() + "WRONG",
 			},
-			Code:  http.StatusUnauthorized,
-			Error: "unauthorized app",
+			Regions:   []string{"US"},
+			Code:      http.StatusUnauthorized,
+			Error:     "unauthorized health authority",
+			ErrorCode: "unknown_health_authority_id",
 		},
 		{
-			Name:       "write to unauthorized region",
+			Name:       "write_to_unauthorized_region",
 			TestRegion: regions.next(),
 			AuthorizedApp: func() *aamodel.AuthorizedApp {
 				authApp := aamodel.NewAuthorizedApp()
@@ -244,15 +265,16 @@ func TestPublishWithBypass(t *testing.T) {
 				return authApp
 			}(),
 			Publish: verifyapi.Publish{
-				Keys:           util.GenerateExposureKeys(2, 5, false),
-				Regions:        []string{regions.current() + "X"},
-				AppPackageName: names.current(),
+				Keys:              util.GenerateExposureKeys(2, 5, false),
+				HealthAuthorityID: names.current(),
 			},
-			Code:  http.StatusUnauthorized,
-			Error: "tried to write to unauthorized region " + regions.current() + "X",
+			Regions:      []string{regions.current() + "X"},
+			Code:         http.StatusUnauthorized,
+			Error:        "tried to write to unauthorized region " + regions.current() + "X",
+			SkipVersions: map[version]bool{useV1: true},
 		},
 		{
-			Name:       "bad HA certificate",
+			Name:       "bad_HA_certificate",
 			TestRegion: regions.next(),
 			AuthorizedApp: func() *aamodel.AuthorizedApp {
 				authApp := aamodel.NewAuthorizedApp()
@@ -262,12 +284,12 @@ func TestPublishWithBypass(t *testing.T) {
 			}(),
 			Publish: verifyapi.Publish{
 				Keys:                util.GenerateExposureKeys(2, 5, false),
-				Regions:             []string{regions.current()},
-				AppPackageName:      names.current(),
+				HealthAuthorityID:   names.current(),
 				VerificationPayload: "totally not a JWT",
 			},
-			Code:  http.StatusUnauthorized,
-			Error: "unable to validate diagnosis verification: token contains an invalid number of segments",
+			Regions: []string{regions.current()},
+			Code:    http.StatusUnauthorized,
+			Error:   "unable to validate diagnosis verification: token contains an invalid number of segments",
 		},
 		{
 			Name:       "valid_HA_certificate",
@@ -290,12 +312,12 @@ func TestPublishWithBypass(t *testing.T) {
 			}(),
 			Publish: verifyapi.Publish{
 				Keys:                util.GenerateExposureKeys(2, 5, false),
-				Regions:             []string{regions.current()},
 				Traveler:            true,
-				AppPackageName:      names.current(),
+				HealthAuthorityID:   names.current(),
 				VerificationPayload: "totally not a JWT",
 			},
-			Code: http.StatusOK,
+			Regions: []string{}, // will receive defaults
+			Code:    http.StatusOK,
 		},
 		{
 			Name:       "valid_HA_certificate_with_overrides",
@@ -317,18 +339,13 @@ func TestPublishWithBypass(t *testing.T) {
 				return authApp
 			}(),
 			Publish: verifyapi.Publish{
-				Keys:                util.GenerateExposureKeys(2, 5, false),
-				Regions:             []string{regions.current()},
-				AppPackageName:      names.current(),
+				Keys:                util.GenerateExposureKeys(2, 0, false),
+				HealthAuthorityID:   names.current(),
 				VerificationPayload: "totally not a JWT",
 			},
-			Overrides: []verifyapi.TransmissionRiskOverride{
-				{
-					TransmissionRisk:     8,
-					SinceRollingInterval: 0,
-				},
-			},
-			WantTRAdjustment: []int{8, 8}, // 2 entries, both override to 8
+			Regions:          []string{regions.current()},
+			ReportType:       verifyapi.ReportTypeConfirmed,
+			WantTRAdjustment: []int{verifyapi.TransmissionRiskConfirmedStandard, verifyapi.TransmissionRiskConfirmedStandard}, // 2 entries, both override to confirmed
 			Code:             http.StatusOK,
 		},
 		{
@@ -352,10 +369,10 @@ func TestPublishWithBypass(t *testing.T) {
 			}(),
 			Publish: verifyapi.Publish{
 				Keys:                util.GenerateExposureKeys(2, 5, false),
-				Regions:             []string{regions.current()},
-				AppPackageName:      names.current(),
+				HealthAuthorityID:   names.current(),
 				VerificationPayload: "totally not a JWT",
 			},
+			Regions:   []string{regions.current()},
 			JWTTiming: time.Hour,
 			Code:      http.StatusUnauthorized,
 			Error:     "unable to validate diagnosis verification: Token used before issued",
@@ -381,243 +398,300 @@ func TestPublishWithBypass(t *testing.T) {
 			}(),
 			Publish: verifyapi.Publish{
 				Keys:                util.GenerateExposureKeys(2, 5, false),
-				Regions:             []string{regions.current()},
-				AppPackageName:      names.current(),
+				HealthAuthorityID:   names.current(),
 				VerificationPayload: "totally not a JWT",
 			},
+			Regions:   []string{regions.current()},
 			JWTTiming: -6 * time.Minute,
 			Code:      http.StatusUnauthorized,
 			Error:     "unable to validate diagnosis verification: token is expired by 1m",
 		},
 	}
 
-	ctx := context.Background()
-	// Database init for all modules that will be used.
-	testDB := coredb.NewTestDatabase(t)
-	// Make key manager
-	kms, err := keys.NewInMemory(ctx)
-	if err != nil {
-		t.Fatalf("can't make kms: %v", err)
-	}
-	keyID := "rev"
-	kms.AddEncryptionKey(keyID)
-	tokenAAD := make([]byte, 16)
-	if _, err := rand.Read(tokenAAD); err != nil {
-		t.Fatalf("not enough entropy: %v", err)
-	}
-	// Configure revision keys.
-	revDB, err := revisiondb.New(testDB, &revisiondb.KMSConfig{WrapperKeyID: keyID, KeyManager: kms})
-	if err != nil {
-		t.Fatalf("unable to create revision DB handle: %v", err)
-	}
-	if _, err := revDB.CreateRevisionKey(ctx); err != nil {
-		t.Fatalf("unable to create revision key: %v", err)
-	}
+	for _, ver := range versions {
+		addVer := "v1_"
+		if ver == useV1Alpha1 {
+			addVer = "v1Alpha1_"
+		}
 
-	for _, tc := range cases {
-		t.Run(tc.Name, func(t *testing.T) {
-			ctx = context.Background()
+		ctx := context.Background()
+		// Database init for all modules that will be used.
+		testDB := coredb.NewTestDatabase(t)
+		// Make key manager
+		kms, err := keys.NewInMemory(ctx)
+		if err != nil {
+			t.Fatalf("can't make kms: %v", err)
+		}
+		keyID := "rev"
+		kms.AddEncryptionKey(keyID)
+		tokenAAD := make([]byte, 16)
+		if _, err := rand.Read(tokenAAD); err != nil {
+			t.Fatalf("not enough entropy: %v", err)
+		}
+		// Configure revision keys.
+		revDB, err := revisiondb.New(testDB, &revisiondb.KMSConfig{WrapperKeyID: keyID, KeyManager: kms})
+		if err != nil {
+			t.Fatalf("unable to create revision DB handle: %v", err)
+		}
+		if _, err := revDB.CreateRevisionKey(ctx); err != nil {
+			t.Fatalf("unable to create revision key: %v", err)
+		}
 
-			// And set up publish handler up front.
-			config := Config{}
-			config.AuthorizedApp.CacheDuration = time.Nanosecond
-			config.CreatedAtTruncateWindow = time.Second
-			config.MaxKeysOnPublish = 20
-			config.MaxSameStartIntervalKeys = 2
-			config.MaxIntervalAge = 14 * 24 * time.Hour
-			aaProvider, err := authorizedapp.NewDatabaseProvider(ctx, testDB, config.AuthorizedAppConfig())
-			if err != nil {
-				t.Fatal(err)
-			}
-			config.RevisionToken.AAD = tokenAAD
-			config.RevisionToken.KeyID = keyID
-			env := serverenv.New(ctx,
-				serverenv.WithDatabase(testDB),
-				serverenv.WithAuthorizedAppProvider(aaProvider),
-				serverenv.WithKeyManager(kms))
-			// Some config overrides for test.
-			handler, err := NewHandler(ctx, &config, env)
-			if err != nil {
-				t.Fatal(err)
+		for _, tc := range cases {
+			if tc.SkipVersions[ver] {
+				continue
 			}
 
-			// See if there is a health authority to set up.
-			if tc.HealthAuthority != nil {
-				verDB := verdb.New(testDB)
-				if err := verDB.AddHealthAuthority(ctx, tc.HealthAuthority); err != nil {
+			t.Run(addVer+tc.Name, func(t *testing.T) {
+				ctx = context.Background()
+
+				// And set up publish handler up front.
+				config := Config{}
+				config.AuthorizedApp.CacheDuration = time.Nanosecond
+				config.CreatedAtTruncateWindow = time.Second
+				config.MaxKeysOnPublish = 20
+				config.MaxSameStartIntervalKeys = 2
+				config.MaxIntervalAge = 14 * 24 * time.Hour
+				aaProvider, err := authorizedapp.NewDatabaseProvider(ctx, testDB, config.AuthorizedAppConfig())
+				if err != nil {
 					t.Fatal(err)
 				}
-				if tc.HealthAuthorityKey != nil {
-					if tc.SigningKey == nil {
-						t.Fatal("test cases that have health authority keys registered must provide a siningKey as well")
-					}
-					// Join in the public key.
-					tc.HealthAuthorityKey.PublicKeyPEM = tc.SigningKey.PublicKey
-					if err := verDB.AddHealthAuthorityKey(ctx, tc.HealthAuthority, tc.HealthAuthorityKey); err != nil {
-						t.Fatal(err)
-					}
+				config.RevisionToken.AAD = tokenAAD
+				config.RevisionToken.KeyID = keyID
+				env := serverenv.New(ctx,
+					serverenv.WithDatabase(testDB),
+					serverenv.WithAuthorizedAppProvider(aaProvider),
+					serverenv.WithKeyManager(kms))
+				// Some config overrides for test.
+
+				var handler http.Handler
+				if ver == useV1 {
+					handler, err = NewV1Handler(ctx, &config, env)
+				} else {
+					handler, err = NewV1Alpha1Handler(ctx, &config, env)
 				}
-			}
-
-			// Insert the authorized app for the test case, if one exists.
-			if tc.AuthorizedApp != nil {
-				appDB := aadb.New(env.Database())
-				// join in the health authority, if there is one for this test.
-				if tc.HealthAuthority != nil {
-					tc.AuthorizedApp.AllowedHealthAuthorityIDs[tc.HealthAuthority.ID] = struct{}{}
-				}
-				if err := appDB.InsertAuthorizedApp(ctx, tc.AuthorizedApp); err != nil {
-					t.Fatal(err)
-				}
-			}
-			pubDB := pubdb.New(env.Database())
-
-			// If verification is being used. The JWT and HMAC Salt must be incorporated.
-			if tc.HealthAuthority != nil {
-				cfg := jwtConfig{
-					HealthAuthority:    tc.HealthAuthority,
-					HealthAuthorityKey: tc.HealthAuthorityKey,
-					Publish:            &tc.Publish,
-					Key:                tc.SigningKey.Key,
-					JWTWarp:            tc.JWTTiming,
-					Overrides:          tc.Overrides,
-				}
-				verification, salt := issueJWT(t, cfg)
-				tc.Publish.VerificationPayload = verification
-				tc.Publish.HMACKey = salt
-			}
-
-			// Marshal the provided publish request.
-			jsonString, err := json.Marshal(tc.Publish)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			server := httptest.NewServer(handler)
-			defer server.Close()
-
-			// make the request
-			contentType := "application/json"
-			if tc.ContentType != "" {
-				contentType = tc.ContentType
-			}
-			resp, err := server.Client().Post(server.URL, contentType, strings.NewReader(string(jsonString)))
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// For non success status, check that they body contains the expected message
-			defer resp.Body.Close()
-			respBytes, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			log.Printf("\n\n%#v\n\n", string(respBytes))
-
-			var response verifyapi.PublishResponse
-			if err := json.Unmarshal(respBytes, &response); err != nil {
-				t.Fatalf("unable to unmarshal response body: %v; data: %v", err, string(respBytes))
-			}
-			if resp.StatusCode != tc.Code {
-				t.Fatalf("http response code want: %v, got %v.", tc.Code, resp.StatusCode)
-			}
-
-			if resp.StatusCode == http.StatusOK {
-				// For success requests, verify that the exposures were inserted.
-				criteria := pubdb.IterateExposuresCriteria{
-					IncludeRegions: []string{tc.TestRegion},
-					SinceTimestamp: time.Now().Add(-1 * time.Minute),
-					UntilTimestamp: time.Now().Add(time.Minute),
-				}
-
-				got := make([]*model.Exposure, 0, len(tc.Publish.Keys))
-				_, err = pubDB.IterateExposures(ctx, criteria, func(ex *model.Exposure) error {
-					got = append(got, ex)
-					return nil
-				})
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				want := make([]*model.Exposure, 0, len(tc.Publish.Keys))
-				tokenWant := &pb.RevisionTokenData{}
-				for _, k := range tc.Publish.Keys {
-					if key, err := base64util.DecodeString(k.Key); err != nil {
+				// See if there is a health authority to set up.
+				if tc.HealthAuthority != nil {
+					verDB := verdb.New(testDB)
+					if err := verDB.AddHealthAuthority(ctx, tc.HealthAuthority); err != nil {
 						t.Fatal(err)
-					} else {
-						next := model.Exposure{
-							ExposureKey:      key,
-							AppPackageName:   tc.Publish.AppPackageName,
-							TransmissionRisk: k.TransmissionRisk,
+					}
+					if tc.HealthAuthorityKey != nil {
+						if tc.SigningKey == nil {
+							t.Fatal("test cases that have health authority keys registered must provide a siningKey as well")
+						}
+						// Join in the public key.
+						tc.HealthAuthorityKey.PublicKeyPEM = tc.SigningKey.PublicKey
+						if err := verDB.AddHealthAuthorityKey(ctx, tc.HealthAuthority, tc.HealthAuthorityKey); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+
+				// Insert the authorized app for the test case, if one exists.
+				if tc.AuthorizedApp != nil {
+					appDB := aadb.New(env.Database())
+					// join in the health authority, if there is one for this test.
+					if tc.HealthAuthority != nil {
+						tc.AuthorizedApp.AllowedHealthAuthorityIDs[tc.HealthAuthority.ID] = struct{}{}
+					}
+					if err := appDB.InsertAuthorizedApp(ctx, tc.AuthorizedApp); err != nil {
+						t.Fatal(err)
+					}
+				}
+				pubDB := pubdb.New(env.Database())
+
+				// If verification is being used. The JWT and HMAC Salt must be incorporated.
+				if tc.HealthAuthority != nil {
+					cfg := jwtConfig{
+						HealthAuthority:    tc.HealthAuthority,
+						HealthAuthorityKey: tc.HealthAuthorityKey,
+						Publish:            &tc.Publish,
+						Key:                tc.SigningKey.Key,
+						JWTWarp:            tc.JWTTiming,
+						ReportType:         tc.ReportType,
+					}
+					verification, salt := issueJWT(t, cfg)
+					tc.Publish.VerificationPayload = verification
+					tc.Publish.HMACKey = salt
+				}
+
+				// Marshal the provided publish request.
+				var jsonString []byte
+				if ver == useV1 {
+					jsonString, err = json.Marshal(tc.Publish)
+				} else {
+					publish := v1alpha1.Publish{
+						Regions:              tc.Regions,
+						AppPackageName:       tc.Publish.HealthAuthorityID,
+						VerificationPayload:  tc.Publish.VerificationPayload,
+						HMACKey:              tc.Publish.HMACKey,
+						SymptomOnsetInterval: tc.Publish.SymptomOnsetInterval,
+						Traveler:             tc.Publish.Traveler,
+						RevisionToken:        tc.Publish.RevisionToken,
+						Padding:              tc.Publish.Padding,
+					}
+					publish.Keys = make([]v1alpha1.ExposureKey, len(tc.Publish.Keys))
+					for i, k := range tc.Publish.Keys {
+						publish.Keys[i] = v1alpha1.ExposureKey{
+							Key:              k.Key,
 							IntervalNumber:   k.IntervalNumber,
 							IntervalCount:    k.IntervalCount,
-							Regions:          tc.Publish.Regions,
-							Traveler:         tc.Publish.Traveler,
-							LocalProvenance:  true,
-							FederationSyncID: 0,
+							TransmissionRisk: k.TransmissionRisk,
 						}
-						if tc.HealthAuthority != nil {
-							next.SetHealthAuthorityID(tc.HealthAuthority.ID)
+					}
+					jsonString, err = json.Marshal(publish)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				server := httptest.NewServer(handler)
+				defer server.Close()
+
+				// make the request
+				contentType := "application/json"
+				if tc.ContentType != "" {
+					contentType = tc.ContentType
+				}
+				resp, err := server.Client().Post(server.URL, contentType, strings.NewReader(string(jsonString)))
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// For non success status, check that they body contains the expected message
+				defer resp.Body.Close()
+				respBytes, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				log.Printf("\n\n%#v\n\n", string(respBytes))
+
+				var response verifyapi.PublishResponse
+				if err := json.Unmarshal(respBytes, &response); err != nil {
+					t.Fatalf("unable to unmarshal response body: %v; data: %v", err, string(respBytes))
+				}
+				if resp.StatusCode != tc.Code {
+					t.Fatalf("http response code want: %v, got %v.", tc.Code, resp.StatusCode)
+				}
+
+				if ver == useV1 {
+					// The extended data validation only happens on verifyapi.
+
+					if resp.StatusCode == http.StatusOK {
+						// For success requests, verify that the exposures were inserted.
+						criteria := pubdb.IterateExposuresCriteria{
+							IncludeRegions: []string{"US"},
+							SinceTimestamp: time.Now().Add(-1 * time.Minute),
+							UntilTimestamp: time.Now().Add(time.Minute),
 						}
 
-						want = append(want, &next)
+						got := make([]*model.Exposure, 0, len(tc.Publish.Keys))
+						_, err = pubDB.IterateExposures(ctx, criteria, func(ex *model.Exposure) error {
+							got = append(got, ex)
+							return nil
+						})
+						if err != nil {
+							t.Fatal(err)
+						}
 
-						tokenWant.RevisableKeys = append(tokenWant.RevisableKeys,
-							&pb.RevisableKey{
-								TemporaryExposureKey: key,
-								IntervalNumber:       k.IntervalNumber,
-								IntervalCount:        k.IntervalCount,
+						// In v1 regions get joined in from the HA or supplemental data from a v1alpha1 upgrade.
+						wantRegions := tc.Regions
+						if len(wantRegions) == 0 {
+							wantRegions = tc.AuthorizedApp.AllAllowedRegions()
+						}
+
+						want := make([]*model.Exposure, 0, len(tc.Publish.Keys))
+						tokenWant := &pb.RevisionTokenData{}
+						for _, k := range tc.Publish.Keys {
+							if key, err := base64util.DecodeString(k.Key); err != nil {
+								t.Fatal(err)
+							} else {
+								next := model.Exposure{
+									ExposureKey:      key,
+									AppPackageName:   tc.Publish.HealthAuthorityID,
+									TransmissionRisk: k.TransmissionRisk,
+									IntervalNumber:   k.IntervalNumber,
+									IntervalCount:    k.IntervalCount,
+									Regions:          wantRegions,
+									Traveler:         tc.Publish.Traveler,
+									LocalProvenance:  true,
+									FederationSyncID: 0,
+								}
+								if tc.ReportType != "" {
+									next.ReportType = tc.ReportType
+								}
+								if tc.HealthAuthority != nil {
+									next.SetHealthAuthorityID(tc.HealthAuthority.ID)
+								}
+
+								want = append(want, &next)
+
+								tokenWant.RevisableKeys = append(tokenWant.RevisableKeys,
+									&pb.RevisableKey{
+										TemporaryExposureKey: key,
+										IntervalNumber:       k.IntervalNumber,
+										IntervalCount:        k.IntervalCount,
+									})
+							}
+						}
+
+						// Adjust expectations based on transmission risk overrides placed in JWT.
+						for i, a := range tc.WantTRAdjustment {
+							want[i].TransmissionRisk = a
+						}
+
+						sorter := cmp.Transformer("Sort", func(in []*model.Exposure) []*model.Exposure {
+							out := append([]*model.Exposure(nil), in...) // Copy input to avoid mutating it
+							sort.Slice(out, func(i int, j int) bool {
+								return bytes.Compare(out[i].ExposureKey, out[j].ExposureKey) <= 0
 							})
+							return out
+						})
+						ignoreCreatedAt := cmpopts.IgnoreFields(*want[0], "CreatedAt")
+
+						if diff := cmp.Diff(want, got, sorter, ignoreCreatedAt, cmpopts.IgnoreUnexported(model.Exposure{})); diff != "" {
+							t.Errorf("mismatch (-want, +got):\n%s", diff)
+						}
+
+						// Crack the revision token - it should contain the uploaded exposure keys.
+						tm, err := revision.New(ctx, revDB, time.Minute, 1)
+						if err != nil {
+							t.Fatalf("unable to create token manager: %v", err)
+						}
+						revTokenBytes, err := base64util.DecodeString(response.RevisionToken)
+						if err != nil {
+							t.Fatalf("revision token encoded incorrectly: %v", err)
+						}
+						revToken, err := tm.UnmarshalRevisionToken(ctx, revTokenBytes, tokenAAD)
+						if err != nil {
+							t.Fatalf("unable to decrypt revision token: %v", err)
+						}
+						revisableSorter := cmp.Transformer("Sort", func(in []*pb.RevisableKey) []*pb.RevisableKey {
+							out := append([]*pb.RevisableKey(nil), in...)
+							sort.Slice(out, func(i int, j int) bool {
+								return bytes.Compare(out[i].TemporaryExposureKey, out[j].TemporaryExposureKey) <= 0
+							})
+							return out
+						})
+						if diff := cmp.Diff(tokenWant.RevisableKeys, revToken.RevisableKeys, revisableSorter, cmpopts.IgnoreUnexported(pb.RevisableKey{})); diff != "" {
+							t.Errorf("mismatch (-want, +got):\n%s", diff)
+						}
+					} else {
+						if !strings.Contains(response.ErrorMessage, tc.Error) {
+							t.Errorf("missing error text '%v', got '%+v'", tc.Error, response)
+						}
+						if tc.ErrorCode != "" && response.ErrorCode != tc.ErrorCode {
+							t.Errorf("wrong error code want: %v, got: %v", tc.ErrorCode, response.ErrorCode)
+						}
 					}
 				}
-
-				// Adjust expectations based on transmission risk overrides placed in JWT.
-				for i, a := range tc.WantTRAdjustment {
-					want[i].TransmissionRisk = a
-				}
-
-				sorter := cmp.Transformer("Sort", func(in []*model.Exposure) []*model.Exposure {
-					out := append([]*model.Exposure(nil), in...) // Copy input to avoid mutating it
-					sort.Slice(out, func(i int, j int) bool {
-						return bytes.Compare(out[i].ExposureKey, out[j].ExposureKey) <= 0
-					})
-					return out
-				})
-				ignoreCreatedAt := cmpopts.IgnoreFields(*want[0], "CreatedAt")
-
-				if diff := cmp.Diff(want, got, sorter, ignoreCreatedAt, cmpopts.IgnoreUnexported(model.Exposure{})); diff != "" {
-					t.Errorf("mismatch (-want, +got):\n%s", diff)
-				}
-
-				// Crack the revision token - it should contain the uploaded exposure keys.
-				tm, err := revision.New(ctx, revDB, time.Minute, 1)
-				if err != nil {
-					t.Fatalf("unable to create token manager: %v", err)
-				}
-				revTokenBytes, err := base64util.DecodeString(response.RevisionToken)
-				if err != nil {
-					t.Fatalf("revision token encoded incorrectly: %v", err)
-				}
-				revToken, err := tm.UnmarshalRevisionToken(ctx, revTokenBytes, tokenAAD)
-				if err != nil {
-					t.Fatalf("unable to decrypt revision token: %v", err)
-				}
-				revisableSorter := cmp.Transformer("Sort", func(in []*pb.RevisableKey) []*pb.RevisableKey {
-					out := append([]*pb.RevisableKey(nil), in...)
-					sort.Slice(out, func(i int, j int) bool {
-						return bytes.Compare(out[i].TemporaryExposureKey, out[j].TemporaryExposureKey) <= 0
-					})
-					return out
-				})
-				if diff := cmp.Diff(tokenWant.RevisableKeys, revToken.RevisableKeys, revisableSorter, cmpopts.IgnoreUnexported(pb.RevisableKey{})); diff != "" {
-					t.Errorf("mismatch (-want, +got):\n%s", diff)
-				}
-			} else {
-				if !strings.Contains(response.Error, tc.Error) {
-					t.Errorf("missing error text '%v', got '%+v'", tc.Error, response)
-				}
-			}
-		})
+			})
+		}
 	}
 }

--- a/internal/publish/publish_v1.go
+++ b/internal/publish/publish_v1.go
@@ -1,0 +1,91 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package publish defines the exposure keys publishing API.
+package publish
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"go.opencensus.io/trace"
+
+	"github.com/google/exposure-notifications-server/internal/jsonutil"
+	"github.com/google/exposure-notifications-server/internal/serverenv"
+	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	"github.com/mikehelmick/go-chaff"
+)
+
+// NewV1Handler creates the HTTP handler for the TTK publishing API set at v1.
+func NewV1Handler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (http.Handler, error) {
+	processor, err := newProcessor(ctx, config, env)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1Handler{processor: processor}, nil
+}
+
+type v1Handler struct {
+	processor *publishHandler
+}
+
+func (h *v1Handler) handleRequest(w http.ResponseWriter, r *http.Request) response {
+	ctx, span := trace.StartSpan(r.Context(), "(*publish.publishHandler).handleRequest")
+	defer span.End()
+
+	var data v1.Publish
+	code, err := jsonutil.Unmarshal(w, r, &data)
+	if err != nil {
+		message := fmt.Sprintf("error unmarshaling API call, code: %v: %v", code, err)
+		span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: message})
+		return response{
+			status: http.StatusBadRequest,
+			pubResponse: &v1.PublishResponse{
+				ErrorMessage: message,
+				ErrorCode:    v1.ErrorBadRequest,
+			},
+			metric: "publish-bad-json",
+			count:  1,
+		}
+	}
+
+	return h.processor.process(ctx, &data, newVersionBridge([]string{}))
+}
+
+// ServeHTTP handles the publish event. It tracks requests and can handle chaff
+// requests when provided a request with the X-Chaff header.
+func (h *v1Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.processor.tracker.HandleTrack(chaff.HeaderDetector("X-Chaff"),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			response := h.handleRequest(w, r)
+
+			if response.metric != "" {
+				ctx := r.Context()
+				metrics := h.processor.serverenv.MetricsExporter(ctx)
+				metrics.WriteInt(response.metric, true, response.count)
+			}
+
+			data, err := json.Marshal(response.pubResponse)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, "{\"error\": \"%v\"}", err.Error())
+				return
+			}
+			w.WriteHeader(response.status)
+			fmt.Fprintf(w, "%s", data)
+		})).ServeHTTP(w, r)
+}

--- a/internal/publish/publish_v1alpha1.go
+++ b/internal/publish/publish_v1alpha1.go
@@ -1,0 +1,119 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package publish defines the exposure keys publishing API.
+package publish
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"go.opencensus.io/trace"
+
+	"github.com/google/exposure-notifications-server/internal/jsonutil"
+	"github.com/google/exposure-notifications-server/internal/serverenv"
+	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	"github.com/mikehelmick/go-chaff"
+)
+
+// NewV1Alpha1Handler creates the HTTP handler for the TTK publishing API set at v1alpha1.
+func NewV1Alpha1Handler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (http.Handler, error) {
+	processor, err := newProcessor(ctx, config, env)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1alpha1Handler{processor: processor}, nil
+}
+
+type v1alpha1Handler struct {
+	processor *publishHandler
+}
+
+func (h *v1alpha1Handler) handleRequest(w http.ResponseWriter, r *http.Request) response {
+	ctx, span := trace.StartSpan(r.Context(), "(*publish.publishHandler).handleRequest")
+	defer span.End()
+
+	var data v1alpha1.Publish
+	code, err := jsonutil.Unmarshal(w, r, &data)
+	if err != nil {
+		message := fmt.Sprintf("error unmarshaling API call, code: %v: %v", code, err)
+		span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: message})
+		return response{
+			status:      http.StatusBadRequest,
+			pubResponse: &v1.PublishResponse{ErrorMessage: message}, // will be down-converted in ServeHTTP
+			metric:      "publish-bad-json", count: 1}
+	}
+
+	// Upconvert the exposure key records.
+	v1keys := make([]v1.ExposureKey, len(data.Keys))
+	for i, k := range data.Keys {
+		v1keys[i] = v1.ExposureKey{
+			Key:              k.Key,
+			IntervalNumber:   k.IntervalNumber,
+			IntervalCount:    k.IntervalCount,
+			TransmissionRisk: k.TransmissionRisk,
+		}
+	}
+
+	// Upconvert v1alpha1 to v1.
+	publish := v1.Publish{
+		Keys:                 v1keys,
+		HealthAuthorityID:    data.AppPackageName,
+		VerificationPayload:  data.VerificationPayload,
+		HMACKey:              data.HMACKey,
+		SymptomOnsetInterval: data.SymptomOnsetInterval,
+		Traveler:             data.Traveler,
+		RevisionToken:        data.RevisionToken,
+		Padding:              data.Padding,
+	}
+	bridge := newVersionBridge(data.Regions)
+
+	return h.processor.process(ctx, &publish, bridge)
+}
+
+// ServeHTTP handles the publish event. It tracks requests and can handle chaff
+// requests when provided a request with the X-Chaff header.
+func (h *v1alpha1Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.processor.tracker.HandleTrack(chaff.HeaderDetector("X-Chaff"),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			response := h.handleRequest(w, r)
+
+			// Downgrade the v1 response to a v1alpha1 response.
+			alpha1Response := v1alpha1.PublishResponse{
+				RevisionToken:     response.pubResponse.RevisionToken,
+				InsertedExposures: response.pubResponse.InsertedExposures,
+				Error:             response.pubResponse.ErrorMessage,
+				Padding:           response.pubResponse.Padding,
+			}
+
+			if response.metric != "" {
+				ctx := r.Context()
+				metrics := h.processor.serverenv.MetricsExporter(ctx)
+				metrics.WriteInt(response.metric, true, response.count)
+			}
+
+			data, err := json.Marshal(&alpha1Response)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, "{\"error\": \"%v\"}", err.Error())
+				return
+			}
+			w.WriteHeader(response.status)
+			fmt.Fprintf(w, "%s", data)
+		})).ServeHTTP(w, r)
+}

--- a/internal/verification/phaverify.go
+++ b/internal/verification/phaverify.go
@@ -25,7 +25,7 @@ import (
 	aamodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
 	"github.com/google/exposure-notifications-server/internal/verification/database"
 	"github.com/google/exposure-notifications-server/internal/verification/model"
-	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-server/pkg/cache"
 	utils "github.com/google/exposure-notifications-server/pkg/verification"
@@ -59,24 +59,24 @@ type VerifiedClaims struct {
 // VerifyDiagnosisCertificate accepts a publish request (from which is extracts the JWT),
 // fully verifies the JWT and signture against what the passed in authorrized app is allowed
 // to use. Returns any transmission risk overrides if they are present.
-func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamodel.AuthorizedApp, publish *v1.Publish) (*VerifiedClaims, error) {
+func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamodel.AuthorizedApp, publish *verifyapi.Publish) (*VerifiedClaims, error) {
 	// These get assigned during the ParseWithClaims closure.
 	var healthAuthorityID int64
-	var claims *v1.VerificationClaims
+	var claims *verifyapi.VerificationClaims
 
 	// Unpack JWT so we can determine issuer and key version.
-	token, err := jwt.ParseWithClaims(publish.VerificationPayload, &v1.VerificationClaims{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(publish.VerificationPayload, &verifyapi.VerificationClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if method, ok := token.Method.(*jwt.SigningMethodECDSA); !ok || method.Name != jwt.SigningMethodES256.Name {
 			return nil, fmt.Errorf("unsupported signing method, must be %v", jwt.SigningMethodES256.Name)
 		}
 
 		var ok bool
-		kid, ok := token.Header[v1.KeyIDHeader]
+		kid, ok := token.Header[verifyapi.KeyIDHeader]
 		if !ok {
 			return nil, fmt.Errorf("missing required header field, 'kid' indicating key id")
 		}
 
-		claims, ok = token.Claims.(*v1.VerificationClaims)
+		claims, ok = token.Claims.(*verifyapi.VerificationClaims)
 		if !ok {
 			return nil, fmt.Errorf("does not contain expected claim set")
 		}

--- a/internal/verification/phaverify.go
+++ b/internal/verification/phaverify.go
@@ -25,7 +25,7 @@ import (
 	aamodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
 	"github.com/google/exposure-notifications-server/internal/verification/database"
 	"github.com/google/exposure-notifications-server/internal/verification/model"
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-server/pkg/cache"
 	utils "github.com/google/exposure-notifications-server/pkg/verification"
@@ -54,30 +54,29 @@ type VerifiedClaims struct {
 	HealthAuthorityID    int64
 	ReportType           string // blank indicates no report type was present.
 	SymptomOnsetInterval uint32 // 0 indicates no symptom onset interval present. This should be checked for "reasonable" value before application.
-	TransmissionRisks    verifyapi.TransmissionRiskVector
 }
 
 // VerifyDiagnosisCertificate accepts a publish request (from which is extracts the JWT),
 // fully verifies the JWT and signture against what the passed in authorrized app is allowed
 // to use. Returns any transmission risk overrides if they are present.
-func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamodel.AuthorizedApp, publish *verifyapi.Publish) (*VerifiedClaims, error) {
+func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamodel.AuthorizedApp, publish *v1.Publish) (*VerifiedClaims, error) {
 	// These get assigned during the ParseWithClaims closure.
 	var healthAuthorityID int64
-	var claims *verifyapi.VerificationClaims
+	var claims *v1.VerificationClaims
 
 	// Unpack JWT so we can determine issuer and key version.
-	token, err := jwt.ParseWithClaims(publish.VerificationPayload, &verifyapi.VerificationClaims{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(publish.VerificationPayload, &v1.VerificationClaims{}, func(token *jwt.Token) (interface{}, error) {
 		if method, ok := token.Method.(*jwt.SigningMethodECDSA); !ok || method.Name != jwt.SigningMethodES256.Name {
 			return nil, fmt.Errorf("unsupported signing method, must be %v", jwt.SigningMethodES256.Name)
 		}
 
 		var ok bool
-		kid, ok := token.Header[verifyapi.KeyIDHeader]
+		kid, ok := token.Header[v1.KeyIDHeader]
 		if !ok {
 			return nil, fmt.Errorf("missing required header field, 'kid' indicating key id")
 		}
 
-		claims, ok = token.Claims.(*verifyapi.VerificationClaims)
+		claims, ok = token.Claims.(*v1.VerificationClaims)
 		if !ok {
 			return nil, fmt.Errorf("does not contain expected claim set")
 		}
@@ -148,6 +147,5 @@ func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamo
 		HealthAuthorityID:    healthAuthorityID,
 		ReportType:           claims.ReportType,
 		SymptomOnsetInterval: claims.SymptomOnsetInterval,
-		TransmissionRisks:    claims.TransmissionRisks,
 	}, nil
 }

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/verification/model"
 	"github.com/google/go-cmp/cmp"
 
-	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 	utils "github.com/google/exposure-notifications-server/pkg/verification"
 )
@@ -139,8 +139,8 @@ func TestVerifyCertificate(t *testing.T) {
 				authApp.AllowedHealthAuthorityIDs[healthAuthority.ID] = struct{}{}
 
 				// Build a sample certificate.
-				publish := v1.Publish{
-					Keys: []v1.ExposureKey{
+				publish := verifyapi.Publish{
+					Keys: []verifyapi.ExposureKey{
 						{
 							Key:              "IRgYIhYiy4WMl9z68bMk6w==",
 							IntervalNumber:   2650032,
@@ -181,7 +181,7 @@ func TestVerifyCertificate(t *testing.T) {
 					// contains legacy transmission risk field, but will be an empty array, just there.
 					claims = v1alpha1claims
 				} else {
-					v1claims := v1.NewVerificationClaims()
+					v1claims := verifyapi.NewVerificationClaims()
 					v1claims.Audience = "exposure-notifications-server"
 					v1claims.Issuer = "doh.my.gov"
 					v1claims.IssuedAt = time.Now().Add(tc.Warp).Unix()

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -35,8 +35,10 @@ import (
 	coredb "github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/verification/database"
 	"github.com/google/exposure-notifications-server/internal/verification/model"
+	"github.com/google/go-cmp/cmp"
 
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 	utils "github.com/google/exposure-notifications-server/pkg/verification"
 )
 
@@ -75,128 +77,161 @@ func TestVerifyCertificate(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		tc := tc
+	for version := 0; version <= 1; version++ {
+		for _, tc := range cases {
+			tc := tc
 
-		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
-
-			// Generate ECDSA key pair.
-			privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-			if err != nil {
-				t.Fatal(err)
-			}
-			publicKey := privateKey.Public()
-
-			// Get the PEM for the public key.
-			x509EncodedPub, err := x509.MarshalPKIXPublicKey(publicKey)
-			if err != nil {
-				t.Fatal(err)
-			}
-			pemEncodedPub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x509EncodedPub})
-			pemPublicKey := string(pemEncodedPub)
-
-			// Set up database. Create HealthAuthority + HAKey for the test.
-			testDB := coredb.NewTestDatabase(t)
-			ctx := context.Background()
-			haDB := database.New(testDB)
-
-			healthAuthority := model.HealthAuthority{
-				Issuer:   "doh.my.gov",
-				Audience: "exposure-notifications-server",
-				Name:     "Very Real Health Authority",
-			}
-			if err := haDB.AddHealthAuthority(ctx, &healthAuthority); err != nil {
-				t.Fatal(err)
+			vname := "v1alpha1"
+			if version == 1 {
+				vname = "v1"
 			}
 
-			hak := model.HealthAuthorityKey{
-				Version:      "v1",
-				From:         time.Now(),
-				PublicKeyPEM: pemPublicKey,
-			}
-			if err := haDB.AddHealthAuthorityKey(ctx, &healthAuthority, &hak); err != nil {
-				t.Fatal(err)
-			}
+			t.Run(tc.Name+"_"+vname, func(t *testing.T) {
+				t.Parallel()
 
-			// Build the verification certificate.
-			hmacKeyBytes := make([]byte, 32)
-			if _, err := rand.Read(hmacKeyBytes); err != nil {
-				t.Fatal(err)
-			}
-			hmacKeyB64 := base64.StdEncoding.EncodeToString(hmacKeyBytes)
-
-			// Fake authorized app.
-			authApp := aamodel.NewAuthorizedApp()
-			authApp.AllowedHealthAuthorityIDs[healthAuthority.ID] = struct{}{}
-
-			// Build a sample certificate.
-			publish := verifyapi.Publish{
-				Keys: []verifyapi.ExposureKey{
-					{
-						Key:              "IRgYIhYiy4WMl9z68bMk6w==",
-						IntervalNumber:   2650032,
-						IntervalCount:    144,
-						TransmissionRisk: 4,
-					},
-					{
-						Key:              "dPCphLzfG4uzXneNimkPRQ====",
-						IntervalNumber:   2650032 + 144,
-						IntervalCount:    144,
-						TransmissionRisk: 4,
-					},
-					{
-						Key:              "5AUyPfJKcg5cr3OgKdR8Sw==",
-						IntervalNumber:   2650032 + 144*2,
-						IntervalCount:    144,
-						TransmissionRisk: 4,
-					},
-				},
-			}
-
-			// Calculate the HMAC.
-			hmac, err := utils.CalculateExposureKeyHMAC(publish.Keys, hmacKeyBytes)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			claims := verifyapi.NewVerificationClaims()
-			claims.Audience = "exposure-notifications-server"
-			claims.Issuer = "doh.my.gov"
-			claims.IssuedAt = time.Now().Add(tc.Warp).Unix()
-			claims.ExpiresAt = time.Now().Add(tc.Warp).Add(5 * time.Minute).Unix()
-			claims.SignedMAC = tc.MacAdjustment + base64.StdEncoding.EncodeToString(hmac) // would be generated on the client and passed through.
-			// leaves PHAClaims and transmission risk overrides out of it.
-
-			token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
-			token.Header["kid"] = "v1" // matches the key configured above.
-			jwtText, err := token.SignedString(privateKey)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			// Insert this data into the publish request.
-			publish.VerificationPayload = jwtText
-			publish.HMACKey = tc.MacKeyAdjustment + hmacKeyB64
-
-			// Actually test the verify code.
-			verifier, err := New(haDB, &Config{time.Nanosecond})
-			if err != nil {
-				t.Fatal(err)
-			}
-			verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish)
-			if err != nil {
-				if !strings.Contains(err.Error(), tc.Error) {
-					t.Fatalf("wanted error '%v', got error '%v'", tc.Error, err.Error())
+				// Generate ECDSA key pair.
+				privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatal(err)
 				}
-			} else if tc.Error != "" {
-				t.Fatalf("wanted error '%v', but got nil", tc.Error)
-			}
-			if verifiedClaims != nil {
-				if len(verifiedClaims.TransmissionRisks) != 0 {
-					t.Errorf("wanted no overrides, got %v", verifiedClaims.TransmissionRisks)
+				publicKey := privateKey.Public()
+
+				// Get the PEM for the public key.
+				x509EncodedPub, err := x509.MarshalPKIXPublicKey(publicKey)
+				if err != nil {
+					t.Fatal(err)
 				}
-			}
-		})
+				pemEncodedPub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x509EncodedPub})
+				pemPublicKey := string(pemEncodedPub)
+
+				// Set up database. Create HealthAuthority + HAKey for the test.
+				testDB := coredb.NewTestDatabase(t)
+				ctx := context.Background()
+				haDB := database.New(testDB)
+
+				healthAuthority := model.HealthAuthority{
+					Issuer:   "doh.my.gov",
+					Audience: "exposure-notifications-server",
+					Name:     "Very Real Health Authority",
+				}
+				if err := haDB.AddHealthAuthority(ctx, &healthAuthority); err != nil {
+					t.Fatal(err)
+				}
+
+				hak := model.HealthAuthorityKey{
+					Version:      "v1",
+					From:         time.Now(),
+					PublicKeyPEM: pemPublicKey,
+				}
+				if err := haDB.AddHealthAuthorityKey(ctx, &healthAuthority, &hak); err != nil {
+					t.Fatal(err)
+				}
+
+				// Build the verification certificate.
+				hmacKeyBytes := make([]byte, 32)
+				if _, err := rand.Read(hmacKeyBytes); err != nil {
+					t.Fatal(err)
+				}
+				hmacKeyB64 := base64.StdEncoding.EncodeToString(hmacKeyBytes)
+
+				// Fake authorized app.
+				authApp := aamodel.NewAuthorizedApp()
+				authApp.AllowedHealthAuthorityIDs[healthAuthority.ID] = struct{}{}
+
+				// Build a sample certificate.
+				publish := v1.Publish{
+					Keys: []v1.ExposureKey{
+						{
+							Key:              "IRgYIhYiy4WMl9z68bMk6w==",
+							IntervalNumber:   2650032,
+							IntervalCount:    144,
+							TransmissionRisk: 4,
+						},
+						{
+							Key:              "dPCphLzfG4uzXneNimkPRQ====",
+							IntervalNumber:   2650032 + 144,
+							IntervalCount:    144,
+							TransmissionRisk: 4,
+						},
+						{
+							Key:              "5AUyPfJKcg5cr3OgKdR8Sw==",
+							IntervalNumber:   2650032 + 144*2,
+							IntervalCount:    144,
+							TransmissionRisk: 4,
+						},
+					},
+				}
+
+				// Calculate the HMAC.
+				hmac, err := utils.CalculateExposureKeyHMAC(publish.Keys, hmacKeyBytes)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				var claims jwt.Claims
+				if version == 0 {
+					v1alpha1claims := v1alpha1.NewVerificationClaims()
+					v1alpha1claims.Audience = "exposure-notifications-server"
+					v1alpha1claims.Issuer = "doh.my.gov"
+					v1alpha1claims.IssuedAt = time.Now().Add(tc.Warp).Unix()
+					v1alpha1claims.ExpiresAt = time.Now().Add(tc.Warp).Add(5 * time.Minute).Unix()
+					v1alpha1claims.SignedMAC = tc.MacAdjustment + base64.StdEncoding.EncodeToString(hmac) // would be generated on the client and passed through.
+					v1alpha1claims.ReportType = "confirmed"
+					v1alpha1claims.SymptomOnsetInterval = 250250
+					// contains legacy transmission risk field, but will be an empty array, just there.
+					claims = v1alpha1claims
+				} else {
+					v1claims := v1.NewVerificationClaims()
+					v1claims.Audience = "exposure-notifications-server"
+					v1claims.Issuer = "doh.my.gov"
+					v1claims.IssuedAt = time.Now().Add(tc.Warp).Unix()
+					v1claims.ExpiresAt = time.Now().Add(tc.Warp).Add(5 * time.Minute).Unix()
+					v1claims.SignedMAC = tc.MacAdjustment + base64.StdEncoding.EncodeToString(hmac)
+					v1claims.ReportType = "confirmed"
+					v1claims.SymptomOnsetInterval = 250250
+					claims = v1claims
+				}
+
+				token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+				token.Header["kid"] = "v1" // matches the key configured above.
+				jwtText, err := token.SignedString(privateKey)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Insert this data into the publish request.
+				publish.VerificationPayload = jwtText
+				publish.HMACKey = tc.MacKeyAdjustment + hmacKeyB64
+
+				// Actually test the verify code.
+				verifier, err := New(haDB, &Config{time.Nanosecond})
+				if err != nil {
+					t.Fatal(err)
+				}
+				verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish)
+				if err != nil {
+					if !strings.Contains(err.Error(), tc.Error) {
+						t.Fatalf("wanted error '%v', got error '%v'", tc.Error, err.Error())
+					}
+				} else if tc.Error != "" {
+					t.Fatalf("wanted error '%v', but got nil", tc.Error)
+				}
+
+				if tc.Error == "" {
+					if verifiedClaims == nil {
+						t.Fatalf("verified claims are nil")
+					}
+
+					want := &VerifiedClaims{
+						HealthAuthorityID:    healthAuthority.ID,
+						ReportType:           "confirmed",
+						SymptomOnsetInterval: 250250,
+					}
+					if diff := cmp.Diff(want, verifiedClaims); diff != "" {
+						t.Errorf("claims mismatch (-want, +got):\n%s", diff)
+					}
+				}
+			})
+		}
 	}
 }

--- a/migrations/000035_AddTravelerBit.down.sql
+++ b/migrations/000035_AddTravelerBit.down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE Exposure
+    DROP COLUMN traveler;
+
+END;

--- a/migrations/000035_AddTravelerBit.up.sql
+++ b/migrations/000035_AddTravelerBit.up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- Traveler column is not indexed because we always iterate over keys by their created_at
+-- or revised_at time which is indexed and do secondary filtering in the server.
+ALTER TABLE Exposure
+    ADD COLUMN traveler BOOL NOT NULL DEFAULT false;
+
+END;

--- a/pkg/api/v1/exposure_types.go
+++ b/pkg/api/v1/exposure_types.go
@@ -1,0 +1,142 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "time"
+
+// The following constants are generally useful in implementations of this API
+// and for clients as well..
+const (
+	// only valid exposure key keyLength
+	KeyLength = 16
+
+	// Transmission risk constraints (inclusive..inclusive)
+	MinTransmissionRisk = 0 // 0 indicates, no/unknown risk.
+	MaxTransmissionRisk = 8
+
+	// Intervals are defined as 10 minute periods, there are 144 of them in a day.
+	// IntervalCount constraints (inclusive..inclusive)
+	MinIntervalCount = 1
+	MaxIntervalCount = 144
+
+	// interval length
+	IntervalLength = 10 * time.Minute
+
+	// Error Code defintiions.
+	// ErrorUnknownHealthAuthorityID indicates that the health authority was not found.
+	ErrorUnknownHealthAuthorityID = "unknown_health_authority_id"
+	// ErrorUnableToLoadHealthAuthority indicates a retryable error loading the configuration.
+	ErrorUnableToLoadHealthAuthority = "unable_to_load_health_authority"
+	// ErrorHealthAuthorityMissingRegionConfiguration indicautes the request can not accepted because
+	// the specified health authority is not configured correctly.
+	ErrorHealthAuthorityMissingRegionConfiguration = "health_authority_missing_region_config"
+	// ErrorVerificationCertificateInvalid indicates a problem with the verification certificate.
+	ErrorVerificationCertificateInvalid = "health_authority_verification_certificate_invalid"
+	// ErrorBadRequest indicates that the client sent a request that couldn't be parsed correctly
+	// or otherwise contains invalid data, see the extended ErrorMessage for details.
+	ErrorBadRequest = "bad_request"
+	// ErrorInternalError
+	ErrorInternalError = "internal_error"
+)
+
+// Publish represents the body of the PublishInfectedIds API call.
+// temporaryExposureKeys: Required and must have length >= 1 and <= 21 (`maxKeysPerPublish`)
+// healthAuthorityID: The identifier for the mobile application.
+//  - Android: The App Package AppPackageName
+//  - iOS: The BundleID
+// verificationPayload: The Verification Certificate from a verification server.
+// hmackey: the device generated secret that is used to recalcualte the HMAC value
+//  that is present in the verification payload.
+//
+// symptomOnsetInterval: An interval number that aligns with the symptom onset date.
+//  - Uses the same interval system as TEK timing.
+//  - Will be rounded down to the start of the UTC day provided.
+//  - Will be used to calculate the days +/- symptom onset for provided keys.
+//  - MUST be no more than 14 days ago.
+//  - Does not have to be within range of any of the provided keys (i.e. future
+//    key uploads)
+//
+// traveler - set to true if the TEKs in this publish set are consider to be the
+//  keys of a "traveler" who has left the home region represented by this server
+//  (or by the home health authority in case of a multi-tenant installation).
+//
+// revisionToken: An opaque string that must be passed in-tact from on additional
+//   publish requests from the same device, there the same TEKs may be published
+//   again.
+//
+// Padding: random base64 encoded data to obscure the request size. The server will
+// not process this data in any way.
+type Publish struct {
+	Keys                 []ExposureKey `json:"temporaryExposureKeys"`
+	HealthAuthorityID    string        `json:"healthAuthorityID"`
+	VerificationPayload  string        `json:"verificationPayload"`
+	HMACKey              string        `json:"hmackey"`
+	SymptomOnsetInterval int32         `json:"symptomOnsetInterval"`
+	Traveler             bool          `json:"traveler"`
+	RevisionToken        string        `json:"revisionToken"`
+
+	Padding string `json:"padding"`
+}
+
+// PublishResponse is sent back to the client on a publish request.
+// If successful, the revisionToken indicates an opaque string that must be
+// passed back if the same devices wishes to publish TEKs again.
+//
+// On error, the error field will contain the error details.
+//
+// The Padding field may be populated with random data on both success and
+// error responses.
+type PublishResponse struct {
+	RevisionToken     string `json:"revisionToken"`
+	InsertedExposures int    `json:"insertedExposures"`
+	ErrorMessage      string `json:"error"`
+	ErrorCode         string `json:"errorCode"`
+	Padding           string `json:"padding"`
+}
+
+// ExposureKey is the 16 byte key, the start time of the key and the
+// duration of the key. A duration of 0 means 24 hours.
+// - ALL fields are REQUIRED and must meet the constraints below.
+// Key must be the base64 (RFC 4648) encoded 16 byte exposure key from the device.
+// - Base64 encoding should include padding, as per RFC 4648
+// - if the key is not exactly 16 bytes in length, the request will be failed
+// - that is, the whole batch will fail.
+// IntervalNumber must be "reasonable" as in the system won't accept keys that
+//   are scheduled to start in the future or that are too far in the past, which
+//   is configurable per installation.
+// IntervalCount must >= `minIntervalCount` and <= `maxIntervalCount`
+//   1 - 144 inclusive.
+// transmissionRisk must be >= 0 and <= 8.
+//   Transmission risk is depercated, but should still be populated for compatibility
+//   with olrder clients. If it is omitted, and there is a valid report type,
+//   then transmissionRisk will be set to 0.
+//   IF there is a report type from the verification certificate AND tranismission risk
+//    is not set, then a report type of
+//     CONFIRMED will lead to TR 2
+//     LIKELY will lead to TR 4
+//     NEGATIVE will lead to TR 6
+type ExposureKey struct {
+	Key              string `json:"key"`
+	IntervalNumber   int32  `json:"rollingStartNumber"`
+	IntervalCount    int32  `json:"rollingPeriod"`
+	TransmissionRisk int    `json:"transmissionRisk"` // DEPRECATED
+}
+
+// ExposureKeys represents a set of ExposureKey objects as input to
+// export file generation utility.
+// Keys: Required and must have length >= 1.
+type ExposureKeys struct {
+	Keys []ExposureKey `json:"temporaryExposureKeys"`
+}

--- a/pkg/api/v1/exposure_types.go
+++ b/pkg/api/v1/exposure_types.go
@@ -57,7 +57,7 @@ const (
 //  - Android: The App Package AppPackageName
 //  - iOS: The BundleID
 // verificationPayload: The Verification Certificate from a verification server.
-// hmackey: the device generated secret that is used to recalcualte the HMAC value
+// hmacKey: the device generated secret that is used to recalcualte the HMAC value
 //  that is present in the verification payload.
 //
 // symptomOnsetInterval: An interval number that aligns with the symptom onset date.
@@ -81,10 +81,10 @@ const (
 type Publish struct {
 	Keys                 []ExposureKey `json:"temporaryExposureKeys"`
 	HealthAuthorityID    string        `json:"healthAuthorityID"`
-	VerificationPayload  string        `json:"verificationPayload"`
-	HMACKey              string        `json:"hmackey"`
-	SymptomOnsetInterval int32         `json:"symptomOnsetInterval"`
-	Traveler             bool          `json:"traveler"`
+	VerificationPayload  string        `json:"verificationPayload,omitempty"`
+	HMACKey              string        `json:"hmacKey,omitempty"`
+	SymptomOnsetInterval int32         `json:"symptomOnsetInterval,omitempty"`
+	Traveler             bool          `json:"traveler,omitempty"`
 	RevisionToken        string        `json:"revisionToken"`
 
 	Padding string `json:"padding"`
@@ -94,16 +94,19 @@ type Publish struct {
 // If successful, the revisionToken indicates an opaque string that must be
 // passed back if the same devices wishes to publish TEKs again.
 //
-// On error, the error field will contain the error details.
+// On error, the error message will contain a message from the server
+// and the 'code' field will contain one of the constants defined in this file.
+// The intent is that code can be used to show a localized error message on the
+// device.
 //
 // The Padding field may be populated with random data on both success and
 // error responses.
 type PublishResponse struct {
-	RevisionToken     string `json:"revisionToken"`
-	InsertedExposures int    `json:"insertedExposures"`
-	ErrorMessage      string `json:"error"`
-	ErrorCode         string `json:"errorCode"`
-	Padding           string `json:"padding"`
+	RevisionToken     string `json:"revisionToken,omitempty"`
+	InsertedExposures int    `json:"insertedExposures,omitempty"`
+	ErrorMessage      string `json:"error,omitempty"`
+	Code              string `json:"code,omitempty"`
+	Padding           string `json:"padding,omitempty"`
 }
 
 // ExposureKey is the 16 byte key, the start time of the key and the
@@ -119,8 +122,8 @@ type PublishResponse struct {
 // IntervalCount must >= `minIntervalCount` and <= `maxIntervalCount`
 //   1 - 144 inclusive.
 // transmissionRisk must be >= 0 and <= 8.
-//   Transmission risk is depercated, but should still be populated for compatibility
-//   with olrder clients. If it is omitted, and there is a valid report type,
+//   Transmission risk is optional, but should still be populated for compatibility
+//   with older clients. If it is omitted, and there is a valid report type,
 //   then transmissionRisk will be set to 0.
 //   IF there is a report type from the verification certificate AND tranismission risk
 //    is not set, then a report type of
@@ -131,7 +134,7 @@ type ExposureKey struct {
 	Key              string `json:"key"`
 	IntervalNumber   int32  `json:"rollingStartNumber"`
 	IntervalCount    int32  `json:"rollingPeriod"`
-	TransmissionRisk int    `json:"transmissionRisk"` // DEPRECATED
+	TransmissionRisk int    `json:"transmissionRisk,omitempty"` // Optional
 }
 
 // ExposureKeys represents a set of ExposureKey objects as input to

--- a/pkg/api/v1/verification_types.go
+++ b/pkg/api/v1/verification_types.go
@@ -54,16 +54,20 @@ const (
 // This data is used to set data on the uploaded TEKs and will be reflected on export. See the export file format:
 // https://github.com/google/exposure-notifications-server/blob/main/internal/pb/export/export.proto#L73
 type VerificationClaims struct {
+	jwt.StandardClaims
+
 	// ReportType is one of 'confirmed', 'likely', or 'negative' as defined by the constants in this file.
+	// Required. Claims must contain a valid report type or the publish request won't have any effect.
 	ReportType string `json:"reportType"`
 	// SymptomOnsetInterval uses the same 10 minute interval timing as TEKs use. If an interval is provided that isn not the
 	// start of a UTC day, then it will be rounded down to the beginning of that UTC day. And from there the days +/- symptom
 	// onset will be calculated.
-	SymptomOnsetInterval uint32 `json:"symptomOnsetInterval"`
+	// Optional. If present, TEKs will be adjusted accordingly on publish.
+	SymptomOnsetInterval uint32 `json:"symptomOnsetInterval,omitempty"`
 
 	// SignedMac is the HMAC of the TEKs that may be uploaded with the certificate containing these claims.
+	// Required, indicates what can be uploaded with this certificate.
 	SignedMAC string `json:"tekmac"`
-	jwt.StandardClaims
 }
 
 // NewVerificationClaims initializes a new VerificationClaims struct.

--- a/pkg/api/v1/verification_types.go
+++ b/pkg/api/v1/verification_types.go
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package v1alpha1 contains API definitions that can be used outside of this
-// codebase in their alpha form.
-// These APIs are not considered to be stable at HEAD.
-package v1alpha1
+// Package v1 contains API definitions that can be used outside of this codebase.
+// The v1 API is considered stable.
+// It will only add new optional fields and no fields will be removed.
+package v1
 
 import (
-	"sort"
-
 	"github.com/dgrijalva/jwt-go"
 )
 
@@ -52,35 +50,6 @@ const (
 	TransmissionRiskNegative          = 6
 )
 
-// TransmissionRiskVector is an additional set of claims that can be
-// included in the verification certificatin for a diagnosis as received
-// from a trusted public health authority.
-// DEPRECATED - If received at a server, these values are ignored. Will be removed in v0.3
-type TransmissionRiskVector []TransmissionRiskOverride
-
-// Compile time check that TransmissionRiskVector implements the sort interface.
-var _ sort.Interface = TransmissionRiskVector{}
-
-// TransmissionRiskOverride is an indvidual transmission risk override.
-type TransmissionRiskOverride struct {
-	TransmissionRisk     int   `json:"tr"`
-	SinceRollingInterval int32 `json:"sinceRollingInterval"`
-}
-
-func (a TransmissionRiskVector) Len() int {
-	return len(a)
-}
-
-// Less sorts the TransmissionRiskVector vector with the largest SinceRollingPeriod
-// value first. Descending sort.
-func (a TransmissionRiskVector) Less(i, j int) bool {
-	return a[i].SinceRollingInterval > a[j].SinceRollingInterval
-}
-
-func (a TransmissionRiskVector) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
 // VerificationClaims represents the accepted Claims portion of the verification certificate JWT.
 // This data is used to set data on the uploaded TEKs and will be reflected on export. See the export file format:
 // https://github.com/google/exposure-notifications-server/blob/main/internal/pb/export/export.proto#L73
@@ -92,18 +61,12 @@ type VerificationClaims struct {
 	// onset will be calculated.
 	SymptomOnsetInterval uint32 `json:"symptomOnsetInterval"`
 
-	// Deprecated, but not scheduled for removal.
-	// TransmissionRisks will continue to be supported. On newer versions of the device software,
-	// the ReportType and days +/- symptom onset will be used.
-	TransmissionRisks TransmissionRiskVector `json:"trisk,omitempty"`
-
+	// SignedMac is the HMAC of the TEKs that may be uploaded with the certificate containing these claims.
 	SignedMAC string `json:"tekmac"`
 	jwt.StandardClaims
 }
 
 // NewVerificationClaims initializes a new VerificationClaims struct.
 func NewVerificationClaims() *VerificationClaims {
-	return &VerificationClaims{
-		TransmissionRisks: []TransmissionRiskOverride{},
-	}
+	return &VerificationClaims{}
 }

--- a/pkg/api/v1alpha1/exposure_types.go
+++ b/pkg/api/v1alpha1/exposure_types.go
@@ -56,6 +56,10 @@ const (
 //  - Does not have to be within range of any of the provided keys (i.e. future
 //    key uploads)
 //
+// traveler - set to true if the TEKs in this publish set are consider to be the
+//  keys of a "traveler" who has left the home region represented by this server
+//  (or by the home health authority in case of a multi-tenant installation).
+//
 // revisionToken: An opaque string that must be passed in-tact from on additional
 //   publish requests from the same device, there the same TEKs may be published
 //   again.
@@ -72,6 +76,7 @@ type Publish struct {
 	VerificationPayload  string        `json:"verificationPayload"`
 	HMACKey              string        `json:"hmackey"`
 	SymptomOnsetInterval int32         `json:"symptomOnsetInterval"`
+	Traveler             bool          `json:"traveler"`
 	RevisionToken        string        `json:"revisionToken"`
 
 	Padding string `json:"padding"`

--- a/pkg/api/v1alpha1/exposure_types.go
+++ b/pkg/api/v1alpha1/exposure_types.go
@@ -56,10 +56,6 @@ const (
 //  - Does not have to be within range of any of the provided keys (i.e. future
 //    key uploads)
 //
-// traveler - set to true if the TEKs in this publish set are consider to be the
-//  keys of a "traveler" who has left the home region represented by this server
-//  (or by the home health authority in case of a multi-tenant installation).
-//
 // revisionToken: An opaque string that must be passed in-tact from on additional
 //   publish requests from the same device, there the same TEKs may be published
 //   again.
@@ -76,7 +72,6 @@ type Publish struct {
 	VerificationPayload  string        `json:"verificationPayload"`
 	HMACKey              string        `json:"hmackey"`
 	SymptomOnsetInterval int32         `json:"symptomOnsetInterval"`
-	Traveler             bool          `json:"traveler"`
 	RevisionToken        string        `json:"revisionToken"`
 
 	Padding string `json:"padding"`

--- a/pkg/util/generate.go
+++ b/pkg/util/generate.go
@@ -22,7 +22,7 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 )
 
@@ -66,11 +66,11 @@ func RandomRevisedReportType() (string, error) {
 	}
 	switch n {
 	case 0:
-		return v1alpha1.ReportTypeConfirmed, nil
+		return v1.ReportTypeConfirmed, nil
 	case 1:
-		return v1alpha1.ReportTypeNegative, nil
+		return v1.ReportTypeNegative, nil
 	}
-	return v1alpha1.ReportTypeConfirmed, nil
+	return v1.ReportTypeConfirmed, nil
 }
 
 func RandomReportType() (string, error) {
@@ -80,18 +80,18 @@ func RandomReportType() (string, error) {
 	}
 	switch n {
 	case 0:
-		return v1alpha1.ReportTypeConfirmed, nil
+		return v1.ReportTypeConfirmed, nil
 	case 1:
-		return v1alpha1.ReportTypeClinical, nil
+		return v1.ReportTypeClinical, nil
 	case 2:
-		return v1alpha1.ReportTypeNegative, nil
+		return v1.ReportTypeNegative, nil
 	}
-	return v1alpha1.ReportTypeConfirmed, nil
+	return v1.ReportTypeConfirmed, nil
 }
 
 // RandomTransmissionRisk produces a random transmission risk score.
 func RandomTransmissionRisk() (int, error) {
-	n, err := RandomInt(v1alpha1.MaxTransmissionRisk)
+	n, err := RandomInt(v1.MaxTransmissionRisk)
 	return n + 1, err
 }
 
@@ -105,7 +105,7 @@ func RandomArrValue(arr []string) (string, error) {
 }
 
 // GenerateExposureKeys creates the given number of exposure keys.
-func GenerateExposureKeys(numKeys, tr int, randomInterval bool) []v1alpha1.ExposureKey {
+func GenerateExposureKeys(numKeys, tr int, randomInterval bool) []v1.ExposureKey {
 	// When publishing multiple keys - they'll be on different days.
 	var err error
 	intervalCount := int32(144)
@@ -118,7 +118,7 @@ func GenerateExposureKeys(numKeys, tr int, randomInterval bool) []v1alpha1.Expos
 	// Keys will normally align to UTC day boundries.
 	utcDay := time.Now().UTC().Truncate(24 * time.Hour)
 	intervalNumber := int32(utcDay.Unix()/600) - intervalCount
-	exposureKeys := make([]v1alpha1.ExposureKey, numKeys)
+	exposureKeys := make([]v1.ExposureKey, numKeys)
 	for i := 0; i < numKeys; i++ {
 		transmissionRisk := tr
 		if transmissionRisk < 0 {
@@ -145,12 +145,12 @@ func GenerateExposureKeys(numKeys, tr int, randomInterval bool) []v1alpha1.Expos
 }
 
 // RandomExposureKey creates a random exposure key.
-func RandomExposureKey(intervalNumber int32, intervalCount int32, transmissionRisk int) (v1alpha1.ExposureKey, error) {
+func RandomExposureKey(intervalNumber int32, intervalCount int32, transmissionRisk int) (v1.ExposureKey, error) {
 	key, err := GenerateKey()
 	if err != nil {
-		return v1alpha1.ExposureKey{}, err
+		return v1.ExposureKey{}, err
 	}
-	return v1alpha1.ExposureKey{
+	return v1.ExposureKey{
 		Key:              key,
 		IntervalNumber:   int32(intervalNumber),
 		IntervalCount:    intervalCount,

--- a/pkg/verification/utils.go
+++ b/pkg/verification/utils.go
@@ -32,16 +32,17 @@ import (
 	"sort"
 	"strings"
 
-	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 )
 
 // CalculateExpsureKeyHMACv1Alpha1 is a convenience method for anyone still on v1alpha1.
-// This method is DEPRECATED and will be removed in v0.3
+// Deprecated: use CalculateExposureKeyHMAC instead
+// Preserved for clients on v1alpha1, will be removed in v0.3 release.
 func CalculateExpsureKeyHMACv1Alpha1(legacyKeys []v1alpha1.ExposureKey, secret []byte) ([]byte, error) {
-	keys := make([]v1.ExposureKey, len(legacyKeys))
+	keys := make([]verifyapi.ExposureKey, len(legacyKeys))
 	for i, k := range legacyKeys {
-		keys[i] = v1.ExposureKey{
+		keys[i] = verifyapi.ExposureKey{
 			Key:              k.Key,
 			IntervalNumber:   k.IntervalNumber,
 			IntervalCount:    k.IntervalCount,
@@ -53,7 +54,7 @@ func CalculateExpsureKeyHMACv1Alpha1(legacyKeys []v1alpha1.ExposureKey, secret [
 
 // CalculateExposureKeyHMAC will calculate the verification protocol HMAC value.
 // Input keys are already to be base64 encoded. They will be sorted if necessary.
-func CalculateExposureKeyHMAC(keys []v1.ExposureKey, secret []byte) ([]byte, error) {
+func CalculateExposureKeyHMAC(keys []verifyapi.ExposureKey, secret []byte) ([]byte, error) {
 	if len(keys) == 0 {
 		return nil, fmt.Errorf("cannot calculate hmac on empty exposure keys")
 	}

--- a/pkg/verification/utils.go
+++ b/pkg/verification/utils.go
@@ -32,12 +32,28 @@ import (
 	"sort"
 	"strings"
 
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 )
+
+// CalculateExpsureKeyHMACv1Alpha1 is a convenience method for anyone still on v1alpha1.
+// This method is DEPRECATED and will be removed in v0.3
+func CalculateExpsureKeyHMACv1Alpha1(legacyKeys []v1alpha1.ExposureKey, secret []byte) ([]byte, error) {
+	keys := make([]v1.ExposureKey, len(legacyKeys))
+	for i, k := range legacyKeys {
+		keys[i] = v1.ExposureKey{
+			Key:              k.Key,
+			IntervalNumber:   k.IntervalNumber,
+			IntervalCount:    k.IntervalCount,
+			TransmissionRisk: k.TransmissionRisk,
+		}
+	}
+	return CalculateExposureKeyHMAC(keys, secret)
+}
 
 // CalculateExposureKeyHMAC will calculate the verification protocol HMAC value.
 // Input keys are already to be base64 encoded. They will be sorted if necessary.
-func CalculateExposureKeyHMAC(keys []verifyapi.ExposureKey, secret []byte) ([]byte, error) {
+func CalculateExposureKeyHMAC(keys []v1.ExposureKey, secret []byte) ([]byte, error) {
 	if len(keys) == 0 {
 		return nil, fmt.Errorf("cannot calculate hmac on empty exposure keys")
 	}

--- a/pkg/verification/utils_test.go
+++ b/pkg/verification/utils_test.go
@@ -18,13 +18,13 @@ import (
 	"encoding/base64"
 	"testing"
 
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
 
 func TestCalculateHac(t *testing.T) {
 	secret := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
-	eKeys := []verifyapi.ExposureKey{
+	eKeys := []v1.ExposureKey{
 		{
 			Key:              "z2Cx9hdz2SlxZ8GEgqTYpA==",
 			IntervalNumber:   1,

--- a/pkg/verification/utils_test.go
+++ b/pkg/verification/utils_test.go
@@ -18,13 +18,13 @@ import (
 	"encoding/base64"
 	"testing"
 
-	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
 
 func TestCalculateHac(t *testing.T) {
 	secret := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 
-	eKeys := []v1.ExposureKey{
+	eKeys := []verifyapi.ExposureKey{
 		{
 			Key:              "z2Cx9hdz2SlxZ8GEgqTYpA==",
 			IntervalNumber:   1,

--- a/tools/admin-console/templates/authorizedapp.html
+++ b/tools/admin-console/templates/authorizedapp.html
@@ -2,25 +2,26 @@
 {{template "top" .}}
 
 {{if .new}}
-<h2>Create New Authorized Application</h2>
+<h2>Create New Authorized Health Authority</h2>
 {{else}}
-<h2>Edit Application {{.app.AppPackageName}}</h2>
+<h2>Edit Health Authority {{.app.AppPackageName}}</h2>
 {{end}}
 
 <form method="POST" action="/app" class="form-horizontal">
   <input type="hidden" name="Key" value="{{.previousKey}}" />
-  <div class="alert alert-info" role="alert">Basic Application Authorization Information</div>
+  <div class="alert alert-info" role="alert">Basic Information</div>
   <div class="form-group row">
-    <label class="control-label col-sm-3" for="AppPackageName">App Package Name / Bundle ID:</label>
+    <label class="control-label col-sm-3" for="AppPackageName">Health Authority ID:</label>
     <div class="col-sm-6">
       <input type="text" id="AppPackageName" name="AppPackageName" size="50" value="{{.app.AppPackageName}}">
+      <small id="RegionsHelpBlock" class="form-text text-muted">This exact string must be passed by clients. Reverse DNS is recommended, but not required.</small>
     </div>
   </div>
   <div class="form-group row">
     <label class="control-label col-sm-3" for="Regions">Regions:</label>
     <div class="col-sm-6">
       <textarea class="form-control" name="Regions" id="Regions" rows="3">{{.app.RegionsOnePerLine}}</textarea>
-      <small id="RegionsHelpBlock" class="form-text text-muted">One per line, leave blank for all</small>
+      <small id="RegionsHelpBlock" class="form-text text-muted">One per line. TEKs uploaded by this health authority will be present in all configurd regions (v1 API)</small>
     </div>
   </div>
   <hr/>

--- a/tools/admin-console/templates/index.html
+++ b/tools/admin-console/templates/index.html
@@ -1,20 +1,20 @@
 {{define "index"}}
 {{template "top" .}}
 
-<h2>Authorized Applications</h2>
+<h2>Authorized Health Authority Configuration</h2>
 <ul>
   {{if .apps}}
     {{range .apps}}
       <li><a href="/app?apn={{.AppPackageName}}">{{.AppPackageName}}</a></li>
     {{end}}
   {{else}}
-    <li><i>There are no authorized applications</i></li>
+    <li><i>There are no authorized health authorities</i></li>
   {{end}}
 </ul>
-<a href="/app?apn=" class="btn btn-outline-primary">Create new Authorized Application</a>
+<a href="/app?apn=" class="btn btn-outline-primary">Create new Authorized Health Authority</a>
 
 <hr/>
-<h2>Health Authority and Health Authority Keys</h2>
+<h2>Health Authority Verification Key Keys</h2>
 <ul>
   {{if .healthauthorities}}
     {{range .healthauthorities}}
@@ -24,7 +24,7 @@
     <li><i>There are no health authorities configured</i><li>
   {{end}}
 </ul>
-<a href="/healthauthority/0" class="btn btn-outline-primary">Create new Health Authority</a>
+<a href="/healthauthority/0" class="btn btn-outline-primary">Create new Health Authority Key Configuration</a>
 
 <hr/>
 <h2>Export Configurations</h2>

--- a/tools/export-generate/main.go
+++ b/tools/export-generate/main.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/util"
 
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
 
 var (

--- a/tools/exposure-client/main.go
+++ b/tools/exposure-client/main.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/util"
 )
 
@@ -63,7 +63,7 @@ func realMain() error {
 		return fmt.Errorf("failed to get random padding: %w", err)
 	}
 
-	data := v1.Publish{
+	data := verifyapi.Publish{
 		Keys:              exposureKeys,
 		HealthAuthorityID: *healthAuthority,
 		Padding:           base64.RawStdEncoding.EncodeToString(padding),

--- a/tools/hmac-calculator/main.go
+++ b/tools/hmac-calculator/main.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"os"
 
-	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-server/pkg/verification"
 )
@@ -59,7 +59,7 @@ func main() {
 	log.Printf("Expected HMAC B64: %v", base64.StdEncoding.EncodeToString(wantHMAC))
 }
 
-func ReadFile(fname string) (*v1.Publish, error) {
+func ReadFile(fname string) (*verifyapi.Publish, error) {
 	f, err := os.Open(fname)
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func ReadFile(fname string) (*v1.Publish, error) {
 		return nil, fmt.Errorf("file too large: %v - more than %v bytes", fname, bufferSize)
 	}
 
-	var publish v1.Publish
+	var publish verifyapi.Publish
 	if err := json.Unmarshal(buffer[0:n], &publish); err != nil {
 		return nil, fmt.Errorf("json.Unmarshal: %w", err)
 	}

--- a/tools/hmac-calculator/main.go
+++ b/tools/hmac-calculator/main.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	v1 "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-server/pkg/verification"
 )
@@ -59,7 +59,7 @@ func main() {
 	log.Printf("Expected HMAC B64: %v", base64.StdEncoding.EncodeToString(wantHMAC))
 }
 
-func ReadFile(fname string) (*v1alpha1.Publish, error) {
+func ReadFile(fname string) (*v1.Publish, error) {
 	f, err := os.Open(fname)
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func ReadFile(fname string) (*v1alpha1.Publish, error) {
 		return nil, fmt.Errorf("file too large: %v - more than %v bytes", fname, bufferSize)
 	}
 
-	var publish v1alpha1.Publish
+	var publish v1.Publish
 	if err := json.Unmarshal(buffer[0:n], &publish); err != nil {
 		return nil, fmt.Errorf("json.Unmarshal: %w", err)
 	}


### PR DESCRIPTION
    Create v1 publish API
    
    * upconvert from v1alpha1 (scheduled for removal)
    * add "traveler" boolean indicating a key has left the designed HA boundry
    * change authorized app to health authority ID
    * default the region(s) for a health authority
    
    Fixes #792
    Fixes #793
    Basis for #794