### PR TITLE
Making stackdriver exporter options configurable in env var

### DIFF
--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -73,5 +73,5 @@ type StackdriverConfig struct {
 	// stackdriver request.
 	ReportingInterval    time.Duration `env:"STACKDRIVER_REPORTING_INTERVAL, default=2m"`
 	BundleDelayThreshold time.Duration `env:"STACKDRIVER_BUNDLE_DELAY_THRESHOLD, default=2s"`
-	BundleCountThreshold int           `env:"STACKDRIVER_BUNDLE_COUNT_THRESHOLD, default=50"`
+	BundleCountThreshold uint          `env:"STACKDRIVER_BUNDLE_COUNT_THRESHOLD, default=50"`
 }

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -15,6 +15,8 @@
 // Package observability sets up and configures observability tools.
 package observability
 
+import "time"
+
 // ExporterType represents a type of observability exporter.
 type ExporterType string
 
@@ -60,4 +62,8 @@ type StackdriverConfig struct {
 	// Allows for providing a real Google Cloud location when running locally for development.
 	// This is ignored if a real location was found during discovery.
 	LocationOverride string `env:"DEV_STACKDRIVER_LOCATION"`
+
+	ReportingInterval    time.Duration `env:"STACKDRIVER_REPORTING_INTERVAL, default=2m"`
+	BundleDelayThreshold time.Duration `env:"STACKDRIVER_BUNDLE_DELAY_THRESHOLD, default=2s"`
+	BundleCountThreshold int           `env:"STACKDRIVER_BUNDLE_COUNT_THRESHOLD, default=50"`
 }

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -63,6 +63,14 @@ type StackdriverConfig struct {
 	// This is ignored if a real location was found during discovery.
 	LocationOverride string `env:"DEV_STACKDRIVER_LOCATION"`
 
+	// The following options are mostly for tuning the metrics reporting
+	// behavior. You normally should not change these values.
+	// ReportingInterval: should be >=60s as stackdriver enforces 60s minimal
+	// interval.
+	// BundleDelayThreshold / BundleCountThreshold: the stackdriver exporter
+	// uses https://google.golang.org/api/support/bundler, these two options
+	// control the max delay/count for batching the data points into one
+	// stackdriver request.
 	ReportingInterval    time.Duration `env:"STACKDRIVER_REPORTING_INTERVAL, default=2m"`
 	BundleDelayThreshold time.Duration `env:"STACKDRIVER_BUNDLE_DELAY_THRESHOLD, default=2s"`
 	BundleCountThreshold int           `env:"STACKDRIVER_BUNDLE_COUNT_THRESHOLD, default=50"`

--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -50,7 +50,7 @@ func NewStackdriver(ctx context.Context, config *StackdriverConfig) (Exporter, e
 		ProjectID:               projectID,
 		ReportingInterval:       config.ReportingInterval,
 		BundleDelayThreshold:    config.BundleDelayThreshold,
-		BundleCountThreshold:    config.BundleCountThreshold,
+		BundleCountThreshold:    int(config.BundleCountThreshold),
 		MonitoredResource:       monitoredResource,
 		DefaultMonitoringLabels: &stackdriver.Labels{},
 		OnError: func(err error) {

--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -80,7 +80,6 @@ func (e *stackdriverExporter) StartExporter() error {
 	trace.RegisterExporter(e.exporter)
 
 	view.RegisterExporter(e.exporter)
-	view.SetReportingPeriod(SDExportFrequency)
 
 	return nil
 }

--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -18,7 +18,6 @@ package observability
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
@@ -27,11 +26,7 @@ import (
 	"go.opencensus.io/trace"
 )
 
-var (
-	_ Exporter = (*stackdriverExporter)(nil)
-
-	SDExportFrequency = time.Minute * 2
-)
+var _ Exporter = (*stackdriverExporter)(nil)
 
 type stackdriverExporter struct {
 	exporter *stackdriver.Exporter
@@ -53,7 +48,9 @@ func NewStackdriver(ctx context.Context, config *StackdriverConfig) (Exporter, e
 	exporter, err := stackdriver.NewExporter(stackdriver.Options{
 		Context:                 ctx,
 		ProjectID:               projectID,
-		ReportingInterval:       SDExportFrequency,
+		ReportingInterval:       config.ReportingInterval,
+		BundleDelayThreshold:    config.BundleDelayThreshold,
+		BundleCountThreshold:    config.BundleCountThreshold,
 		MonitoredResource:       monitoredResource,
 		DefaultMonitoringLabels: &stackdriver.Labels{},
 		OnError: func(err error) {


### PR DESCRIPTION
This allows me to fine-tuning these values and see if adjusting the
value can eliminate
https://github.com/google/exposure-notifications-verification-server/issues/474

The value used should be backward compatible. The value for
BundleDelayThreshold/BundleCountThreshold is from
https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/blob/db101e30979316cca594a74b3181a9a3b6094086/trace.go#L72-L81

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```