### PR TITLE
Fix double-quoted padding

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -150,7 +150,7 @@ func (r *response) padResponse(c *Config) error {
 		return fmt.Errorf("padding: wrote less bytes than expected")
 	}
 
-	r.pubResponse.Padding = fmt.Sprintf("%q", base64.StdEncoding.EncodeToString(b))
+	r.pubResponse.Padding = base64.StdEncoding.EncodeToString(b)
 	return nil
 }
 


### PR DESCRIPTION
Fixes GH-966

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix double-quoting in padding
```