### PR TITLE
Observability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.0
 	github.com/google/mako v0.2.0
+	github.com/google/uuid v1.0.0
 	github.com/hashicorp/go-hclog v0.13.0
 	github.com/hashicorp/go-memdb v1.2.1 // indirect
 	github.com/hashicorp/go-msgpack v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -515,6 +515,7 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=

--- a/internal/observability/config.go
+++ b/internal/observability/config.go
@@ -42,6 +42,11 @@ type OpenCensusConfig struct {
 // StackdriverConfig holds the configuration options for the stackdriver exporter
 type StackdriverConfig struct {
 	ProjectID string `env:"PROJECT_ID, default=$GOOGLE_CLOUD_PROJECT"`
+	// Knative+Cloud Run container contract env vars
+	// https://cloud.google.com/run/docs/reference/container-contract#env-vars
+	// If present, can be used to configured the Stackdriver MonitoredResource correctly.
+	Service  string `env:"K_SERVICE"`
+	Revision string `env:"K_REVISION"`
 }
 
 // OCAgentConfig holds the configuration options for the default opencensus exporter

--- a/internal/observability/config.go
+++ b/internal/observability/config.go
@@ -47,8 +47,6 @@ type StackdriverConfig struct {
 	// If present, can be used to configured the Stackdriver MonitoredResource correctly.
 	Service  string `env:"K_SERVICE"`
 	Revision string `env:"K_REVISION"`
-
-	CloudRunResourceType bool `env:"STACKDRIVER_CLOUD_RUN_RESOURCE, default=true"`
 }
 
 // OCAgentConfig holds the configuration options for the default opencensus exporter

--- a/internal/observability/config.go
+++ b/internal/observability/config.go
@@ -47,6 +47,8 @@ type StackdriverConfig struct {
 	// If present, can be used to configured the Stackdriver MonitoredResource correctly.
 	Service  string `env:"K_SERVICE"`
 	Revision string `env:"K_REVISION"`
+
+	Namespace string `env:"K_CONFIGURATION, default=ens"`
 }
 
 // OCAgentConfig holds the configuration options for the default opencensus exporter

--- a/internal/observability/config.go
+++ b/internal/observability/config.go
@@ -47,6 +47,8 @@ type StackdriverConfig struct {
 	// If present, can be used to configured the Stackdriver MonitoredResource correctly.
 	Service  string `env:"K_SERVICE"`
 	Revision string `env:"K_REVISION"`
+
+	CloudRunResourceType bool `env:"STACKDRIVER_CLOUD_RUN_RESOURCE, default=true"`
 }
 
 // OCAgentConfig holds the configuration options for the default opencensus exporter

--- a/internal/observability/generic.go
+++ b/internal/observability/generic.go
@@ -30,6 +30,8 @@ var _ Exporter = (*GenericExporter)(nil)
 
 var initExporterOnce sync.Once
 
+type FlushFn func()
+
 type traceAndViewExporter interface {
 	trace.Exporter
 	view.Exporter
@@ -40,6 +42,7 @@ type traceAndViewExporter interface {
 type GenericExporter struct {
 	exporter   traceAndViewExporter
 	sampleRate float64
+	flushFn    FlushFn
 }
 
 func (g *GenericExporter) InitExportOnce() error {
@@ -48,6 +51,10 @@ func (g *GenericExporter) InitExportOnce() error {
 		err = g.initExporter()
 	})
 	return err
+}
+
+func (g *GenericExporter) Flush() {
+	g.flushFn()
 }
 
 func (g *GenericExporter) initExporter() error {

--- a/internal/observability/noop.go
+++ b/internal/observability/noop.go
@@ -24,3 +24,5 @@ type NoopExporter struct{}
 func (g *NoopExporter) InitExportOnce() error {
 	return nil
 }
+
+func (g *NoopExporter) Flush() {}

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -18,6 +18,7 @@ package observability
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"contrib.go.opencensus.io/exporter/stackdriver"
@@ -46,7 +47,8 @@ func NewFromEnv(ctx context.Context, config *Config) (Exporter, error) {
 		}
 		logger := logging.FromContext(ctx).Named("stackdriver")
 		sde, err := stackdriver.NewExporter(stackdriver.Options{
-			ProjectID: config.StackdriverConfig.ProjectID,
+			ProjectID:         config.StackdriverConfig.ProjectID,
+			ReportingInterval: time.Minute, // stackdriver export interval minimum
 			OnError: func(err error) {
 				logger.Errorf("stackdriver export error: %v", err)
 			},

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -21,6 +21,7 @@ import (
 
 	"contrib.go.opencensus.io/exporter/ocagent"
 	"contrib.go.opencensus.io/exporter/stackdriver"
+	"github.com/google/exposure-notifications-server/internal/logging"
 )
 
 // Exporter defines the minimum shared functionality for an observability exporter
@@ -43,8 +44,12 @@ func NewFromEnv(ctx context.Context, config *Config) (Exporter, error) {
 		if config.StackdriverConfig.ProjectID == "" {
 			return nil, fmt.Errorf("configuration PROJECT_ID is required to use the Stackdriver observability exporter")
 		}
+		logger := logging.FromContext(ctx).Named("stackdriver")
 		sde, err := stackdriver.NewExporter(stackdriver.Options{
 			ProjectID: config.StackdriverConfig.ProjectID,
+			OnError: func(err error) {
+				logger.Errorf("stackdriver export error: %v", err)
+			},
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Stackdriver observability exporter: %v", err)

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -29,6 +29,7 @@ import (
 // used by this application.
 type Exporter interface {
 	InitExportOnce() error
+	Flush()
 }
 
 // NewFromEnv returns the observability exporter given the provided configuration, or an error
@@ -60,7 +61,7 @@ func NewFromEnv(ctx context.Context, config *Config) (Exporter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Stackdriver observability exporter: %v", err)
 		}
-		return &GenericExporter{sde, config.TraceProbabilitySampleRate}, nil
+		return &GenericExporter{sde, config.TraceProbabilitySampleRate, func() { sde.Flush() }}, nil
 
 	case ExporterOCAgent, ExporterPrometheus:
 		var opts []ocagent.ExporterOption
@@ -75,6 +76,6 @@ func NewFromEnv(ctx context.Context, config *Config) (Exporter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create OpenCensus observability exporter: %v", err)
 		}
-		return &GenericExporter{oce, config.TraceProbabilitySampleRate}, nil
+		return &GenericExporter{oce, config.TraceProbabilitySampleRate, func() { oce.Flush() }}, nil
 	}
 }

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -47,12 +47,12 @@ func NewFromEnv(ctx context.Context, config *Config) (Exporter, error) {
 		}
 		logger := logging.FromContext(ctx).Named("stackdriver")
 
-		r, l := NewStackdriverMonitoredResoruce(&config.StackdriverConfig).MonitoredResource()
-		logger.Errorf("monitored resource: %v :: %+v", r, l)
+		monitoredResource := NewStackdriverMonitoredResoruce(&config.StackdriverConfig)
 
 		sde, err := stackdriver.NewExporter(stackdriver.Options{
 			ProjectID:         config.StackdriverConfig.ProjectID,
 			ReportingInterval: time.Minute, // stackdriver export interval minimum
+			MonitoredResource: monitoredResource,
 			OnError: func(err error) {
 				logger.Errorf("stackdriver export error: %v", err)
 			},

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -46,6 +46,10 @@ func NewFromEnv(ctx context.Context, config *Config) (Exporter, error) {
 			return nil, fmt.Errorf("configuration PROJECT_ID is required to use the Stackdriver observability exporter")
 		}
 		logger := logging.FromContext(ctx).Named("stackdriver")
+
+		r, l := NewStackdriverMonitoredResoruce(&config.StackdriverConfig).MonitoredResource()
+		logger.Errorf("monitored resource: %v :: %+v", r, l)
+
 		sde, err := stackdriver.NewExporter(stackdriver.Options{
 			ProjectID:         config.StackdriverConfig.ProjectID,
 			ReportingInterval: time.Minute, // stackdriver export interval minimum

--- a/internal/observability/resource.go
+++ b/internal/observability/resource.go
@@ -35,20 +35,20 @@ func NewStackdriverMonitoredResoruce(c *StackdriverConfig) monitoredresource.Int
 
 	// On GCP we can fill in some of the information.
 	detected := gcp.Autodetect()
+	providedLabels := make(map[string]string)
 	if detected != nil {
-		_, labels = detected.MonitoredResource()
+		_, providedLabels = detected.MonitoredResource()
 	}
 
-	if _, ok := labels["project_id"]; !ok {
+	if _, ok := providedLabels["project_id"]; !ok {
 		labels["project_id"] = c.ProjectID
 	}
-	if _, ok := labels["job"]; !ok && c.Service != "" {
+	if c.Service != "" {
 		labels["job"] = c.Service
 	}
 	// Transform "instance_id" to "task_id" or generate task_id
-	if iid, ok := labels["instance_id"]; ok {
+	if iid, ok := providedLabels["instance_id"]; ok {
 		labels["task_id"] = iid
-		delete(labels, "instance_id")
 	} else {
 		labels["task_id"] = base64.StdEncoding.EncodeToString(uuid.NodeID())
 	}

--- a/internal/observability/resource.go
+++ b/internal/observability/resource.go
@@ -19,7 +19,7 @@ import (
 	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp"
 )
 
-const ResourceType = "enservice"
+const cloudRunResource = "cloud_run_revision"
 
 var _ monitoredresource.Interface = (*StackdriverMonitoredResoruce)(nil)
 
@@ -30,7 +30,7 @@ type StackdriverMonitoredResoruce struct {
 
 func NewStackdriverMonitoredResoruce(c *StackdriverConfig) monitoredresource.Interface {
 	detected := gcp.Autodetect()
-	resource := ResourceType
+	resource := "exposurenotifications"
 	labels := make(map[string]string)
 	if detected != nil {
 		resource, labels = detected.MonitoredResource()
@@ -39,11 +39,15 @@ func NewStackdriverMonitoredResoruce(c *StackdriverConfig) monitoredresource.Int
 	if _, ok := labels["project_id"]; !ok {
 		labels["project_id"] = c.ProjectID
 	}
-	if _, ok := labels["revision"]; !ok && c.Revision != "" {
-		labels["revision"] = c.Revision
+	if _, ok := labels["revision_name"]; !ok && c.Revision != "" {
+		labels["revision_name"] = c.Revision
 	}
-	if _, ok := labels["service"]; !ok && c.Service != "" {
-		labels["service"] = c.Service
+	if _, ok := labels["service_name"]; !ok && c.Service != "" {
+		labels["service_name"] = c.Service
+	}
+
+	if c.CloudRunResourceType {
+		resource = cloudRunResource
 	}
 
 	return &StackdriverMonitoredResoruce{

--- a/internal/observability/resource.go
+++ b/internal/observability/resource.go
@@ -15,24 +15,13 @@
 package observability
 
 import (
-	"encoding/base64"
-
 	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
 	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp"
-	"github.com/google/uuid"
 )
 
 const ResourceType = "enservice"
 
 var _ monitoredresource.Interface = (*StackdriverMonitoredResoruce)(nil)
-
-var (
-	nodeUUID string
-)
-
-func init() {
-	nodeUUID = base64.StdEncoding.EncodeToString(uuid.NodeID())
-}
 
 type StackdriverMonitoredResoruce struct {
 	resource string
@@ -47,16 +36,15 @@ func NewStackdriverMonitoredResoruce(c *StackdriverConfig) monitoredresource.Int
 		resource, labels = detected.MonitoredResource()
 	}
 
-	/*
-		l := make(map[string]string)
-		l["project_id"] = c.ProjectID
-		if c.Revision != "" {
-			l["revision"] = c.Revision
-		}
-		if c.Service != "" {
-			l["service"] = c.Service
-		}
-	*/
+	if _, ok := labels["project_id"]; !ok {
+		labels["project_id"] = c.ProjectID
+	}
+	if _, ok := labels["revision"]; !ok && c.Revision != "" {
+		labels["revision"] = c.Revision
+	}
+	if _, ok := labels["service"]; !ok && c.Service != "" {
+		labels["service"] = c.Service
+	}
 
 	return &StackdriverMonitoredResoruce{
 		resource: resource,

--- a/internal/observability/resource.go
+++ b/internal/observability/resource.go
@@ -42,9 +42,13 @@ func NewStackdriverMonitoredResoruce(c *StackdriverConfig) monitoredresource.Int
 
 	if _, ok := providedLabels["project_id"]; !ok {
 		labels["project_id"] = c.ProjectID
+	} else {
+		labels["project_id"] = providedLabels["project_id"]
 	}
 	if c.Service != "" {
 		labels["job"] = c.Service
+	} else {
+		labels["job"] = "unknown"
 	}
 	// Transform "instance_id" to "task_id" or generate task_id
 	if iid, ok := providedLabels["instance_id"]; ok {
@@ -52,6 +56,14 @@ func NewStackdriverMonitoredResoruce(c *StackdriverConfig) monitoredresource.Int
 	} else {
 		labels["task_id"] = base64.StdEncoding.EncodeToString(uuid.NodeID())
 	}
+	if zone, ok := providedLabels["zone"]; ok {
+		labels["location"] = zone
+	} else if loc, ok := providedLabels["location"]; ok {
+		labels["location"] = loc
+	} else {
+		labels["location"] = "unknown"
+	}
+	labels["namespace"] = c.Namespace
 
 	return &StackdriverMonitoredResoruce{
 		resource: resource,

--- a/internal/observability/resource.go
+++ b/internal/observability/resource.go
@@ -1,0 +1,69 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observability
+
+import (
+	"encoding/base64"
+
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp"
+	"github.com/google/uuid"
+)
+
+const ResourceType = "enservice"
+
+var _ monitoredresource.Interface = (*StackdriverMonitoredResoruce)(nil)
+
+var (
+	nodeUUID string
+)
+
+func init() {
+	nodeUUID = base64.StdEncoding.EncodeToString(uuid.NodeID())
+}
+
+type StackdriverMonitoredResoruce struct {
+	resource string
+	labels   map[string]string
+}
+
+func NewStackdriverMonitoredResoruce(c *StackdriverConfig) monitoredresource.Interface {
+	detected := gcp.Autodetect()
+	resource := ResourceType
+	labels := make(map[string]string)
+	if detected != nil {
+		resource, labels = detected.MonitoredResource()
+	}
+
+	/*
+		l := make(map[string]string)
+		l["project_id"] = c.ProjectID
+		if c.Revision != "" {
+			l["revision"] = c.Revision
+		}
+		if c.Service != "" {
+			l["service"] = c.Service
+		}
+	*/
+
+	return &StackdriverMonitoredResoruce{
+		resource: resource,
+		labels:   labels,
+	}
+}
+
+func (s *StackdriverMonitoredResoruce) MonitoredResource() (string, map[string]string) {
+	return s.resource, s.labels
+}

--- a/internal/serverenv/env.go
+++ b/internal/serverenv/env.go
@@ -176,5 +176,10 @@ func (s *ServerEnv) Close(ctx context.Context) error {
 	if s.database != nil {
 		s.database.Close(ctx)
 	}
+
+	if s.observabilityExporter != nil {
+		s.observabilityExporter.Flush()
+	}
+
 	return nil
 }


### PR DESCRIPTION
Fixes #669

## Proposed Changes

* Change strackdriver export period to 1m & add exporter Flush() to server shutdown
* for customer metrics on stackdriver, use a customer monitored resource. We attempt to fill this in using GCE discovery and combination of env vars (Some of which are present when running under knative or cloud run). Fallback to generating a UUID to use as job instance.

**Release Note**

```release-note
Fix metrics exporting when using stackdriver
```