### PR TITLE
allow publish to return a partial success/failure

### DIFF
--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -442,7 +442,7 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		upcaseRegions[i] = strings.ToUpper(r)
 	}
 
-	var transformErrors error
+	var transformErrors *multierror.Error
 	for i, exposureKey := range inData.Keys {
 		exposure, err := TransformExposureKey(exposureKey, inData.HealthAuthorityID, upcaseRegions, &settings)
 		if err != nil {
@@ -473,7 +473,7 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 
 	if len(entities) == 0 {
 		// All keys in the batch are valid.
-		return nil, transformErrors
+		return nil, transformErrors.ErrorOrNil()
 	}
 
 	// Validate the uploaded data meets configuration parameters.
@@ -524,5 +524,5 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		}
 	}
 
-	return entities, transformErrors
+	return entities, transformErrors.ErrorOrNil()
 }

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/verification"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/hashicorp/go-multierror"
 
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
@@ -441,11 +442,13 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		upcaseRegions[i] = strings.ToUpper(r)
 	}
 
-	for _, exposureKey := range inData.Keys {
+	var transformErrors error
+	for i, exposureKey := range inData.Keys {
 		exposure, err := TransformExposureKey(exposureKey, inData.HealthAuthorityID, upcaseRegions, &settings)
 		if err != nil {
 			logger.Debugf("individual key transform failed: %v", err)
-			return nil, fmt.Errorf("invalid publish data: %v", err)
+			transformErrors = multierror.Append(transformErrors, fmt.Errorf("key %d cannot be imported: %w", i, err))
+			continue
 		}
 		// If there are verified claims, apply to this key.
 		if claims != nil {
@@ -466,6 +469,11 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		}
 		exposure.Traveler = inData.Traveler
 		entities = append(entities, exposure)
+	}
+
+	if len(entities) == 0 {
+		// All keys in the batch are valid.
+		return nil, transformErrors
 	}
 
 	// Validate the uploaded data meets configuration parameters.
@@ -516,5 +524,5 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		}
 	}
 
-	return entities, nil
+	return entities, transformErrors
 }

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -122,8 +122,8 @@ func TestInvalidBase64(t *testing.T) {
 	batchTime := time.Date(2020, 3, 1, 10, 43, 1, 0, time.UTC)
 
 	_, err = transformer.TransformPublish(ctx, source, regions, nil, batchTime)
-	expErr := `invalid publish data: illegal base64 data at input byte 4`
-	if err == nil || err.Error() != expErr {
+	expErr := `key 0 cannot be imported: illegal base64 data at input byte 4`
+	if err == nil || !strings.Contains(err.Error(), expErr) {
 		t.Errorf("expected error '%v', got: %v", expErr, err)
 	}
 }

--- a/pkg/api/v1/exposure_types.go
+++ b/pkg/api/v1/exposure_types.go
@@ -54,6 +54,9 @@ const (
 	// ErrorInvalidRevisionToken indicates a revision token was passed, but is missing a
 	// key or has invalid metadata.
 	ErrorInvalidRevisionToken = "invalid_revision_token"
+	// ErrorPartialFailure indicates that some exposure keys in the publish request had invalid
+	// data (size, timing metadata) and were dropped. Other keys were saved.
+	ErrorPartialFailure = "partial_failure"
 )
 
 // Publish represents the body of the PublishInfectedIds API call.
@@ -83,6 +86,13 @@ const (
 //
 // Padding: random base64 encoded data to obscure the request size. The server will
 // not process this data in any way.
+//
+// Partial success: If at least one of the Keys passed in is valid, then the publish
+// request will accept those keys, return a response code of 200 (OK) AND also
+// return a 'Code' of ErrorPartialFailure allong with an error message of
+// exactly which keys were not accepted and why. This does not indicate a failure
+// that must be reported to the user, but does indicate an issue with the application
+// making the upload (sending invalid data).
 type Publish struct {
 	Keys                 []ExposureKey `json:"temporaryExposureKeys"`
 	HealthAuthorityID    string        `json:"healthAuthorityID"`


### PR DESCRIPTION
Fixes #862

* If individual TEKs in a publish are invalid, allow the rest of the publish to commit
* introduce partial success error code

**Release Note**

```release-note
If just some of the exposure keys in a publish request are bad, drop those but accept the rest. Convey a partial success message back in the publish response.
```