### PR TITLE
Give key-rotation service acct perms to the secret

### DIFF
--- a/terraform/service_keyrotation.tf
+++ b/terraform/service_keyrotation.tf
@@ -32,6 +32,12 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-key-rotation" {
   ]
 }
 
+resource "google_secret_manager_secret_iam_member" "revision-token-aad" {
+  secret_id = google_secret_manager_secret.revision_token_aad.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.key-rotation.email}"
+}
+
 resource "google_secret_manager_secret_iam_member" "key-rotation-db" {
   for_each = toset([
     "sslcert",


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-server/issues/791

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Give the key-rotation service-account permissions to the token-aad secret

Note: I tried to deploy and this causes the container to fail to start
