### PR TITLE
Sort exposures in unit test to make the result deterministic

### DIFF
--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -756,6 +756,10 @@ func TestIterateExposuresCursor(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
+	// IterateExposures doesn't guarantee the order, sort to make this test deterministic
+	sort.Slice(seen, func(i, j int) bool {
+		return seen[i].IntervalNumber < seen[j].IntervalNumber
+	})
 	if diff := cmp.Diff(exposures[:2], seen, ignoreUnexportedExposure); diff != "" {
 		t.Fatalf("exposures mismatch (-want, +got):\n%s", diff)
 	}
@@ -770,6 +774,9 @@ func TestIterateExposuresCursor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	sort.Slice(seen, func(i, j int) bool {
+		return seen[i].IntervalNumber < seen[j].IntervalNumber
+	})
 	if diff := cmp.Diff(exposures[2:], seen, ignoreUnexportedExposure); diff != "" {
 		t.Fatalf("exposures mismatch (-want, +got):\n%s", diff)
 	}

--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -757,10 +757,10 @@ func TestIterateExposuresCursor(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	// IterateExposures doesn't guarantee the order, sort to make this test deterministic
-	sort.Slice(seen, func(i, j int) bool {
+	sortExposureFunc := func(i, j int) bool {
 		return seen[i].IntervalNumber < seen[j].IntervalNumber
-	})
-	if diff := cmp.Diff(exposures[:2], seen, ignoreUnexportedExposure); diff != "" {
+	}
+	if diff := cmp.Diff(exposures[:2], seen, ignoreUnexportedExposure, cmpopts.SortSlices(sortExposureFunc)); diff != "" {
 		t.Fatalf("exposures mismatch (-want, +got):\n%s", diff)
 	}
 	if want := encodeCursor("2"); cursor != want {
@@ -774,10 +774,7 @@ func TestIterateExposuresCursor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sort.Slice(seen, func(i, j int) bool {
-		return seen[i].IntervalNumber < seen[j].IntervalNumber
-	})
-	if diff := cmp.Diff(exposures[2:], seen, ignoreUnexportedExposure); diff != "" {
+	if diff := cmp.Diff(exposures[2:], seen, ignoreUnexportedExposure, cmpopts.SortSlices(sortExposureFunc)); diff != "" {
 		t.Fatalf("exposures mismatch (-want, +got):\n%s", diff)
 	}
 	if cursor != "" {

--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -757,8 +757,8 @@ func TestIterateExposuresCursor(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	// IterateExposures doesn't guarantee the order, sort to make this test deterministic
-	sortExposureFunc := func(i, j int) bool {
-		return seen[i].IntervalNumber < seen[j].IntervalNumber
+	sortExposureFunc := func(e1, e2 *model.Exposure) bool {
+		return e1.IntervalNumber < e2.IntervalNumber
 	}
 	if diff := cmp.Diff(exposures[:2], seen, ignoreUnexportedExposure, cmpopts.SortSlices(sortExposureFunc)); diff != "" {
 		t.Fatalf("exposures mismatch (-want, +got):\n%s", diff)


### PR DESCRIPTION
This test failed randomly with out of order problem https://oss-prow.knative.dev/view/gs/oss-prow/pr-logs/pull/google_exposure-notifications-server/981/pull-en-server-release-unit/1304300664213475328

/assign @sethvargo 