### PR TITLE
Fix data race in tests

### DIFF
--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -50,85 +50,31 @@ import (
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
 
-var (
-	// ExportDir is the default export bucket of blob storage
-	ExportDir = "my-bucket"
-	// FileNameRoot is the default file path root under blob storage
-	FileNameRoot = "/"
-)
-
-// NewTestServer sets up clients used for integration tests
-func NewTestServer(tb testing.TB, exportPeriod time.Duration) (*serverenv.ServerEnv, *Client, *database.DB, testutil.JWTConfig) {
-	ctx := context.Background()
-	env, client, jwtCfg := testServer(tb)
-	db := env.Database()
-	enClient := &Client{client: client}
-
-	// Create an authorized app
-	aa := env.AuthorizedAppProvider()
-	if err := aa.Add(ctx, &authorizedappmodel.AuthorizedApp{
-		AppPackageName: "com.example.app",
-		AllowedRegions: map[string]struct{}{
-			"TEST": {},
-		},
-		AllowedHealthAuthorityIDs: map[int64]struct{}{
-			1: {},
-		},
-
-		// TODO: hook up verification, and disable
-		BypassHealthAuthorityVerification: false,
-	}); err != nil {
-		tb.Fatal(err)
-	}
-
-	// Create a signature info
-	si := &exportmodel.SignatureInfo{
-		SigningKey:        "signer",
-		SigningKeyVersion: "v1",
-		SigningKeyID:      "US",
-	}
-	if err := exportdatabase.New(db).AddSignatureInfo(ctx, si); err != nil {
-		tb.Fatal(err)
-	}
-
-	// Create an export config
-	ec := &exportmodel.ExportConfig{
-		BucketName:       ExportDir,
-		FilenameRoot:     FileNameRoot,
-		Period:           exportPeriod,
-		OutputRegion:     "TEST",
-		From:             time.Now().Add(-2 * time.Second),
-		Thru:             time.Now().Add(1 * time.Hour),
-		SignatureInfoIDs: []int64{},
-	}
-	if err := exportdatabase.New(db).AddExportConfig(ctx, ec); err != nil {
-		tb.Fatal(err)
-	}
-
-	return env, enClient, db, jwtCfg
-}
-
-// testServer sets up mocked local servers for running tests
-func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client, testutil.JWTConfig) {
+// NewTestServer sets up mocked local servers for running tests
+func NewTestServer(tb testing.TB, exportPeriod time.Duration) (*serverenv.ServerEnv, *Client, *testutil.JWTConfig, string, string) {
 	tb.Helper()
 
 	ctx := context.Background()
 
-	aa, err := authorizedapp.NewMemoryProvider(ctx, nil)
+	aap, err := authorizedapp.NewMemoryProvider(ctx, nil)
 	if err != nil {
 		tb.Fatal(err)
 	}
 
-	if FileNameRoot, err = randomString(); err != nil {
-		tb.Fatal(err)
-	}
+	bucketName := testRandomID(tb, 32)
+	filenameRoot := testRandomID(tb, 32)
+
 	bs, err := storage.NewMemory(ctx)
-	if v := os.Getenv("GOOGLE_CLOUD_BUCKET"); v != "" && !testing.Short() {
-		ExportDir = os.Getenv("GOOGLE_CLOUD_BUCKET")
-		bs, err = storage.NewGoogleCloudStorage(ctx)
-	}
 	if err != nil {
 		tb.Fatal(err)
+	}
+
+	if v := os.Getenv("GOOGLE_CLOUD_BUCKET"); v != "" && !testing.Short() {
+		bs, err = storage.NewGoogleCloudStorage(ctx)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		bucketName = v
 	}
 
 	db := database.NewTestDatabase(tb)
@@ -182,7 +128,7 @@ func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client, testutil.JWT
 		From:    time.Now().Add(-1 * time.Minute),
 	}
 	testutil.InitalizeVerificationDB(ctx, tb, db, ha, haKey, sk)
-	jwtCfg := testutil.JWTConfig{
+	jwtCfg := &testutil.JWTConfig{
 		HealthAuthority:    ha,
 		HealthAuthorityKey: haKey,
 		Key:                sk.Key,
@@ -195,7 +141,7 @@ func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client, testutil.JWT
 	}
 
 	env := serverenv.New(ctx,
-		serverenv.WithAuthorizedAppProvider(aa),
+		serverenv.WithAuthorizedAppProvider(aap),
 		serverenv.WithBlobStorage(bs),
 		serverenv.WithDatabase(db),
 		serverenv.WithKeyManager(km),
@@ -318,7 +264,50 @@ func testServer(tb testing.TB) (*serverenv.ServerEnv, *http.Client, testutil.JWT
 	// Create a client
 	client := testClient(tb, srv)
 
-	return env, client, jwtCfg
+	enClient := &Client{client: client}
+
+	// Create an authorized app
+	aa := env.AuthorizedAppProvider()
+	if err := aa.Add(ctx, &authorizedappmodel.AuthorizedApp{
+		AppPackageName: "com.example.app",
+		AllowedRegions: map[string]struct{}{
+			"TEST": {},
+		},
+		AllowedHealthAuthorityIDs: map[int64]struct{}{
+			1: {},
+		},
+
+		// TODO: hook up verification, and disable
+		BypassHealthAuthorityVerification: false,
+	}); err != nil {
+		tb.Fatal(err)
+	}
+
+	// Create a signature info
+	si := &exportmodel.SignatureInfo{
+		SigningKey:        "signer",
+		SigningKeyVersion: "v1",
+		SigningKeyID:      "US",
+	}
+	if err := exportdatabase.New(db).AddSignatureInfo(ctx, si); err != nil {
+		tb.Fatal(err)
+	}
+
+	// Create an export config
+	ec := &exportmodel.ExportConfig{
+		BucketName:       bucketName,
+		FilenameRoot:     filenameRoot,
+		Period:           exportPeriod,
+		OutputRegion:     "TEST",
+		From:             time.Now().Add(-2 * time.Second),
+		Thru:             time.Now().Add(1 * time.Hour),
+		SignatureInfoIDs: []int64{},
+	}
+	if err := exportdatabase.New(db).AddExportConfig(ctx, ec); err != nil {
+		tb.Fatal(err)
+	}
+
+	return env, enClient, jwtCfg, bucketName, filenameRoot
 }
 
 type prefixRoundTripper struct {
@@ -352,13 +341,14 @@ func testClient(tb testing.TB, srv *server.Server) *http.Client {
 	}
 }
 
-func randomString() (string, error) {
-	var b [512]byte
+func testRandomID(tb testing.TB, size int) string {
+	tb.Helper()
+
+	b := make([]byte, size)
 	if _, err := rand.Read(b[:]); err != nil {
-		return "", fmt.Errorf("failed to generate random: %w", err)
+		tb.Fatalf("failed to generate random: %v", err)
 	}
-	digest := fmt.Sprintf("%x", sha256.Sum256(b[:]))
-	return digest[:32], nil
+	return fmt.Sprintf("%x", sha256.Sum256(b[:]))
 }
 
 // Eventually retries the given function n times, sleeping 1s between each
@@ -380,6 +370,6 @@ func Eventually(tb testing.TB, times uint64, f func() error) {
 }
 
 // IndexFilePath returns the filepath of index file under blob storage
-func IndexFilePath() string {
-	return path.Join(FileNameRoot, "index.txt")
+func IndexFilePath(root string) string {
+	return path.Join(root, "index.txt")
 }

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -74,7 +74,8 @@ func TestExport(t *testing.T) {
 	makoQuickstore, cancel := setup(t)
 	defer cancel(context.Background())
 
-	env, client, db, jwtCfg := integration.NewTestServer(t, exportPeriod)
+	env, client, jwtCfg, exportDir, exportRoot := integration.NewTestServer(t, exportPeriod)
+	db := env.Database()
 	keys := util.GenerateExposureKeys(keysPerPublish, -1, false)
 	payload := &verifyapi.Publish{
 		Keys:              keys,
@@ -174,8 +175,8 @@ func TestExport(t *testing.T) {
 			return err
 		}
 
-		index, err := env.Blobstore().GetObject(ctx, integration.ExportDir,
-			integration.IndexFilePath())
+		index, err := env.Blobstore().GetObject(ctx, exportDir,
+			integration.IndexFilePath(exportRoot))
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
 				time.Sleep(500 * time.Millisecond)
@@ -184,15 +185,15 @@ func TestExport(t *testing.T) {
 			return err
 		} else if c := strings.TrimSpace(string(index)); c == "" {
 			time.Sleep(500 * time.Millisecond)
-			return retry.RetryableError(fmt.Errorf("index file %s/%s is empty", integration.ExportDir, integration.IndexFilePath()))
+			return retry.RetryableError(fmt.Errorf("index file %s/%s is empty", exportDir, integration.IndexFilePath(exportRoot)))
 		}
 
 		var got int
 		for _, f := range strings.Split(string(index), "\n") {
 			// Download the latest export file contents
-			data, err := env.Blobstore().GetObject(ctx, integration.ExportDir, f)
+			data, err := env.Blobstore().GetObject(ctx, exportDir, f)
 			if err != nil {
-				return fmt.Errorf("failed to open %s/%s: %v", integration.ExportDir, f, err)
+				return fmt.Errorf("failed to open %s/%s: %v", exportDir, f, err)
 			}
 
 			// Process contents as an export
@@ -244,8 +245,8 @@ func TestExport(t *testing.T) {
 
 	var remainings []string
 	integration.Eventually(t, 30, func() error {
-		index, err := env.Blobstore().GetObject(ctx, integration.ExportDir,
-			path.Join(integration.FileNameRoot, "index.txt"))
+		index, err := env.Blobstore().GetObject(ctx, exportDir,
+			path.Join(exportRoot, "index.txt"))
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
 				return retry.RetryableError(fmt.Errorf("Can not find index file: %v", err))
@@ -257,7 +258,7 @@ func TestExport(t *testing.T) {
 		return nil
 	})
 	for _, r := range remainings {
-		_, err := env.Blobstore().GetObject(ctx, integration.ExportDir, r)
+		_, err := env.Blobstore().GetObject(ctx, exportDir, r)
 		if err == nil {
 			t.Fatalf("Should have been cleaned up %q: %v", r, err)
 		}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -452,7 +452,7 @@ func TestPublishWithBypass(t *testing.T) {
 				// See if there is a health authority to set up.
 				if tc.HealthAuthority != nil {
 					testutil.InitalizeVerificationDB(ctx, t, testDB, tc.HealthAuthority, tc.HealthAuthorityKey, signingKey)
-					cfg := testutil.JWTConfig{
+					cfg := &testutil.JWTConfig{
 						HealthAuthority:    tc.HealthAuthority,
 						HealthAuthorityKey: tc.HealthAuthorityKey,
 						ExposureKeys:       tc.Publish.Keys,
@@ -891,7 +891,7 @@ func TestKeyRevision(t *testing.T) {
 			revisionToken := ""
 			// Do the initial insert
 			{
-				cfg := testutil.JWTConfig{
+				cfg := &testutil.JWTConfig{
 					HealthAuthority:    healthAuthority,
 					HealthAuthorityKey: healthAuthorityKey,
 					ExposureKeys:       tc.Publish.Keys,
@@ -950,7 +950,7 @@ func TestKeyRevision(t *testing.T) {
 					Key:                signingKey.Key,
 					ReportType:         verifyapi.ReportTypeConfirmed,
 				}
-				verification, salt := testutil.IssueJWT(t, cfg)
+				verification, salt := testutil.IssueJWT(t, &cfg)
 				tc.Publish.VerificationPayload = verification
 				tc.Publish.HMACKey = salt
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -84,7 +84,7 @@ func GetSigningKey(tb testing.TB) *SigningKey {
 
 // IssueJWT generates a JWT as if it came from the
 // authorized health authority.
-func IssueJWT(t *testing.T, cfg JWTConfig) (jwtText, hmacKey string) {
+func IssueJWT(t *testing.T, cfg *JWTConfig) (jwtText, hmacKey string) {
 	t.Helper()
 
 	hmacKeyBytes := make([]byte, 32)


### PR DESCRIPTION
jwtConfig is shared, tests run in parallel

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```