### PR TITLE
fix nil pointer when revision token bypass is on.

### DIFF
--- a/internal/publish/database/exposure.go
+++ b/internal/publish/database/exposure.go
@@ -405,10 +405,13 @@ func (db *PublishDB) InsertAndReviseExposures(ctx context.Context, incoming []*m
 			}
 
 			// Build a map of allowed revisions for validation and comparison.
-			allowedRevisions := make(map[string]*pb.RevisableKey, len(token.RevisableKeys))
-			for _, v := range token.RevisableKeys {
-				b := base64.StdEncoding.EncodeToString(v.TemporaryExposureKey)
-				allowedRevisions[b] = v
+			allowedRevisions := make(map[string]*pb.RevisableKey)
+			if token != nil {
+				// Special handling for the allow bypass scenario where no token was presented.
+				for _, v := range token.RevisableKeys {
+					b := base64.StdEncoding.EncodeToString(v.TemporaryExposureKey)
+					allowedRevisions[b] = v
+				}
 			}
 
 			// Check that any existing exposures are present in the token.


### PR DESCRIPTION
Fixes #886 

## Proposed Changes

* Fix a nil pointer that can only occur when revision token bypass is on, keys are being revised, and no revision token was provided.

**Release Note**

```release-note
Nil pointer fix for development scenarios.
```