### PR TITLE
Fix dropping all labels

### DIFF
--- a/pkg/observability/resource.go
+++ b/pkg/observability/resource.go
@@ -115,14 +115,14 @@ func (s *stackdriverMonitoredResource) MonitoredResource() (string, map[string]s
 // removeUnusedLabels deletes unused labels to not flood stackdriver.
 func removeUnusedLabels(resource string, in map[string]string) map[string]string {
 	// The labels each resource type requires.
-	requiredLabels = map[string]map[string]bool{
+	requiredLabels := map[string]map[string]bool{
 		// https://cloud.google.com/monitoring/api/resources#tag_generic_task
 		"generic_task": {"project_id": true, "location": true, "namespace": true, "job": true, "task_id": true},
 	}
 
 	ret := map[string]string{}
 	for k, v := range in {
-		if requiredLabels[k] {
+		if requiredLabels[resource][k] {
 			ret[k] = v
 		}
 	}

--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -52,7 +52,7 @@ func NewStackdriver(ctx context.Context, config *StackdriverConfig) (Exporter, e
 		ReportingInterval: time.Minute, // stackdriver export interval minimum
 		MonitoredResource: monitoredResource,
 		OnError: func(err error) {
-			logger.Errorw("failed to export metric", "error", err)
+			logger.Errorw("failed to export metric", "error", err, "resource", monitoredResource)
 		},
 	})
 


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* We were accidentally dropping all stackdriver labels due to a bug.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Reenables sending of stackdriver metrics.
```