### PR TITLE
Deletion based off of createdAt of next key

### DIFF
--- a/internal/keyrotation/rotate.go
+++ b/internal/keyrotation/rotate.go
@@ -87,15 +87,14 @@ func (s *Server) doRotate(ctx context.Context) error {
 		if key.KeyID == effectiveID {
 			continue
 		}
-		// A key is safe to delete if the previous one was effective for the period.
 		if time.Since(previousCreated) < s.config.DeleteOldKeyPeriod {
-			continue
+			continue // A key is not safe to delete until the previous one was effective for the period.
 		}
-		previousCreated = key.CreatedAt
 		if err := s.revisionDB.DestroyKey(ctx, key.KeyID); err != nil {
 			result = multierror.Append(result, err)
 			continue
 		}
+		previousCreated = key.CreatedAt
 		deleted++
 	}
 

--- a/internal/keyrotation/rotate.go
+++ b/internal/keyrotation/rotate.go
@@ -88,7 +88,7 @@ func (s *Server) doRotate(ctx context.Context) error {
 			continue
 		}
 		if time.Since(previousCreated) < s.config.DeleteOldKeyPeriod {
-			continue // A key is not safe to delete until the previous one was effective for the period.
+			continue // A key is not safe to delete until the newer one was effective for the period.
 		}
 		if err := s.revisionDB.DestroyKey(ctx, key.KeyID); err != nil {
 			result = multierror.Append(result, err)

--- a/internal/keyrotation/rotate_test.go
+++ b/internal/keyrotation/rotate_test.go
@@ -46,7 +46,7 @@ func TestRotateKeys(t *testing.T) {
 	key, aad, wrapped := testMakeKey(ctx, t, kms, keyID)
 
 	neg20Days, _ := time.ParseDuration("-480h")
-	neg40Days, _ := time.ParseDuration("-480h")
+	neg40Days, _ := time.ParseDuration("-960h")
 	staleTime := time.Now().Add(neg20Days)
 	reallyStaleTime := time.Now().Add(neg40Days)
 	notStaleTime := time.Now()

--- a/internal/keyrotation/rotate_test.go
+++ b/internal/keyrotation/rotate_test.go
@@ -46,7 +46,9 @@ func TestRotateKeys(t *testing.T) {
 	key, aad, wrapped := testMakeKey(ctx, t, kms, keyID)
 
 	neg20Days, _ := time.ParseDuration("-480h")
+	neg40Days, _ := time.ParseDuration("-480h")
 	staleTime := time.Now().Add(neg20Days)
+	reallyStaleTime := time.Now().Add(neg40Days)
 	notStaleTime := time.Now()
 
 	testCases := []struct {
@@ -76,9 +78,9 @@ func TestRotateKeys(t *testing.T) {
 			},
 		},
 		{
-			name:             "one stale",
-			expectKeyCount:   1,
-			expectNotAllowed: []int64{111},
+			name:           "dont delete old effective",
+			expectKeyCount: 2, // should generate a new one
+			expectAllowed:  []int64{111},
 			keys: []revisiondb.RevisionKey{
 				{
 					KeyID:         111,
@@ -91,10 +93,9 @@ func TestRotateKeys(t *testing.T) {
 			},
 		},
 		{
-			name:             "one fresh, one stale",
-			expectKeyCount:   1,
-			expectAllowed:    []int64{121},
-			expectNotAllowed: []int64{122},
+			name:           "one fresh, one stale",
+			expectKeyCount: 2,
+			expectAllowed:  []int64{121, 122},
 			keys: []revisiondb.RevisionKey{
 				{
 					KeyID:         121,
@@ -107,6 +108,38 @@ func TestRotateKeys(t *testing.T) {
 				{
 					KeyID:         122,
 					CreatedAt:     staleTime,
+					Allowed:       true,
+					AAD:           aad,
+					WrappedCipher: wrapped,
+					DEK:           key,
+				},
+			},
+		},
+		{
+			name:             "very old retired",
+			expectKeyCount:   2,
+			expectAllowed:    []int64{131, 132},
+			expectNotAllowed: []int64{133},
+			keys: []revisiondb.RevisionKey{
+				{
+					KeyID:         131,
+					CreatedAt:     notStaleTime,
+					Allowed:       true,
+					AAD:           aad,
+					WrappedCipher: wrapped,
+					DEK:           key,
+				},
+				{
+					KeyID:         132,
+					CreatedAt:     staleTime,
+					Allowed:       true,
+					AAD:           aad,
+					WrappedCipher: wrapped,
+					DEK:           key,
+				},
+				{
+					KeyID:         133,
+					CreatedAt:     reallyStaleTime,
 					Allowed:       true,
 					AAD:           aad,
 					WrappedCipher: wrapped,


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-server/issues/791

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Only rotate keys if they are 15d older than the current effective key
    * Current impl compares to now