### PR TITLE
Fix revision token validation

### DIFF
--- a/internal/revision/revision.go
+++ b/internal/revision/revision.go
@@ -186,24 +186,28 @@ func buildTokenBufer(previous *pb.RevisionTokenData, eKeys []*model.Exposure) *p
 		RevisableKeys: make([]*pb.RevisableKey, 0, len(eKeys)),
 	}
 	got := make(map[string]struct{})
-	for _, k := range eKeys {
-		got[k.ExposureKeyBase64()] = struct{}{}
-		pbKey := pb.RevisableKey{
-			TemporaryExposureKey: make([]byte, len(k.ExposureKey)),
-			IntervalNumber:       k.IntervalNumber,
-			IntervalCount:        k.IntervalCount,
-		}
-		copy(pbKey.TemporaryExposureKey, k.ExposureKey)
-		tokenData.RevisableKeys = append(tokenData.RevisableKeys, &pbKey)
-	}
-	// Add in previous keys that weren't also in the new exposures
+
+	// Add in previous keys that weren't also in the new exposures. This needs to
+	// come first so the revision token is valid for all keys, not just the ones
+	// uploaded now.
 	if previous != nil {
 		for _, rk := range previous.RevisableKeys {
-			if _, ok := got[base64.StdEncoding.EncodeToString(rk.TemporaryExposureKey)]; !ok {
-				tokenData.RevisableKeys = append(tokenData.RevisableKeys, rk)
-			}
+			got[base64.StdEncoding.EncodeToString(rk.TemporaryExposureKey)] = struct{}{}
+			tokenData.RevisableKeys = append(tokenData.RevisableKeys, rk)
 		}
 	}
+
+	// Now add new keys and their metadata, iff they aren't already in the list.
+	for _, k := range eKeys {
+		if _, ok := got[k.ExposureKeyBase64()]; !ok {
+			tokenData.RevisableKeys = append(tokenData.RevisableKeys, &pb.RevisableKey{
+				TemporaryExposureKey: append([]byte{}, k.ExposureKey...), // deep copy
+				IntervalNumber:       k.IntervalNumber,
+				IntervalCount:        k.IntervalCount,
+			})
+		}
+	}
+
 	return &tokenData
 }
 

--- a/internal/revision/revision.go
+++ b/internal/revision/revision.go
@@ -187,9 +187,8 @@ func buildTokenBufer(previous *pb.RevisionTokenData, eKeys []*model.Exposure) *p
 	}
 	got := make(map[string]struct{})
 
-	// Add in previous keys that weren't also in the new exposures. This needs to
-	// come first so the revision token is valid for all keys, not just the ones
-	// uploaded now.
+	// Add in previous keys from the revision token. This needs to come first so
+	// the revision token is valid for all keys, not just the ones uploaded now.
 	if previous != nil {
 		for _, rk := range previous.RevisableKeys {
 			got[base64.StdEncoding.EncodeToString(rk.TemporaryExposureKey)] = struct{}{}

--- a/internal/revision/revision_test.go
+++ b/internal/revision/revision_test.go
@@ -94,14 +94,42 @@ func TestBuildTokenBuffer(t *testing.T) {
 						IntervalCount:        144,
 					},
 					{
+						TemporaryExposureKey: []byte{8, 9, 10, 11},
+						IntervalNumber:       200144,
+						IntervalCount:        82,
+					},
+					{
 						TemporaryExposureKey: []byte{1, 2, 3, 4},
 						IntervalNumber:       200000,
 						IntervalCount:        144,
 					},
+				},
+			},
+		},
+		{
+			name: "merge_duplicates_prefers_previous",
+			publish: []*model.Exposure{
+				{
+					ExposureKey:    []byte{4, 3, 2, 1},
+					IntervalNumber: 200134,
+					IntervalCount:  122,
+				},
+			},
+			previous: &pb.RevisionTokenData{
+				RevisableKeys: []*pb.RevisableKey{
 					{
-						TemporaryExposureKey: []byte{8, 9, 10, 11},
+						TemporaryExposureKey: []byte{4, 3, 2, 1},
 						IntervalNumber:       200144,
-						IntervalCount:        82,
+						IntervalCount:        144,
+					},
+				},
+			},
+			want: &pb.RevisionTokenData{
+				RevisableKeys: []*pb.RevisableKey{
+					{
+						TemporaryExposureKey: []byte{4, 3, 2, 1},
+						IntervalNumber:       200144,
+						IntervalCount:        144,
 					},
 				},
 			},


### PR DESCRIPTION
Previously when validating a revision token, we would accept a full payload of TEK+metadata, and then immediately perform a database lookup on the TEK, ignoring any metadata. As a result, users could make requests with arbitrarily changed metadata, and the server would never throw a validation error. The server would not actually _accept_ those changed metadata values, it would just happily ignore them and use the persisted values in the database. This commit adds validation to ensure the incoming TEK metadata matches the database TEK metadata matches the revision token metadata. It also improves the logging around these cases.

In a similar vein, the only way the above is possible is due to a bug in how we construct revision token. This commit also inverts the logic to always include ALL previous revision tokens (and their metadata) FIRST in the revision token, then include any newly uploaded TEKs. This ensures that a partial upload of new keys would still return a revision token that could be used to revise any of the previous 14 days of keys, not just the uploaded ones.

Fixes GH-864

**Release Note**

```release-note
Fix revision token validation and ensure revision tokens are valid for the previous 14 days of keys, not just the keys uploaded in the revision request.
```

/assign @mikehelmick 