### PR TITLE
Add x-api-version header in API responses

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -42,6 +42,10 @@ import (
 	"github.com/mikehelmick/go-chaff"
 )
 
+const (
+	HeaderAPIVersion = "x-api-version"
+)
+
 // NewHandler creates common API handler for the publish API.
 // This supports all current versions of the API and each defines it's own entry point via
 // an http.HandlerFunc

--- a/internal/publish/publish_v1.go
+++ b/internal/publish/publish_v1.go
@@ -32,6 +32,8 @@ func (h *PublishHandler) handleRequest(w http.ResponseWriter, r *http.Request) r
 	ctx, span := trace.StartSpan(r.Context(), "(*publish.PublishHandler).handleRequest")
 	defer span.End()
 
+	w.Header().Set(HeaderAPIVersion, "v1")
+
 	var data verifyapi.Publish
 	code, err := jsonutil.Unmarshal(w, r, &data)
 	if err != nil {

--- a/internal/publish/publish_v1alpha1.go
+++ b/internal/publish/publish_v1alpha1.go
@@ -33,6 +33,8 @@ func (h *PublishHandler) handleV1Apha1Request(w http.ResponseWriter, r *http.Req
 	ctx, span := trace.StartSpan(r.Context(), "(*publish.PublishHandler).handleRequest")
 	defer span.End()
 
+	w.Header().Set(HeaderAPIVersion, "v1alpha")
+
 	var data v1alpha1.Publish
 	code, err := jsonutil.Unmarshal(w, r, &data)
 	if err != nil {
@@ -42,7 +44,6 @@ func (h *PublishHandler) handleV1Apha1Request(w http.ResponseWriter, r *http.Req
 			status:      code,
 			pubResponse: &verifyapi.PublishResponse{ErrorMessage: message}, // will be down-converted in ServeHTTP
 			metric:      "publish-bad-json", count: 1}
-
 	}
 
 	// Upconvert the exposure key records.


### PR DESCRIPTION
This is just a hint to clients to know which API version they invoked.

Did this as part of investigating GH-930 and thought it might be helpful to have in prod.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add `x-api-version` response header to exposure service responses
```