### PR TITLE
Fix AAD acronym, clarify long form

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -78,7 +78,7 @@ func NewHandler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (
 
 	aadBytes := config.RevisionToken.AAD
 	if len(aadBytes) == 0 {
-		return nil, fmt.Errorf("must provide ADD for revision token encryption in REVISION_TOKEN_AAD env variable")
+		return nil, fmt.Errorf("must provide Additional Authenticated Data (AAD) for revision token encryption in REVISION_TOKEN_AAD env variable")
 	}
 	revisionKeyConfig := revisiondb.KMSConfig{
 		WrapperKeyID: config.RevisionToken.KeyID,


### PR DESCRIPTION
Minor patch; the message shown when the `REVISION_TOKEN_AAD` variable was omitted was slightly confusing for me.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fix the acronym for Additional Authenticated Data (`ADD` -> `AAD`), clarify long form.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```