### PR TITLE
enforce previously documented restriction on verification certificate…

### DIFF
--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -316,8 +316,9 @@ func TestPublishWithBypass(t *testing.T) {
 				HealthAuthorityID:   names.current(),
 				VerificationPayload: "totally not a JWT",
 			},
-			Regions: []string{}, // will receive defaults
-			Code:    http.StatusOK,
+			ReportType: verifyapi.ReportTypeConfirmed,
+			Regions:    []string{}, // will receive defaults
+			Code:       http.StatusOK,
 		},
 		{
 			Name:       "valid_HA_certificate_with_overrides",

--- a/internal/verification/phaverify.go
+++ b/internal/verification/phaverify.go
@@ -124,6 +124,11 @@ func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamo
 		return nil, fmt.Errorf("app %v has not authorized health authority issuer: %v", authApp.AppPackageName, claims.Issuer)
 	}
 
+	// Verify our cutom claim types
+	if err := claims.CustomClaimsValid(); err != nil {
+		return nil, err
+	}
+
 	// Verify the HMAC.
 	jwtHMAC, err := base64util.DecodeString(claims.SignedMAC)
 	if err != nil {

--- a/pkg/api/v1/verification_types.go
+++ b/pkg/api/v1/verification_types.go
@@ -18,6 +18,8 @@
 package v1
 
 import (
+	"fmt"
+
 	"github.com/dgrijalva/jwt-go"
 )
 
@@ -50,6 +52,14 @@ const (
 	TransmissionRiskNegative          = 6
 )
 
+var (
+	ValidReportTypes = map[string]bool{
+		ReportTypeConfirmed: true,
+		ReportTypeClinical:  true,
+		ReportTypeNegative:  true,
+	}
+)
+
 // VerificationClaims represents the accepted Claims portion of the verification certificate JWT.
 // This data is used to set data on the uploaded TEKs and will be reflected on export. See the export file format:
 // https://github.com/google/exposure-notifications-server/blob/main/internal/pb/export/export.proto#L73
@@ -73,4 +83,13 @@ type VerificationClaims struct {
 // NewVerificationClaims initializes a new VerificationClaims struct.
 func NewVerificationClaims() *VerificationClaims {
 	return &VerificationClaims{}
+}
+
+// CustomClaimsValid returns nil if the custom claims are valid.
+// .Valid() should still be called to validate the standard claims.
+func (v *VerificationClaims) CustomClaimsValid() error {
+	if !ValidReportTypes[v.ReportType] {
+		return fmt.Errorf("invalid report type: %q", v.ReportType)
+	}
+	return nil
 }

--- a/pkg/api/v1/veritifcation_types_test.go
+++ b/pkg/api/v1/veritifcation_types_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateClaims(t *testing.T) {
+	c := NewVerificationClaims()
+	c.ReportType = "bogus"
+
+	if err := c.CustomClaimsValid(); err == nil {
+		t.Fatal("expected an error, got nil")
+	} else if !strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("wanted an error that contained bogus, got: %v", err)
+	}
+
+	for k, _ := range ValidReportTypes {
+		c.ReportType = k
+		if err := c.CustomClaimsValid(); err != nil {
+			t.Errorf("got error when using valid report type: %q, err: %v", k, err)
+		}
+	}
+}

--- a/pkg/api/v1/veritifcation_types_test.go
+++ b/pkg/api/v1/veritifcation_types_test.go
@@ -29,7 +29,7 @@ func TestValidateClaims(t *testing.T) {
 		t.Fatalf("wanted an error that contained bogus, got: %v", err)
 	}
 
-	for k, _ := range ValidReportTypes {
+	for k := range ValidReportTypes {
 		c.ReportType = k
 		if err := c.CustomClaimsValid(); err != nil {
 			t.Errorf("got error when using valid report type: %q, err: %v", k, err)


### PR DESCRIPTION
…s containing a valid report type

Fixes #822 

## Proposed Changes

* ReportType is documented in v1 API as required, actually enforce that.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Added validation of ReportType claim in verification certificates. All verification certificates must include a valid report type or the publish request will be rejected.
```