### PR TITLE
Make it so revision token issues are 4xx instead of 5xx errors.

### DIFF
--- a/pkg/api/v1/exposure_types.go
+++ b/pkg/api/v1/exposure_types.go
@@ -49,6 +49,11 @@ const (
 	ErrorBadRequest = "bad_request"
 	// ErrorInternalError
 	ErrorInternalError = "internal_error"
+	// ErrorMissingRevisionToken indicates no reivison token passed when one is needed
+	ErrorMissingRevisionToken = "missing_revision_token"
+	// ErrorInvalidRevisionToken indicates a revision token was passed, but is missing a
+	// key or has invalid metadata.
+	ErrorInvalidRevisionToken = "invalid_revision_token"
 )
 
 // Publish represents the body of the PublishInfectedIds API call.


### PR DESCRIPTION
Fixes #804 

it's mostly tests...

**Release Note**

```release-note
Revision token issues now return specific error codes and result in 400 level errors.
v1 API definition contains new error codes.
```