### PR TITLE
Return underlying error when reading exposures

### DIFF
--- a/internal/publish/database/exposure.go
+++ b/internal/publish/database/exposure.go
@@ -386,7 +386,7 @@ func (db *PublishDB) InsertAndReviseExposures(ctx context.Context, incoming []*m
 		// later.
 		existing, err := db.ReadExposures(ctx, tx, b64keys)
 		if err != nil {
-			return fmt.Errorf("unable to check for existing records")
+			return fmt.Errorf("unable to check for existing records: %w", err)
 		}
 		existingMap := make(map[string]*model.Exposure, len(existing))
 		for _, v := range existing {


### PR DESCRIPTION
Refs GH-899

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```