### PR TITLE
Reorganize JWT across perf/integration tests

### DIFF
--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -35,8 +35,6 @@ import (
 	revdb "github.com/google/exposure-notifications-server/internal/revision/database"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/internal/storage"
-	vdb "github.com/google/exposure-notifications-server/internal/verification/database"
-	vm "github.com/google/exposure-notifications-server/internal/verification/model"
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/google/exposure-notifications-server/pkg/server"
@@ -45,14 +43,11 @@ import (
 	authorizedappmodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
 	exportdatabase "github.com/google/exposure-notifications-server/internal/export/database"
 	exportmodel "github.com/google/exposure-notifications-server/internal/export/model"
-	testutil "github.com/google/exposure-notifications-server/internal/utils"
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
 
 var (
 	ExportDir    = "my-bucket"
 	FileNameRoot = "/"
-	jwtCfg       = testutil.JWTConfig{}
 )
 
 // NewTestServer sets up clients used for integration tests
@@ -148,34 +143,6 @@ func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client) {
 	}
 	if _, err := revisionDB.CreateRevisionKey(ctx); err != nil {
 		tb.Fatal(err)
-	}
-
-	verifyDB := vdb.New(db)
-
-	// create a signing key
-	sk := testutil.GetSigningKey(tb)
-
-	// create a health authority
-	ha := &vm.HealthAuthority{
-		Audience: "exposure-notifications-service",
-		Issuer:   "Department of Health",
-		Name:     "Integration Test HA",
-	}
-	haKey := &vm.HealthAuthorityKey{
-		Version: "v1",
-		From:    time.Now().Add(-1 * time.Minute),
-	}
-	haKey.PublicKeyPEM = sk.PublicKey
-	verifyDB.AddHealthAuthority(ctx, ha)
-	verifyDB.AddHealthAuthorityKey(ctx, ha, haKey)
-
-	// jwt config to be used to get a verification certificate
-	jwtCfg = testutil.JWTConfig{
-		HealthAuthority:    ha,
-		HealthAuthorityKey: haKey,
-		Key:                sk.Key,
-		JWTWarp:            time.Duration(0),
-		ReportType:         verifyapi.ReportTypeConfirmed,
 	}
 
 	sm, err := secrets.NewInMemory(ctx)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -42,6 +42,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+var jwtCfg = &testutil.JWTConfig{}
+
 func TestIntegration(t *testing.T) {
 	t.Parallel()
 
@@ -60,8 +62,8 @@ func TestIntegration(t *testing.T) {
 		Keys:              keys,
 		HealthAuthorityID: "com.example.app",
 	}
-	jwtCfg.ExposureKeys = keys
-	verification, salt := testutil.IssueJWT(t, jwtCfg)
+	jwtCfg = testutil.BuildJWTConfig(t, db, keys)
+	verification, salt := testutil.IssueJWT(t, *jwtCfg)
 	payload.VerificationPayload = verification
 	payload.HMACKey = salt
 	if resp, err := client.PublishKeys(payload); err != nil {
@@ -212,7 +214,7 @@ func TestIntegration(t *testing.T) {
 	keys = util.GenerateExposureKeys(3, -1, false)
 	payload.Keys = keys
 	jwtCfg.ExposureKeys = keys
-	verification, salt = testutil.IssueJWT(t, jwtCfg)
+	verification, salt = testutil.IssueJWT(t, *jwtCfg)
 	payload.VerificationPayload = verification
 	payload.HMACKey = salt
 	if resp, err := client.PublishKeys(payload); err != nil {


### PR DESCRIPTION
This organization cleans up some imports and groups like things
It also make mock JWT more availible and aligns with SRP

Was dupe fix of #844 (lost internet so was not able to coordinate well)
I think this is a bit cleaner and more flexible. 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* move config mock to utils where JTWIssue lives
* build JTW Config within each test based on the keys and db
*
