### PR TITLE
Override KeyManagerConfigProvider

### DIFF
--- a/internal/keyrotation/config.go
+++ b/internal/keyrotation/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	SecretManager         secrets.Config
 	ObservabilityExporter observability.Config
 	RevisionToken         revision.Config
+	KeyManager            keys.Config
 
 	Port string `env:"PORT, default=8080"`
 

--- a/internal/keyrotation/config.go
+++ b/internal/keyrotation/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/observability"
 	"github.com/google/exposure-notifications-server/internal/revision"
 	"github.com/google/exposure-notifications-server/internal/setup"
+	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
 )
 
@@ -28,6 +29,7 @@ import (
 var _ setup.DatabaseConfigProvider = (*Config)(nil)
 var _ setup.SecretManagerConfigProvider = (*Config)(nil)
 var _ setup.ObservabilityExporterConfigProvider = (*Config)(nil)
+var _ setup.KeyManagerConfigProvider = (*Config)(nil)
 
 // Config represents the configuration and associated environment variables for
 // the key rotation components.
@@ -59,4 +61,8 @@ func (c *Config) SecretManagerConfig() *secrets.Config {
 
 func (c *Config) ObservabilityExporterConfig() *observability.Config {
 	return &c.ObservabilityExporter
+}
+
+func (c *Config) KeyManagerConfig() *keys.Config {
+	return &c.KeyManager
 }


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-server/issues/831

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Ensure KeyManagerConfigProvider is overridden for key rotation.
     * This allows setup to properly populate the key manager