### PR TITLE
stackdriver config improvements

### DIFF
--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -56,4 +56,8 @@ type StackdriverConfig struct {
 	Service   string `env:"K_SERVICE"`
 	Revision  string `env:"K_REVISION"`
 	Namespace string `env:"K_CONFIGURATION, default=en"`
+
+	// Allows for providing a real Google Cloud location when running locally for development.
+	// This is ignored if a real location was found during discovery.
+	LocationOverride string `env:"DEV_STACKDRIVER_LOCATION"`
 }

--- a/pkg/observability/resource.go
+++ b/pkg/observability/resource.go
@@ -56,12 +56,16 @@ func NewStackdriverMonitoredResoruce(c *StackdriverConfig) monitoredresource.Int
 	} else {
 		labels["task_id"] = base64.StdEncoding.EncodeToString(uuid.NodeID())
 	}
+
 	if zone, ok := providedLabels["zone"]; ok {
 		labels["location"] = zone
 	} else if loc, ok := providedLabels["location"]; ok {
 		labels["location"] = loc
 	} else {
 		labels["location"] = "unknown"
+		if c.LocationOverride != "" {
+			labels["location"] = c.LocationOverride
+		}
 	}
 	labels["namespace"] = c.Namespace
 

--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -44,6 +44,7 @@ func NewStackdriver(ctx context.Context, config *StackdriverConfig) (Exporter, e
 	}
 
 	monitoredResource := NewStackdriverMonitoredResoruce(config)
+	logger.Debugf("stackdriver monitored resource: %+v", monitoredResource)
 
 	exporter, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID:         projectID,


### PR DESCRIPTION

## Proposed Changes

* allow for env var to override location for local dev
* if LOG_DEBUG enabled, log the monitored resource for stackdriver

**Release Note**

```release-note
Stackdriver observability exporter, new env var, 'DEV_STACKDRIVER_LOCATION' to specify a location when doing local development.
```

/assign @icco 