### PR TITLE
Switch to using tracecontext standard for traces

### DIFF
--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"time"
 
-	"contrib.go.opencensus.io/exporter/stackdriver"
 	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,7 +29,9 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
+
 	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 	"google.golang.org/grpc"
 )
 
@@ -113,7 +115,8 @@ func (s *Server) ServeHTTP(ctx context.Context, srv *http.Server) error {
 func (s *Server) ServeHTTPHandler(ctx context.Context, handler http.Handler) error {
 	return s.ServeHTTP(ctx, &http.Server{
 		Handler: &ochttp.Handler{
-			Handler: handler,
+			Handler:     handler,
+			Propogation: tracecontext.HTTPFormat{},
 		},
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -116,7 +116,7 @@ func (s *Server) ServeHTTPHandler(ctx context.Context, handler http.Handler) err
 	return s.ServeHTTP(ctx, &http.Server{
 		Handler: &ochttp.Handler{
 			Handler:     handler,
-			Propogation: tracecontext.HTTPFormat{},
+			Propagation: tracecontext.HTTPFormat{},
 		},
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -116,7 +116,7 @@ func (s *Server) ServeHTTPHandler(ctx context.Context, handler http.Handler) err
 	return s.ServeHTTP(ctx, &http.Server{
 		Handler: &ochttp.Handler{
 			Handler:     handler,
-			Propagation: tracecontext.HTTPFormat{},
+			Propagation: &tracecontext.HTTPFormat{},
 		},
 	})
 }


### PR DESCRIPTION
Small tweak for https://github.com/google/exposure-notifications-verification-server/issues/180

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Changes tracing for http handlers to TraceContext standard

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Changes tracing standard from b3 to TraceContext.
```