### PR TITLE
Fix perf test failure

### DIFF
--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -156,7 +156,7 @@ func TestExport(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got, want := int(resp.Revised), keysPerPublish; got != want {
+		if got, want := int(resp.Inserted), keysPerPublish; got != want {
 			t.Fatalf("Want revised: %d, got %d", want, got)
 		}
 	}


### PR DESCRIPTION
Performance test failed since https://github.com/google/exposure-notifications-server/pull/964

See performance test runs here: https://testgrid.k8s.io/googleoss-en-server#performance

/cc @sethvargo 