### PR TITLE
Fix terraform trap destroy

### DIFF
--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -103,8 +103,8 @@ function destroy() {
 function smoke() {
   # Best effort destroy before applying
   destroy || true
-  deploy
   trap "destroy || true" EXIT
+  deploy
 }
 
 # help prints help.


### PR DESCRIPTION
The best effort terraform destroy is not executed if deploy failed, move trap above deploy should fix this problem
