### PR TITLE
Azure KeyVault KeyManager - fix decoding bug

### DIFF
--- a/pkg/keys/azure_keyvault.go
+++ b/pkg/keys/azure_keyvault.go
@@ -94,7 +94,7 @@ func (v *AzureKeyVault) Encrypt(ctx context.Context, keyID string, plaintext []b
 		return nil, fmt.Errorf("unable to encrypt: %w", err)
 	}
 
-	resBytes, err := base64.URLEncoding.DecodeString(*res.Result)
+	resBytes, err := base64.RawURLEncoding.DecodeString(*res.Result)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode encrypted data: %w", err)
 	}
@@ -119,7 +119,7 @@ func (v *AzureKeyVault) Decrypt(ctx context.Context, keyID string, ciphertext []
 		return nil, fmt.Errorf("unable to decrypt: %w", err)
 	}
 
-	plaintext, err := base64.URLEncoding.DecodeString(*res.Result)
+	plaintext, err := base64.RawURLEncoding.DecodeString(*res.Result)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode decrypted data: %w", err)
 	}


### PR DESCRIPTION

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The KeyVault response requires the use of `RawURLEncoding` instead of `URLEncoding` when parsing the response of `Encrypt` and `Decrypt` operations

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```