### PR TITLE
Add traveler bit to exports

### DIFF
--- a/internal/admin/exports/form.go
+++ b/internal/admin/exports/form.go
@@ -24,16 +24,17 @@ import (
 )
 
 type formData struct {
-	OutputRegion string        `form:"OutputRegion"`
-	InputRegions string        `form:"InputRegions"`
-	BucketName   string        `form:"BucketName"`
-	FilenameRoot string        `form:"FilenameRoot"`
-	Period       time.Duration `form:"Period"`
-	FromDate     string        `form:"fromdate"`
-	FromTime     string        `form:"fromtime"`
-	ThruDate     string        `form:"thrudate"`
-	ThruTime     string        `form:"thrutime"`
-	SigInfoIDs   []int64       `form:"siginfo"`
+	OutputRegion     string        `form:"OutputRegion"`
+	InputRegions     string        `form:"InputRegions"`
+	IncludeTravelers bool          `form:"IncludeTravelers"`
+	BucketName       string        `form:"BucketName"`
+	FilenameRoot     string        `form:"FilenameRoot"`
+	Period           time.Duration `form:"Period"`
+	FromDate         string        `form:"fromdate"`
+	FromTime         string        `form:"fromtime"`
+	ThruDate         string        `form:"thrudate"`
+	ThruTime         string        `form:"thrutime"`
+	SigInfoIDs       []int64       `form:"siginfo"`
 }
 
 func (f *formData) PopulateExportConfig(ec *model.ExportConfig) error {
@@ -57,6 +58,7 @@ func (f *formData) PopulateExportConfig(ec *model.ExportConfig) error {
 			ec.InputRegions = append(ec.InputRegions, strings.TrimSpace(s))
 		}
 	}
+	ec.IncludeTravelers = f.IncludeTravelers
 	ec.From = from
 	ec.Thru = thru
 	ec.SignatureInfoIDs = f.SigInfoIDs

--- a/internal/admin/exports/view.go
+++ b/internal/admin/exports/view.go
@@ -45,6 +45,7 @@ func (v *viewController) Execute(c *gin.Context) {
 	if idParam := c.Param("id"); idParam == "0" {
 		// Default the period to suggest an appropriate value.
 		exportConfig.Period = 24 * time.Hour
+		exportConfig.IncludeTravelers = true // Encourage this default.
 		m.AddJumbotron("Export Config", "Create New Export Config")
 	} else {
 		m.AddJumbotron("Export Config", "Edit Export Config")

--- a/internal/export/batcher.go
+++ b/internal/export/batcher.go
@@ -128,6 +128,7 @@ func (s *Server) maybeCreateBatches(ctx context.Context, ec *model.ExportConfig,
 			EndTimestamp:     br.end,
 			OutputRegion:     ec.OutputRegion,
 			InputRegions:     ec.InputRegions,
+			IncludeTravelers: ec.IncludeTravelers,
 			Status:           model.ExportBatchOpen,
 			SignatureInfoIDs: infoIds,
 		})

--- a/internal/export/model/export_model.go
+++ b/internal/export/model/export_model.go
@@ -39,6 +39,7 @@ type ExportConfig struct {
 	Period           time.Duration
 	OutputRegion     string
 	InputRegions     []string
+	IncludeTravelers bool
 	From             time.Time
 	Thru             time.Time
 	SignatureInfoIDs []int64
@@ -103,6 +104,7 @@ type ExportBatch struct {
 	EndTimestamp     time.Time
 	OutputRegion     string
 	InputRegions     []string
+	IncludeTravelers bool
 	Status           string
 	LeaseExpires     time.Time
 	SignatureInfoIDs []int64
@@ -115,14 +117,15 @@ func (eb *ExportBatch) EffectiveInputRegions() []string {
 }
 
 type ExportFile struct {
-	BucketName   string
-	Filename     string
-	BatchID      int64
-	OutputRegion string
-	InputRegions []string
-	BatchNum     int
-	BatchSize    int
-	Status       string
+	BucketName       string
+	Filename         string
+	BatchID          int64
+	OutputRegion     string
+	InputRegions     []string
+	IncludeTravelers bool
+	BatchNum         int
+	BatchSize        int
+	Status           string
 }
 
 // EffectiveInputRegions either returns `InputRegions` or if that array is

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -117,7 +117,8 @@ func (s *Server) exportBatch(ctx context.Context, eb *model.ExportBatch, emitInd
 		SinceTimestamp:      eb.StartTimestamp,
 		UntilTimestamp:      eb.EndTimestamp,
 		IncludeRegions:      eb.EffectiveInputRegions(),
-		OnlyLocalProvenance: false, // include federated ids
+		IncludeTravelers:    eb.IncludeTravelers, // Travelers are included from "any" region.
+		OnlyLocalProvenance: false,               // include federated ids
 		OnlyRevisedKeys:     false,
 	}
 

--- a/migrations/000036_ExportTravellerSettings.down.sql
+++ b/migrations/000036_ExportTravellerSettings.down.sql
@@ -1,0 +1,26 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE exportconfig
+    DROP COLUMN include_travelers;
+
+ALTER TABLE exportbatch
+    DROP COLUMN include_travelers;
+
+ALTER TABLE exportfile
+    DROP COLUMN include_travelers;
+
+END;

--- a/migrations/000036_ExportTravellerSettings.up.sql
+++ b/migrations/000036_ExportTravellerSettings.up.sql
@@ -1,0 +1,26 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE exportconfig
+    ADD COLUMN include_travelers bool NOT NULL DEFAULT false;
+
+ALTER TABLE exportbatch
+    ADD COLUMN include_travelers bool NOT NULL DEFAULT false;
+
+ALTER TABLE exportfile
+    ADD COLUMN include_travelers bool NOT NULL DEFAULT false;
+
+END;

--- a/tools/admin-console/templates/export.html
+++ b/tools/admin-console/templates/export.html
@@ -37,6 +37,20 @@
 			  to combine multiple regions/apps uploaded to this server.</small>
 		</div>
 	</div>
+	<div class="form-group row">
+		<label class="control-label col-sm-3" for="IncludeTravelers">Include Travelers:</label>
+		<div class="col-sm-6">
+			<select name="IncludeTravelers" id="IncludeTravelers">
+				<option value="true" {{if .export.IncludeTravelers}}selected{{end}}>Yes</option>
+				<option value="false" {{if not .export.IncludeTravelers}}selected{{end}}>No</option>
+			  </select>
+			<small id="InputRegionsHelpBlock" class="form-text text-muted">Should federeated-in traveler
+				keys be included in this export. If this server is sharing keys with anouther server,
+				the recommended setting is 'yes'. Even if you are not yet federating, but may in the
+				future, 'yes' is still the recommended setting.
+			</small>
+		</div>
+	</div>
 
 	<div class="form-group row">
 		<label class="control-label col-sm-3" for="BucketName">Cloud Storage Bucket Name:</label>


### PR DESCRIPTION
Fixes #794 

## Proposed Changes

* Add include_travlers to all export models
* Set that bit on the iterate exposures when generating exports (using existing functionality
* Update admin console so this can be configured

**Release Note**


```release-note
ExportConfig supports the v1 API traveler bit, allowing exports to include "home" region and keys of federated-in travelers.
```