### PR TITLE
tighten up symptom onset defaults, allow partial success

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -53,7 +53,7 @@ type Config struct {
 	// Provides compatibility w/ 1.5 release.
 	MaxSameStartIntervalKeys     uint          `env:"MAX_SAME_START_INTERVAL_KEYS, default=3"`
 	MaxIntervalAge               time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
-	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=21"`
+	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=14"`
 	CreatedAtTruncateWindow      time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 
 	RevisionKeyCacheDuration time.Duration `env:"REVISION_KEY_CACHE_DURATION, default=1m"`

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -465,7 +465,7 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 			daysSince := DaysFromSymptomOnset(onsetInterval, exposure.IntervalNumber)
 			if abs := math.Abs(float64(daysSince)); abs > t.maxSymptomOnsetDays {
 				logger.Debugw("dropping key due to symptom onset magnitude too high", "daysSince", daysSince)
-				transformErrors = multierror.Append(transformErrors, fmt.Errorf("key %d cannot be imported: days from symptom onset is too large, %v > %v.", i, abs, t.maxSymptomOnsetDays))
+				transformErrors = multierror.Append(transformErrors, fmt.Errorf("key %d cannot be imported: days from symptom onset is too large, %v > %v", i, abs, t.maxSymptomOnsetDays))
 				continue
 			}
 			exposure.SetDaysSinceSymptomOnset(daysSince)

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -463,9 +463,12 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		// Set days since onset, either from the API or from the verified claims (see above).
 		if onsetInterval > 0 {
 			daysSince := DaysFromSymptomOnset(onsetInterval, exposure.IntervalNumber)
-			if math.Abs(float64(daysSince)) < t.maxSymptomOnsetDays {
-				exposure.SetDaysSinceSymptomOnset(daysSince)
+			if abs := math.Abs(float64(daysSince)); abs > t.maxSymptomOnsetDays {
+				logger.Debugw("dropping key due to symptom onset magnitude too high", "daysSince", daysSince)
+				transformErrors = multierror.Append(transformErrors, fmt.Errorf("key %d cannot be imported: days from symptom onset is too large, %v > %v.", i, abs, t.maxSymptomOnsetDays))
+				continue
 			}
+			exposure.SetDaysSinceSymptomOnset(daysSince)
 		}
 		exposure.Traveler = inData.Traveler
 		entities = append(entities, exposure)

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -762,7 +762,7 @@ func TestTransform(t *testing.T) {
 					HealthAuthorityID:     int64Ptr(27),
 				},
 			},
-			PartialError: "key 1 cannot be imported: days from symptom onset is too large, 15 > 14.",
+			PartialError: "key 1 cannot be imported: days from symptom onset is too large, 15 > 14",
 		},
 	}
 

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	maxSymptomOnsetDays = 21
+	maxSymptomOnsetDays = 14
 )
 
 type testConfig struct {
@@ -454,11 +454,12 @@ func TestTransform(t *testing.T) {
 	batchTimeRounded := TruncateWindow(batchTime, time.Hour)
 
 	cases := []struct {
-		Name    string
-		Publish *verifyapi.Publish
-		Regions []string
-		Claims  *verification.VerifiedClaims
-		Want    []*Exposure
+		Name         string
+		Publish      *verifyapi.Publish
+		Regions      []string
+		Claims       *verification.VerifiedClaims
+		Want         []*Exposure
+		PartialError string
 	}{
 		{
 			Name: "basic_v1_publish",
@@ -723,6 +724,46 @@ func TestTransform(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "symptom_onset_too_large",
+			Publish: &verifyapi.Publish{
+				Keys: []verifyapi.ExposureKey{
+					{
+						Key:            encodeKey(testKeys[6]),
+						IntervalNumber: intervalNumber - (4 * verifyapi.MaxIntervalCount),
+						IntervalCount:  verifyapi.MaxIntervalCount,
+					},
+					{
+						Key:            encodeKey(testKeys[7]),
+						IntervalNumber: intervalNumber - (1 * verifyapi.MaxIntervalCount),
+						IntervalCount:  verifyapi.MaxIntervalCount,
+					},
+				},
+				HealthAuthorityID: appPackage,
+			},
+			Regions: wantRegions,
+			Claims: &verification.VerifiedClaims{
+				HealthAuthorityID:    27,
+				ReportType:           verifyapi.ReportTypeClinical,
+				SymptomOnsetInterval: uint32(intervalNumber - 16*verifyapi.MaxIntervalCount),
+			},
+			Want: []*Exposure{
+				{
+					ExposureKey:           testKeys[6],
+					IntervalNumber:        intervalNumber - (4 * verifyapi.MaxIntervalCount),
+					IntervalCount:         verifyapi.MaxIntervalCount,
+					TransmissionRisk:      verifyapi.TransmissionRiskClinical,
+					AppPackageName:        appPackage,
+					Regions:               wantRegions,
+					CreatedAt:             batchTimeRounded,
+					LocalProvenance:       true,
+					ReportType:            verifyapi.ReportTypeClinical,
+					DaysSinceSymptomOnset: int32Ptr(12),
+					HealthAuthorityID:     int64Ptr(27),
+				},
+			},
+			PartialError: "key 1 cannot be imported: days from symptom onset is too large, 15 > 14.",
+		},
 	}
 
 	allowedAge := 14 * 24 * time.Hour
@@ -735,8 +776,14 @@ func TestTransform(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			got, err := transformer.TransformPublish(ctx, tc.Publish, tc.Regions, tc.Claims, batchTime)
-			if err != nil {
+			if err != nil && tc.PartialError == "" {
 				t.Fatalf("TransformPublish returned unexpected error: %v", err)
+			} else if tc.PartialError != "" {
+				if err == nil {
+					t.Fatalf("TransformPublish didn't return expected error: %v", tc.PartialError)
+				} else if !strings.Contains(err.Error(), tc.PartialError) {
+					t.Fatalf("TransformPublish didn't return expected error: %q, got: %v", tc.PartialError, err)
+				}
 			}
 
 			if diff := cmp.Diff(tc.Want, got, cmpopts.IgnoreUnexported(Exposure{})); diff != "" {


### PR DESCRIPTION
Fixes #905 

## Proposed Changes

* Tighten symptom onset allowed from 21 to 14 days by default
* Allow partial failure for keys outside that range.

**Release Note**

```release-note
Too large a magnitude for days +/- symptom onset results in partial success instead of total failure.
```