### PR TITLE
Return more specific error codes for key_already_revised and invalid_report_type_transition

### DIFF
--- a/internal/authorizedapp/database_provider.go
+++ b/internal/authorizedapp/database_provider.go
@@ -17,7 +17,6 @@ package authorizedapp
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -92,8 +91,6 @@ func (p *DatabaseProvider) AppConfig(ctx context.Context, name string) (*model.A
 	if config == nil {
 		return nil, ErrAppNotFound
 	}
-
-	log.Printf("AppConfig: %+v %v", config, err)
 
 	// Returned config.
 	return config, nil

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -41,6 +41,20 @@ var (
 	ErrorKeyAlreadyRevised = fmt.Errorf("key has already been revised and cannot be revised again")
 )
 
+var _ error = (*ErrorKeyInvalidReportTypeTransition)(nil)
+
+// ErrorKeyInvalidReportTypeTransition is an error returned when the TEK tried
+// to move to an invalid state (e.g. positive -> likely).
+type ErrorKeyInvalidReportTypeTransition struct {
+	from, to string
+}
+
+// Error implements error.
+func (e *ErrorKeyInvalidReportTypeTransition) Error() string {
+	return fmt.Sprintf("invalid report type transition: cannot transition from %q to %q",
+		e.from, e.to)
+}
+
 // Exposure represents the record as stored in the database
 type Exposure struct {
 	ExposureKey      []byte
@@ -93,7 +107,10 @@ func (e *Exposure) Revise(in *Exposure) (bool, error) {
 		eReportType = verifyapi.ReportTypeClinical
 	}
 	if !(eReportType == verifyapi.ReportTypeClinical && (in.ReportType == verifyapi.ReportTypeConfirmed || in.ReportType == verifyapi.ReportTypeNegative)) {
-		return false, fmt.Errorf("invalid report type transition, cannot transition from '%v' to '%v'", e.ReportType, in.ReportType)
+		return false, &ErrorKeyInvalidReportTypeTransition{
+			from: e.ReportType,
+			to:   in.ReportType,
+		}
 	}
 
 	// Update fields.

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -1169,7 +1169,7 @@ func TestExposureReview(t *testing.T) {
 				ReportType: verifyapi.ReportTypeClinical,
 			},
 			needsRevision: false,
-			err:           "invalid report type transition, cannot transition from 'confirmed' to 'likely'",
+			err:           `invalid report type transition, cannot transition from "confirmed" to "likely"`,
 		},
 		{
 			name: "invalid_transition_from_empty_report_type",

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -1169,7 +1169,7 @@ func TestExposureReview(t *testing.T) {
 				ReportType: verifyapi.ReportTypeClinical,
 			},
 			needsRevision: false,
-			err:           `invalid report type transition, cannot transition from "confirmed" to "likely"`,
+			err:           `invalid report type transition: cannot transition from "confirmed" to "likely"`,
 		},
 		{
 			name: "invalid_transition_from_empty_report_type",
@@ -1181,7 +1181,7 @@ func TestExposureReview(t *testing.T) {
 				ReportType: verifyapi.ReportTypeClinical,
 			},
 			needsRevision: false,
-			err:           "invalid report type transition, cannot transition from '' to 'likely'",
+			err:           `invalid report type transition: cannot transition from "" to "likely"`,
 		},
 		{
 			name: "valid_transition_from_empty_report_type",

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -34,7 +34,6 @@ import (
 	aamodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
 	coredb "github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/pb"
-	"github.com/google/exposure-notifications-server/internal/publish/database"
 	pubdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/revision"
@@ -829,7 +828,7 @@ func TestKeyRevision(t *testing.T) {
 						ReportType:     verifyapi.ReportTypeClinical,
 					})
 				}
-				if _, err := pubDB.InsertAndReviseExposures(ctx, &database.InsertAndReviseExposuresRequest{
+				if _, err := pubDB.InsertAndReviseExposures(ctx, &pubdb.InsertAndReviseExposuresRequest{
 					Incoming: incoming,
 				}); err != nil {
 					t.Fatal(err)
@@ -839,7 +838,7 @@ func TestKeyRevision(t *testing.T) {
 				for _, key := range incoming {
 					key.ReportType = verifyapi.ReportTypeConfirmed
 				}
-				if _, err := pubDB.InsertAndReviseExposures(ctx, &database.InsertAndReviseExposuresRequest{
+				if _, err := pubDB.InsertAndReviseExposures(ctx, &pubdb.InsertAndReviseExposuresRequest{
 					Incoming: incoming,
 				}); err != nil {
 					t.Fatal(err)

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -35,6 +34,7 @@ import (
 	aamodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
 	coredb "github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/pb"
+	"github.com/google/exposure-notifications-server/internal/publish/database"
 	pubdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/revision"
@@ -525,8 +525,6 @@ func TestPublishWithBypass(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				log.Printf("\n\n%#v\n\n", string(respBytes))
-
 				var response verifyapi.PublishResponse
 				if err := json.Unmarshal(respBytes, &response); err != nil {
 					t.Fatalf("unable to unmarshal response body: %v; data: %v", err, string(respBytes))
@@ -773,12 +771,13 @@ func TestKeyRevision(t *testing.T) {
 	pubDB := pubdb.New(testDB)
 
 	cases := []struct {
-		Name           string
-		Publish        verifyapi.Publish
-		ErrorCode      string
-		RevErrorCode   string
-		RevTokenMesser RevisionTokenChanger
-		PublishMesser  PublishDataChanger
+		Name               string
+		Publish            verifyapi.Publish
+		ErrorCode          string
+		RevErrorCode       string
+		RevTokenMesser     RevisionTokenChanger
+		PublishMesser      PublishDataChanger
+		VerificationMesser func(c *testutil.JWTConfig)
 	}{
 		{
 			Name: "normal_revision",
@@ -804,6 +803,65 @@ func TestKeyRevision(t *testing.T) {
 				return ""
 			},
 			PublishMesser: PublishIdentity,
+		},
+		{
+			Name: "key_already_revised",
+			Publish: verifyapi.Publish{
+				Keys:                util.GenerateExposureKeys(2, 0, false),
+				Traveler:            false,
+				HealthAuthorityID:   haName,
+				VerificationPayload: "totally not a JWT",
+			},
+			RevErrorCode:   verifyapi.ErrorKeyAlreadyRevised,
+			RevTokenMesser: TokenIdentity,
+			PublishMesser: func(t *testing.T, data *verifyapi.Publish) (bool, *verifyapi.Publish) {
+				// Create some keys in the database
+				var incoming []*model.Exposure
+				for _, key := range data.Keys {
+					b64Key, err := base64util.DecodeString(key.Key)
+					if err != nil {
+						t.Fatal(err)
+					}
+					incoming = append(incoming, &model.Exposure{
+						ExposureKey:    b64Key,
+						IntervalNumber: key.IntervalNumber,
+						IntervalCount:  key.IntervalCount,
+						ReportType:     verifyapi.ReportTypeClinical,
+					})
+				}
+				if _, err := pubDB.InsertAndReviseExposures(ctx, &database.InsertAndReviseExposuresRequest{
+					Incoming: incoming,
+				}); err != nil {
+					t.Fatal(err)
+				}
+
+				// Revise them
+				for _, key := range incoming {
+					key.ReportType = verifyapi.ReportTypeConfirmed
+				}
+				if _, err := pubDB.InsertAndReviseExposures(ctx, &database.InsertAndReviseExposuresRequest{
+					Incoming: incoming,
+				}); err != nil {
+					t.Fatal(err)
+				}
+
+				return PublishIdentity(t, data)
+			},
+		},
+		{
+			Name: "invalid_report_type_transition",
+			Publish: verifyapi.Publish{
+				Keys:                util.GenerateExposureKeys(2, 0, false),
+				Traveler:            false,
+				HealthAuthorityID:   haName,
+				VerificationPayload: "totally not a JWT",
+			},
+			RevErrorCode:   verifyapi.ErrorInvalidReportTypeTransition,
+			RevTokenMesser: TokenIdentity,
+			PublishMesser:  PublishIdentity,
+			VerificationMesser: func(c *testutil.JWTConfig) {
+				c.ReportType = "totally_not_valid"
+			},
 		},
 		{
 			Name: "token_missing_keys",
@@ -926,7 +984,7 @@ func TestKeyRevision(t *testing.T) {
 				}
 
 				if response.Code != tc.ErrorCode {
-					t.Fatalf("wrong code on initial publish, want %v, got %v", tc.ErrorCode, response.Code)
+					t.Fatalf("wrong code on initial publish, want %#v, got %#v", tc.ErrorCode, response.Code)
 				}
 				revisionToken = response.RevisionToken
 			}
@@ -942,14 +1000,19 @@ func TestKeyRevision(t *testing.T) {
 				keysAreRevisions, publishData = tc.PublishMesser(t, &tc.Publish)
 				tc.Publish = *publishData
 
-				cfg := testutil.JWTConfig{
+				cfg := &testutil.JWTConfig{
 					HealthAuthority:    healthAuthority,
 					HealthAuthorityKey: healthAuthorityKey,
 					ExposureKeys:       tc.Publish.Keys,
 					Key:                signingKey.Key,
 					ReportType:         verifyapi.ReportTypeConfirmed,
 				}
-				verification, salt := testutil.IssueJWT(t, &cfg)
+
+				if messer := tc.VerificationMesser; messer != nil {
+					messer(cfg)
+				}
+
+				verification, salt := testutil.IssueJWT(t, cfg)
 				tc.Publish.VerificationPayload = verification
 				tc.Publish.HMACKey = salt
 
@@ -978,7 +1041,7 @@ func TestKeyRevision(t *testing.T) {
 				}
 
 				if response.Code != tc.RevErrorCode {
-					t.Fatalf("wrong code on initial publish, want %v, got %v", tc.ErrorCode, response.Code)
+					t.Fatalf("wrong code on revision, want %#v, got %#v", tc.RevErrorCode, response.Code)
 				}
 			}
 

--- a/pkg/api/v1/exposure_types.go
+++ b/pkg/api/v1/exposure_types.go
@@ -54,8 +54,15 @@ const (
 	// ErrorInvalidRevisionToken indicates a revision token was passed, but is missing a
 	// key or has invalid metadata.
 	ErrorInvalidRevisionToken = "invalid_revision_token"
-	// ErrorPartialFailure indicates that some exposure keys in the publish request had invalid
-	// data (size, timing metadata) and were dropped. Other keys were saved.
+	// ErrorKeyAlreadyRevised indicates one of the uploaded TEKs was marked for
+	// revision, but it has already been revised.
+	ErrorKeyAlreadyRevised = "key_already_revised"
+	// ErrorInvalidReportTypeTransition indicates an uploaded TEK tried to
+	// transition to an invalid state (like "positive" -> "likely").
+	ErrorInvalidReportTypeTransition = "invalid_report_type_transition"
+	// ErrorPartialFailure indicates that some exposure keys in the publish
+	// request had invalid data (size, timing metadata) and were dropped. Other
+	// keys were saved.
 	ErrorPartialFailure = "partial_failure"
 )
 


### PR DESCRIPTION
Fixes GH-974

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Return specific error responses for `key_already_revised` and `invalid_report_type_transition` on publish
```

/assign @mikehelmick 