### PR TITLE
Enable perf tests to be run in prod/dev modes more easily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,15 @@ performance-test:
 		-tags=performance \
 		./internal/performance
 .PHONY: performance-test
+
+performance-dev-test:
+	@go test \
+		-count=1 \
+		-timeout=30m \
+		-v \
+		-tags=performance \
+		./internal/performance \
+		-args \
+		-dev \
+		-publishes=1000
+.PHONY: performance-dev-test

--- a/Makefile
+++ b/Makefile
@@ -66,15 +66,3 @@ performance-test:
 		-tags=performance \
 		./internal/performance
 .PHONY: performance-test
-
-performance-dev-test:
-	@go test \
-		-count=1 \
-		-timeout=30m \
-		-v \
-		-tags=performance \
-		./internal/performance \
-		-args \
-		-dev \
-		-publishes=1000
-.PHONY: performance-dev-test

--- a/internal/performance/README.md
+++ b/internal/performance/README.md
@@ -4,7 +4,7 @@ This directory contains configs and tests for performance metrics collection,
 the data can be visualized at
 [Mako.dev](https://mako.dev/benchmark?benchmark_key=4790091207671808)
 
-To run these tests, execute [`./scripts/performance.sh <--dev>`](../../scripts/performance.sh) from the root fo the project. This will also require the setting of env `GOOGLE_APPLICATION_CREDENTIALS`, if this is needed contact @chaodaiG or @MushuEE.
+To run these tests, execute [`./scripts/performance.sh <--dev> <#publishes>` ](../../scripts/performance.sh) from the root fo the project. This will also require the setting of env `GOOGLE_APPLICATION_CREDENTIALS`, if this is needed contact @chaodaiG or @MushuEE.
 
 The `--dev` option will run the [development](#Dev) version of the test.
 
@@ -12,4 +12,4 @@ The `--dev` option will run the [development](#Dev) version of the test.
 This uses the production [banchmark_config](./export_test_benchmark.config) and writes results to a [Mako](https://mako.dev/benchmark?benchmark_key=4790091207671808) instance with the provided key.
 
 ## Dev
-This uses the development [banchmark_config](./export_test_benchmark.dev.config) and writes results to a [Mako](https://mako.dev/benchmark?benchmark_key=5698752440434688) instance with the provided key. You may want to set the number of Publishes within this test for more keys, set that from the `-publishes=#` argument in the make target [performance-dev-test](../../Makefile).
+This uses the development [banchmark_config](./export_test_benchmark.dev.config) and writes results to a [Mako](https://mako.dev/benchmark?benchmark_key=5698752440434688) instance with the provided key. You may want to set the number of Publishes within this test for more keys, set that from the the second argument to [performance.sh](../../scripts/performance.sh). Ex. `./scripts/performance.sh --dev 2000`. \**defaults to 1000 for dev and 100000 for prod*

--- a/internal/performance/README.md
+++ b/internal/performance/README.md
@@ -3,3 +3,13 @@
 This directory contains configs and tests for performance metrics collection,
 the data can be visualized at
 [Mako.dev](https://mako.dev/benchmark?benchmark_key=4790091207671808)
+
+To run these tests, execute [`./scripts/performance.sh <--dev>`](../../scripts/performance.sh) from the root fo the project. This will also require the setting of env `GOOGLE_APPLICATION_CREDENTIALS`, if this is needed contact @chaodaiG or @MushuEE.
+
+The `--dev` option will run the [development](#Dev) version of the test.
+
+## Production
+This uses the production [banchmark_config](./export_test_benchmark.config) and writes results to a [Mako](https://mako.dev/benchmark?benchmark_key=4790091207671808) instance with the provided key.
+
+## Dev
+This uses the development [banchmark_config](./export_test_benchmark.dev.config) and writes results to a [Mako](https://mako.dev/benchmark?benchmark_key=5698752440434688) instance with the provided key. You may want to set the number of Publishes within this test for more keys, set that from the `-publishes=#` argument in the make target [performance-dev-test](../../Makefile).

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -47,17 +47,17 @@ type testConfig struct {
 func TestExport(t *testing.T) {
 	const (
 		keysPerPublish = 14
-		// Consider the above publishes are evenly distributed in 24 hours, and
-		// period is 10 minutes
-		exportPeriod = 10 * time.Minute
-		totalBatches = 24 * 6
+		exportPeriod   = 10 * time.Minute
+		totalBatches   = 24 * 6
 	)
 	var (
 		ctx      = context.Background()
 		criteria = publishdb.IterateExposuresCriteria{
 			OnlyLocalProvenance: false,
 		}
-		numPublishes   = 100000
+		numPublishes = 100000
+		// Consider the above publishes are evenly distributed in 24 hours, and
+		// period is 10 minutes
 		batchStartTime = time.Now().Add(time.Duration(-totalBatches-10) * exportPeriod)
 	)
 	c := testConfig{}

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 type testConfig struct {
-	Publishes int  `env:"PUBLISHES,required"`
+	Publishes int  `env:"PUBLISHES,default=1000"`
 	Dev       bool `env:"PERFORMANCE_DEV"`
 }
 
@@ -58,9 +58,7 @@ func TestExport(t *testing.T) {
 			OnlyLocalProvenance: false,
 		}
 		numPublishes   = 100000
-		want           = keysPerPublish * numPublishes
 		batchStartTime = time.Now().Add(time.Duration(-totalBatches-10) * exportPeriod)
-		roughPerBatch  = numPublishes/totalBatches + 1
 	)
 	c := testConfig{}
 	if err := envconfig.ProcessWith(context.Background(), &c, envconfig.OsLookuper()); err != nil {
@@ -69,9 +67,9 @@ func TestExport(t *testing.T) {
 
 	if c.Dev && c.Publishes > 0 {
 		numPublishes = c.Publishes
-		want = keysPerPublish * numPublishes
-		roughPerBatch = numPublishes/totalBatches + 1
 	}
+	want := keysPerPublish * numPublishes
+	roughPerBatch := numPublishes/totalBatches + 1
 
 	makoQuickstore, cancel := setup(t)
 	defer cancel(context.Background())

--- a/internal/performance/export_test_benchmark.dev.config
+++ b/internal/performance/export_test_benchmark.dev.config
@@ -15,9 +15,9 @@
 # For assistance using the command line tool see go/mako-help.
 #
 
-# Prod benchmark configs
-benchmark_name: "Export"
-benchmark_key: "4790091207671808"
+# Development benchmark configs.
+benchmark_name: "Development Export"
+benchmark_key: "5698752440434688"
 
 project_name: "Exposure Notifications Server"
 owner_list: "kgood@google.com"

--- a/internal/performance/helper.go
+++ b/internal/performance/helper.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	benchmarkConfigFile = "export_test_benchmark.config"
+	benchmarkProdConfigFile = "export_test_benchmark.config"
+	benchmarkDevConfigFile  = "export_test_benchmark.dev.config"
 )
 
 type config struct {
@@ -44,13 +45,21 @@ type config struct {
 }
 
 // setup sets up client used for performance test
-func setup(tb testing.TB) (*quickstore.Quickstore, func(context.Context)) {
-	ctx := context.Background()
+func setup(tb testing.TB, dev bool) (*quickstore.Quickstore, func(context.Context)) {
+	var (
+		ctx  = context.Background()
+		data []byte
+		err  error
+	)
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	benchmarkConfig := &mpb.BenchmarkInfo{}
-	data, err := ioutil.ReadFile(benchmarkConfigFile)
+	if dev {
+		data, err = ioutil.ReadFile(benchmarkDevConfigFile)
+	} else {
+		data, err = ioutil.ReadFile(benchmarkProdConfigFile)
+	}
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/internal/performance/helper.go
+++ b/internal/performance/helper.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -45,7 +46,7 @@ type config struct {
 }
 
 // setup sets up client used for performance test
-func setup(tb testing.TB, dev bool) (*quickstore.Quickstore, func(context.Context)) {
+func setup(tb testing.TB) (*quickstore.Quickstore, func(context.Context)) {
 	var (
 		ctx  = context.Background()
 		data []byte
@@ -55,7 +56,7 @@ func setup(tb testing.TB, dev bool) (*quickstore.Quickstore, func(context.Contex
 	defer cancel()
 
 	benchmarkConfig := &mpb.BenchmarkInfo{}
-	if dev {
+	if os.Getenv("PERFORMANCE_DEV") == "1" {
 		data, err = ioutil.ReadFile(benchmarkDevConfigFile)
 	} else {
 		data, err = ioutil.ReadFile(benchmarkProdConfigFile)

--- a/scripts/performance.sh
+++ b/scripts/performance.sh
@@ -14,9 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEV=0
+
+for arg in "$@"
+do
+    case $arg in
+        -d|--dev)
+        DEV=1
+        shift # Remove --dev from processing
+        ;;
+    esac
+done
+
 set -eEuo pipefail
 
 echo "🌳 Set up environment variables"
+echo "# Should Dev: $DEV"
 # Docker image build
 # instruction(https://github.com/google/mako/blob/v0.2.0/docs/GUIDE.md#quickstore-microservice-as-a-docker-image)
 # for mako microservice is currently broken according to mako maintainers. This
@@ -45,4 +58,8 @@ docker \
   &
 
 echo "🧪 Test"
-make performance-test
+if [ $DEV == 1 ]; then
+   make performance-dev-test
+else
+   make performance-test
+fi

--- a/scripts/performance.sh
+++ b/scripts/performance.sh
@@ -16,7 +16,9 @@
 
 if [[ "$1" == "--dev" || "$1" == "-d" ]]; then
  export PERFORMANCE_DEV=1
- export PUBLISHES=1000
+ pubs = $2
+ echo $2
+ export PUBLISHES=${2:-1000}
 fi
 
 set -eEuo pipefail

--- a/scripts/performance.sh
+++ b/scripts/performance.sh
@@ -16,8 +16,6 @@
 
 if [[ "$1" == "--dev" || "$1" == "-d" ]]; then
  export PERFORMANCE_DEV=1
- pubs = $2
- echo $2
  export PUBLISHES=${2:-1000}
 fi
 

--- a/scripts/performance.sh
+++ b/scripts/performance.sh
@@ -14,22 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DEV=0
-
-for arg in "$@"
-do
-    case $arg in
-        -d|--dev)
-        DEV=1
-        shift # Remove --dev from processing
-        ;;
-    esac
-done
+if [[ "$1" == "--dev" || "$1" == "-d" ]]; then
+ export PERFORMANCE_DEV=1
+ export PUBLISHES=1000
+fi
 
 set -eEuo pipefail
 
 echo "🌳 Set up environment variables"
-echo "# Should Dev: $DEV"
 # Docker image build
 # instruction(https://github.com/google/mako/blob/v0.2.0/docs/GUIDE.md#quickstore-microservice-as-a-docker-image)
 # for mako microservice is currently broken according to mako maintainers. This
@@ -58,8 +50,4 @@ docker \
   &
 
 echo "🧪 Test"
-if [ $DEV == 1 ]; then
-   make performance-dev-test
-else
-   make performance-test
-fi
+make performance-test


### PR DESCRIPTION
Add some docs
Split benchmark config + add test flags to make runs more streamline

Link to results dashboards

## Proposed Changes

* Enable dev mode on Mako with `--dev` option to the performance script 
* Add some Docs for perf
* remove need to flip flop comments when making / testing changes in perf

/cc @chaodaiG 