### PR TITLE
implement alternative HMAC calculation

### DIFF
--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -77,161 +77,180 @@ func TestVerifyCertificate(t *testing.T) {
 		},
 	}
 
-	for version := 0; version <= 1; version++ {
-		for _, tc := range cases {
-			tc := tc
+	for iteration := 0; iteration < 2; iteration++ {
+		for version := 0; version <= 1; version++ {
+			for _, tc := range cases {
+				tc := tc
 
-			vname := "v1alpha1"
-			if version == 1 {
-				vname = "v1"
+				vname := "v1alpha1"
+				if version == 1 {
+					vname = "v1"
+				}
+				mod := "withTR"
+				if iteration == 0 {
+					mod = "withoutTR"
+				}
+
+				t.Run(tc.Name+"_"+vname+"_"+mod, func(t *testing.T) {
+					t.Parallel()
+
+					// Generate ECDSA key pair.
+					privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+					if err != nil {
+						t.Fatal(err)
+					}
+					publicKey := privateKey.Public()
+
+					// Get the PEM for the public key.
+					x509EncodedPub, err := x509.MarshalPKIXPublicKey(publicKey)
+					if err != nil {
+						t.Fatal(err)
+					}
+					pemEncodedPub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x509EncodedPub})
+					pemPublicKey := string(pemEncodedPub)
+
+					// Set up database. Create HealthAuthority + HAKey for the test.
+					testDB := coredb.NewTestDatabase(t)
+					ctx := context.Background()
+					haDB := database.New(testDB)
+
+					healthAuthority := model.HealthAuthority{
+						Issuer:   "doh.my.gov",
+						Audience: "exposure-notifications-server",
+						Name:     "Very Real Health Authority",
+					}
+					if err := haDB.AddHealthAuthority(ctx, &healthAuthority); err != nil {
+						t.Fatal(err)
+					}
+
+					hak := model.HealthAuthorityKey{
+						Version:      "v1",
+						From:         time.Now(),
+						PublicKeyPEM: pemPublicKey,
+					}
+					if err := haDB.AddHealthAuthorityKey(ctx, &healthAuthority, &hak); err != nil {
+						t.Fatal(err)
+					}
+
+					// Build the verification certificate.
+					hmacKeyBytes := make([]byte, 32)
+					if _, err := rand.Read(hmacKeyBytes); err != nil {
+						t.Fatal(err)
+					}
+					hmacKeyB64 := base64.StdEncoding.EncodeToString(hmacKeyBytes)
+
+					// Fake authorized app.
+					authApp := aamodel.NewAuthorizedApp()
+					authApp.AllowedHealthAuthorityIDs[healthAuthority.ID] = struct{}{}
+
+					// Build a sample certificate.
+					publish := verifyapi.Publish{
+						Keys: []verifyapi.ExposureKey{
+							{
+								Key:              "IRgYIhYiy4WMl9z68bMk6w==",
+								IntervalNumber:   2650032,
+								IntervalCount:    144,
+								TransmissionRisk: 4,
+							},
+							{
+								Key:              "dPCphLzfG4uzXneNimkPRQ====",
+								IntervalNumber:   2650032 + 144,
+								IntervalCount:    144,
+								TransmissionRisk: 4,
+							},
+							{
+								Key:              "5AUyPfJKcg5cr3OgKdR8Sw==",
+								IntervalNumber:   2650032 + 144*2,
+								IntervalCount:    144,
+								TransmissionRisk: 4,
+							},
+						},
+					}
+					// Iteration 0 uses the "alt" hmac.
+					if iteration == 0 {
+						for i := range publish.Keys {
+							publish.Keys[i].TransmissionRisk = 0
+						}
+					}
+
+					// Calculate the HMAC.
+					allHMACs, err := utils.CalculateAllAllowedExposureKeyHMAC(publish.Keys, hmacKeyBytes)
+					if err != nil {
+						t.Fatal(err)
+					}
+					hmac := allHMACs[0]
+					if iteration == 0 {
+						if l := len(allHMACs); l != 2 {
+							t.Fatalf("expected 2 hmacs, got: %v", l)
+						}
+						hmac = allHMACs[1]
+					}
+
+					var claims jwt.Claims
+					if version == 0 {
+						v1alpha1claims := v1alpha1.NewVerificationClaims()
+						v1alpha1claims.Audience = "exposure-notifications-server"
+						v1alpha1claims.Issuer = "doh.my.gov"
+						v1alpha1claims.IssuedAt = time.Now().Add(tc.Warp).Unix()
+						v1alpha1claims.ExpiresAt = time.Now().Add(tc.Warp).Add(5 * time.Minute).Unix()
+						v1alpha1claims.SignedMAC = tc.MacAdjustment + base64.StdEncoding.EncodeToString(hmac) // would be generated on the client and passed through.
+						v1alpha1claims.ReportType = "confirmed"
+						v1alpha1claims.SymptomOnsetInterval = 250250
+						// contains legacy transmission risk field, but will be an empty array, just there.
+						claims = v1alpha1claims
+					} else {
+						v1claims := verifyapi.NewVerificationClaims()
+						v1claims.Audience = "exposure-notifications-server"
+						v1claims.Issuer = "doh.my.gov"
+						v1claims.IssuedAt = time.Now().Add(tc.Warp).Unix()
+						v1claims.ExpiresAt = time.Now().Add(tc.Warp).Add(5 * time.Minute).Unix()
+						v1claims.SignedMAC = tc.MacAdjustment + base64.StdEncoding.EncodeToString(hmac)
+						v1claims.ReportType = "confirmed"
+						v1claims.SymptomOnsetInterval = 250250
+						claims = v1claims
+					}
+
+					token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+					token.Header["kid"] = "v1" // matches the key configured above.
+					jwtText, err := token.SignedString(privateKey)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					// Insert this data into the publish request.
+					publish.VerificationPayload = jwtText
+					publish.HMACKey = tc.MacKeyAdjustment + hmacKeyB64
+
+					// Actually test the verify code.
+					verifier, err := New(haDB, &Config{time.Nanosecond})
+					if err != nil {
+						t.Fatal(err)
+					}
+					verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish)
+					if err != nil {
+						if !strings.Contains(err.Error(), tc.Error) {
+							t.Fatalf("wanted error '%v', got error '%v'", tc.Error, err.Error())
+						}
+					} else if tc.Error != "" {
+						t.Fatalf("wanted error '%v', but got nil", tc.Error)
+					}
+
+					if tc.Error == "" {
+						if verifiedClaims == nil {
+							t.Fatalf("verified claims are nil")
+						}
+
+						want := &VerifiedClaims{
+							HealthAuthorityID:    healthAuthority.ID,
+							ReportType:           "confirmed",
+							SymptomOnsetInterval: 250250,
+						}
+						if diff := cmp.Diff(want, verifiedClaims); diff != "" {
+							t.Errorf("claims mismatch (-want, +got):\n%s", diff)
+						}
+					}
+				})
 			}
-
-			t.Run(tc.Name+"_"+vname, func(t *testing.T) {
-				t.Parallel()
-
-				// Generate ECDSA key pair.
-				privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-				if err != nil {
-					t.Fatal(err)
-				}
-				publicKey := privateKey.Public()
-
-				// Get the PEM for the public key.
-				x509EncodedPub, err := x509.MarshalPKIXPublicKey(publicKey)
-				if err != nil {
-					t.Fatal(err)
-				}
-				pemEncodedPub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x509EncodedPub})
-				pemPublicKey := string(pemEncodedPub)
-
-				// Set up database. Create HealthAuthority + HAKey for the test.
-				testDB := coredb.NewTestDatabase(t)
-				ctx := context.Background()
-				haDB := database.New(testDB)
-
-				healthAuthority := model.HealthAuthority{
-					Issuer:   "doh.my.gov",
-					Audience: "exposure-notifications-server",
-					Name:     "Very Real Health Authority",
-				}
-				if err := haDB.AddHealthAuthority(ctx, &healthAuthority); err != nil {
-					t.Fatal(err)
-				}
-
-				hak := model.HealthAuthorityKey{
-					Version:      "v1",
-					From:         time.Now(),
-					PublicKeyPEM: pemPublicKey,
-				}
-				if err := haDB.AddHealthAuthorityKey(ctx, &healthAuthority, &hak); err != nil {
-					t.Fatal(err)
-				}
-
-				// Build the verification certificate.
-				hmacKeyBytes := make([]byte, 32)
-				if _, err := rand.Read(hmacKeyBytes); err != nil {
-					t.Fatal(err)
-				}
-				hmacKeyB64 := base64.StdEncoding.EncodeToString(hmacKeyBytes)
-
-				// Fake authorized app.
-				authApp := aamodel.NewAuthorizedApp()
-				authApp.AllowedHealthAuthorityIDs[healthAuthority.ID] = struct{}{}
-
-				// Build a sample certificate.
-				publish := verifyapi.Publish{
-					Keys: []verifyapi.ExposureKey{
-						{
-							Key:              "IRgYIhYiy4WMl9z68bMk6w==",
-							IntervalNumber:   2650032,
-							IntervalCount:    144,
-							TransmissionRisk: 4,
-						},
-						{
-							Key:              "dPCphLzfG4uzXneNimkPRQ====",
-							IntervalNumber:   2650032 + 144,
-							IntervalCount:    144,
-							TransmissionRisk: 4,
-						},
-						{
-							Key:              "5AUyPfJKcg5cr3OgKdR8Sw==",
-							IntervalNumber:   2650032 + 144*2,
-							IntervalCount:    144,
-							TransmissionRisk: 4,
-						},
-					},
-				}
-
-				// Calculate the HMAC.
-				hmac, err := utils.CalculateExposureKeyHMAC(publish.Keys, hmacKeyBytes)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				var claims jwt.Claims
-				if version == 0 {
-					v1alpha1claims := v1alpha1.NewVerificationClaims()
-					v1alpha1claims.Audience = "exposure-notifications-server"
-					v1alpha1claims.Issuer = "doh.my.gov"
-					v1alpha1claims.IssuedAt = time.Now().Add(tc.Warp).Unix()
-					v1alpha1claims.ExpiresAt = time.Now().Add(tc.Warp).Add(5 * time.Minute).Unix()
-					v1alpha1claims.SignedMAC = tc.MacAdjustment + base64.StdEncoding.EncodeToString(hmac) // would be generated on the client and passed through.
-					v1alpha1claims.ReportType = "confirmed"
-					v1alpha1claims.SymptomOnsetInterval = 250250
-					// contains legacy transmission risk field, but will be an empty array, just there.
-					claims = v1alpha1claims
-				} else {
-					v1claims := verifyapi.NewVerificationClaims()
-					v1claims.Audience = "exposure-notifications-server"
-					v1claims.Issuer = "doh.my.gov"
-					v1claims.IssuedAt = time.Now().Add(tc.Warp).Unix()
-					v1claims.ExpiresAt = time.Now().Add(tc.Warp).Add(5 * time.Minute).Unix()
-					v1claims.SignedMAC = tc.MacAdjustment + base64.StdEncoding.EncodeToString(hmac)
-					v1claims.ReportType = "confirmed"
-					v1claims.SymptomOnsetInterval = 250250
-					claims = v1claims
-				}
-
-				token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
-				token.Header["kid"] = "v1" // matches the key configured above.
-				jwtText, err := token.SignedString(privateKey)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				// Insert this data into the publish request.
-				publish.VerificationPayload = jwtText
-				publish.HMACKey = tc.MacKeyAdjustment + hmacKeyB64
-
-				// Actually test the verify code.
-				verifier, err := New(haDB, &Config{time.Nanosecond})
-				if err != nil {
-					t.Fatal(err)
-				}
-				verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish)
-				if err != nil {
-					if !strings.Contains(err.Error(), tc.Error) {
-						t.Fatalf("wanted error '%v', got error '%v'", tc.Error, err.Error())
-					}
-				} else if tc.Error != "" {
-					t.Fatalf("wanted error '%v', but got nil", tc.Error)
-				}
-
-				if tc.Error == "" {
-					if verifiedClaims == nil {
-						t.Fatalf("verified claims are nil")
-					}
-
-					want := &VerifiedClaims{
-						HealthAuthorityID:    healthAuthority.ID,
-						ReportType:           "confirmed",
-						SymptomOnsetInterval: 250250,
-					}
-					if diff := cmp.Diff(want, verifiedClaims); diff != "" {
-						t.Errorf("claims mismatch (-want, +got):\n%s", diff)
-					}
-				}
-			})
 		}
 	}
 }


### PR DESCRIPTION
Fixes #811

## Proposed Changes

* If transmission risk isn't being used (v1.5+ clients), allow the HMAC in the verification certificate to be calculated w/ 3 segments instead of 4
* both HMAC calculations are accepted by the server, but alternative one is only calculated if the request has all transmission risk values set to 0 (default if not present in request)

**Release Note**

```release-note
Verification Certificate HMAC can be calculated without transmission risk values if transmission risk values are all 0
```