### PR TITLE
Upgrade to Go 1.15.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Each binary will have its `main.go` file in a `/cmd/[bin-name]` folder.
 
 To run the server, you must install the following dependencies:
 
-1.  [Go 1.14.0 or newer](https://golang.org/dl/).
+1.  [Go 1.15.1 or newer](https://golang.org/dl/).
 
 1.  [Docker][docker].
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15 AS builder
+FROM golang:1.15.1 AS builder
 
 ARG SERVICE
 

--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -44,7 +44,7 @@ steps:
   - '-allow-failure'
 
 - id: 'download-modules'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'mod'
@@ -66,7 +66,7 @@ steps:
 # cleanup-export
 #
 - id: 'build-cleanup-export'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -92,7 +92,7 @@ steps:
 # cleanup-exposure
 #
 - id: 'build-cleanup-exposure'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -118,7 +118,7 @@ steps:
 # debugger
 #
 - id: 'build-debugger'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -144,7 +144,7 @@ steps:
 # export
 #
 - id: 'build-export'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -170,7 +170,7 @@ steps:
 # exposure
 #
 - id: 'build-exposure'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -196,7 +196,7 @@ steps:
 # cleanup-export
 #
 - id: 'build-federationin'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -222,7 +222,7 @@ steps:
 # federationout
 #
 - id: 'build-federationout'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -248,7 +248,7 @@ steps:
 # generate
 #
 - id: 'build-generate'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -274,7 +274,7 @@ steps:
 # key-rotation
 #
 - id: 'build-key-rotation'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -300,7 +300,7 @@ steps:
 # migrate
 #
 - id: 'build-migrate'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'

--- a/docker/migrate.dockerfile
+++ b/docker/migrate.dockerfile
@@ -14,7 +14,7 @@
 
 # migrate is a base container with migrate and the Cloud SQL proxy installed.
 
-FROM golang:1.15-alpine AS builder
+FROM golang:1.15.1-alpine AS builder
 
 # Install deps
 RUN apk add --no-cache git

--- a/docker/presubmit-test.dockerfile
+++ b/docker/presubmit-test.dockerfile
@@ -14,7 +14,7 @@
 
 # This image is used to run ./scripts/presubmit.sh on CI
 
-FROM golang:1.15
+FROM golang:1.15.1
 
 # Install sudo
 RUN apt-get update -yqq && apt-get install -yqq sudo unzip

--- a/docker/protoc.dockerfile
+++ b/docker/protoc.dockerfile
@@ -14,7 +14,7 @@
 
 # protoc is a base container with protoc and protoc-gen-go installed.
 
-FROM golang:1.15 AS builder
+FROM golang:1.15.1 AS builder
 
 ENV PROTOC_VERSION "3.11.4"
 ENV PROTOC_GEN_GO_VERSION "1.4.1"


### PR DESCRIPTION
Fixes GH-941

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Upgrade to Go 1.15.1
```