### PR TITLE
Add /health

### DIFF
--- a/cmd/cleanup-export/main.go
+++ b/cmd/cleanup-export/main.go
@@ -60,6 +60,7 @@ func realMain(ctx context.Context) error {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", handler)
+	mux.Handle("/health", server.HandleHealthz(ctx))
 
 	srv, err := server.New(config.Port)
 	if err != nil {

--- a/cmd/cleanup-exposure/main.go
+++ b/cmd/cleanup-exposure/main.go
@@ -60,6 +60,7 @@ func realMain(ctx context.Context) error {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", handler)
+	mux.Handle("/health", server.HandleHealthz(ctx))
 
 	srv, err := server.New(config.Port)
 	if err != nil {

--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -54,6 +54,7 @@ func realMain(ctx context.Context) error {
 	defer env.Close(ctx)
 
 	mux := http.NewServeMux()
+	mux.Handle("/health", server.HandleHealthz(ctx))
 	handler, err := publish.NewHandler(ctx, &config, env)
 	if err != nil {
 		return fmt.Errorf("publish.NewHandler: %w", err)

--- a/cmd/federationin/main.go
+++ b/cmd/federationin/main.go
@@ -58,6 +58,7 @@ func realMain(ctx context.Context) error {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", handler)
+	mux.Handle("/health", server.HandleHealthz(ctx))
 
 	srv, err := server.New(config.Port)
 	if err != nil {

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -61,6 +61,7 @@ func realMain(ctx context.Context) error {
 
 	mux := http.NewServeMux()
 	mux.Handle("/", handler)
+	mux.Handle("/health", server.HandleHealthz(ctx))
 
 	srv, err := server.New(config.Port)
 	if err != nil {

--- a/internal/debugger/server.go
+++ b/internal/debugger/server.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/serverenv"
+	"github.com/google/exposure-notifications-server/pkg/server"
 )
 
 // Server is the debugger server.
@@ -55,5 +56,7 @@ func NewServer(config *Config, env *serverenv.ServerEnv) (*Server, error) {
 func (s *Server) Routes(ctx context.Context) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", s.handleDebug(ctx))
+	mux.Handle("/health", server.HandleHealthz(ctx))
+
 	return mux
 }

--- a/internal/export/server.go
+++ b/internal/export/server.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/serverenv"
+	"github.com/google/exposure-notifications-server/pkg/server"
 )
 
 // NewServer makes a Server.
@@ -56,6 +57,7 @@ func (s *Server) Routes(ctx context.Context) *http.ServeMux {
 
 	mux.HandleFunc("/create-batches", s.handleCreateBatches(ctx))
 	mux.HandleFunc("/do-work", s.handleDoWork(ctx))
+	mux.Handle("/health", server.HandleHealthz(ctx))
 
 	return mux
 }

--- a/internal/keyrotation/server.go
+++ b/internal/keyrotation/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/database"
 	revisiondb "github.com/google/exposure-notifications-server/internal/revision/database"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
+	"github.com/google/exposure-notifications-server/pkg/server"
 )
 
 // Server hosts end points to manage key rotation
@@ -66,6 +67,7 @@ func (s *Server) Routes(ctx context.Context) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/rotate-keys", s.handleRotateKeys(ctx))
+	mux.Handle("/health", server.HandleHealthz(ctx))
 
 	return mux
 }

--- a/pkg/server/healthz.go
+++ b/pkg/server/healthz.go
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package server provides an opinionated http server.
-//
-// Although exported, this package is non intended for general consumption. It
-// is a shared dependency between multiple exposure notifications projects. We
-// cannot guarantee that there won't be breaking changes in the future.
 package server
 
 import (

--- a/pkg/server/healthz.go
+++ b/pkg/server/healthz.go
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package server provides an opinionated http server.
+//
+// Although exported, this package is non intended for general consumption. It
+// is a shared dependency between multiple exposure notifications projects. We
+// cannot guarantee that there won't be breaking changes in the future.
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+)
+
+func HandleHealthz(hctx context.Context) http.Handler {
+	logger := logging.FromContext(hctx).Named("healthz")
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"status": "ok"}`)
+	})
+}

--- a/pkg/server/healthz.go
+++ b/pkg/server/healthz.go
@@ -23,13 +23,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
-	"github.com/google/exposure-notifications-server/pkg/logging"
 )
 
 func HandleHealthz(hctx context.Context) http.Handler {
-	logger := logging.FromContext(hctx).Named("healthz")
-
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `{"status": "ok"}`)
 	})


### PR DESCRIPTION
Fixes #881

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adds /health to all web servers. It always returns 200.
```