### PR TITLE
Support destroying key versions in Cloud KMS

### DIFF
--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -102,7 +102,7 @@ func NewTestServer(tb testing.TB, exportPeriod time.Duration) (*serverenv.Server
 	if _, err := km.CreateEncryptionKey("tokenkey"); err != nil {
 		tb.Fatal(err)
 	}
-	if _, err := km.CreateSigningKey("signingkey"); err != nil {
+	if _, err := km.CreateSigningKey(ctx, "signing", "signingkey"); err != nil {
 		tb.Fatal(err)
 	}
 	// create an initial revision key.


### PR DESCRIPTION
1/n of https://github.com/google/exposure-notifications-server/issues/913

⚠️ this requires a sync with the verification server, since it changes the interface!

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Support destroying key versions in Cloud KMS key signer interface
```

/assign @mikehelmick 