### PR TITLE
Update terraform to 1.13.1 in docker and install jq

### DIFF
--- a/docker/presubmit-test.dockerfile
+++ b/docker/presubmit-test.dockerfile
@@ -20,10 +20,14 @@ FROM golang:1.15
 RUN apt-get update -yqq && apt-get install -yqq sudo unzip
 
 # Install terraform
-RUN wget -q https://releases.hashicorp.com/terraform/0.13.0/terraform_0.13.0_linux_amd64.zip \
-  && unzip terraform_0.13.0_linux_amd64.zip \
+RUN wget -q https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_linux_amd64.zip \
+  && unzip terraform_0.13.1_linux_amd64.zip \
   && mv terraform /usr/bin \
-  && rm terraform_0.13.0_linux_amd64.zip
+  && rm terraform_0.13.1_linux_amd64.zip
+
+# Install jq
+RUN curl -o /usr/bin/jq http://stedolan.github.io/jq/download/linux64/jq \
+  && chmod +x /usr/bin/jq
 
 # Install gcloud
 WORKDIR /workspace


### PR DESCRIPTION
jq is needed for grabbing output from terraform as https://www.terraform.io/docs/commands/output.html