### PR TITLE
Allow the same filename to be used across multiple buckets

### DIFF
--- a/migrations/000037_change_unique_index_export_filename.down.sql
+++ b/migrations/000037_change_unique_index_export_filename.down.sql
@@ -1,0 +1,21 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE exportconfig ADD CONSTRAINT filename_root_unique UNIQUE (filename_root);
+
+DROP INDEX IF EXISTS uidx_bucket_name_filename_root;
+
+END;

--- a/migrations/000037_change_unique_index_export_filename.up.sql
+++ b/migrations/000037_change_unique_index_export_filename.up.sql
@@ -1,0 +1,23 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+
+CREATE UNIQUE INDEX uidx_bucket_name_filename_root ON exportconfig (LOWER(bucket_name), LOWER(filename_root));
+
+ALTER TABLE exportconfig DROP CONSTRAINT IF EXISTS filename_root_unique;
+DROP INDEX IF EXISTS filename_root_unique;
+
+END;


### PR DESCRIPTION
This changes the unique constraint to be on bucket AND filename instead of just filename. This allows the same filename to be used with multiple different buckets. It also changes the index to enforce case sensitivity.

Fixes GH-866

**Release Note**

```release-note
Allow the same export filename to be used across multiple buckets
```