### PR TITLE
implement random padding of publish responses

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -56,6 +56,9 @@ type Config struct {
 	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=14"`
 	CreatedAtTruncateWindow      time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 
+	ResponsePaddingMinBytes int64 `env:"RESPONSE_PADDING_MIN_BYTES, default=1024"`
+	ResponsePaddingRange    int64 `env:"RESPONSE_PADDING_RANGE, default=1024"`
+
 	RevisionKeyCacheDuration time.Duration `env:"REVISION_KEY_CACHE_DURATION, default=1m"`
 
 	// API Versions.

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -126,11 +126,20 @@ func (r *response) padResponse(c *Config) error {
 		return fmt.Errorf("no publish response exists to pad")
 	}
 
-	bi, err := rand.Int(rand.Reader, big.NewInt(c.ResponsePaddingRange))
+	minBytes := c.ResponsePaddingMinBytes
+	if minBytes <= 0 {
+		minBytes = 1024
+	}
+	padRange := c.ResponsePaddingRange
+	if padRange <= 0 {
+		padRange = 1024
+	}
+
+	bi, err := rand.Int(rand.Reader, big.NewInt(padRange))
 	if err != nil {
 		return fmt.Errorf("padding: failed to generate random number: %w", err)
 	}
-	i := int(bi.Int64() + c.ResponsePaddingMinBytes)
+	i := int(bi.Int64() + minBytes)
 
 	b := make([]byte, i)
 	n, err := rand.Read(b)

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -434,6 +434,8 @@ func TestPublishWithBypass(t *testing.T) {
 				}
 				config.RevisionToken.AAD = tokenAAD
 				config.RevisionToken.KeyID = keyID
+				config.ResponsePaddingMinBytes = 100
+				config.ResponsePaddingRange = 100
 				env := serverenv.New(ctx,
 					serverenv.WithDatabase(testDB),
 					serverenv.WithAuthorizedAppProvider(aaProvider),
@@ -535,6 +537,9 @@ func TestPublishWithBypass(t *testing.T) {
 				}
 				if resp.StatusCode != tc.Code {
 					t.Fatalf("http response code want: %v, got %v.", tc.Code, resp.StatusCode)
+				}
+				if len(response.Padding) == 0 {
+					t.Errorf("padding is empty on response: %+v", response)
 				}
 
 				if ver == useV1 {
@@ -741,6 +746,8 @@ func TestKeyRevision(t *testing.T) {
 	config.MaxKeysOnPublish = 20
 	config.MaxSameStartIntervalKeys = 2
 	config.MaxIntervalAge = 14 * 24 * time.Hour
+	config.ResponsePaddingMinBytes = 100
+	config.ResponsePaddingRange = 100
 	aaProvider, err := authorizedapp.NewDatabaseProvider(ctx, testDB, config.AuthorizedAppConfig())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION

## Proposed Changes

* pad publish responses (error and success)

**Release Note**

```release-note
Start populating "padding" field on the publish responses. This field has been in the API for several releases, but wasn't populated before.
```