### PR TITLE
Abort integration script when no project ID

### DIFF
--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -22,6 +22,7 @@ ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
 echo "🌳 Set up environment variables"
 if [[ -z "${PROJECT_ID:-}" ]]; then
   echo "✋ PROJECT_ID must be set"
+  exit 1
 fi
 
 


### PR DESCRIPTION
Abort the integration test script when there's no project ID.