### PR TITLE
Add a timeout knob to control stackdriver exporter behavior.

### DIFF
--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -74,4 +74,5 @@ type StackdriverConfig struct {
 	ReportingInterval    time.Duration `env:"STACKDRIVER_REPORTING_INTERVAL, default=2m"`
 	BundleDelayThreshold time.Duration `env:"STACKDRIVER_BUNDLE_DELAY_THRESHOLD, default=2s"`
 	BundleCountThreshold uint          `env:"STACKDRIVER_BUNDLE_COUNT_THRESHOLD, default=50"`
+	Timeout              time.Duration `env:"STACKDRIVER_TIMEOUT, default=5s"`
 }

--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -50,6 +50,7 @@ func NewStackdriver(ctx context.Context, config *StackdriverConfig) (Exporter, e
 		ProjectID:               projectID,
 		ReportingInterval:       config.ReportingInterval,
 		BundleDelayThreshold:    config.BundleDelayThreshold,
+		Timeout:                 config.Timeout,
 		BundleCountThreshold:    int(config.BundleCountThreshold),
 		MonitoredResource:       monitoredResource,
 		DefaultMonitoringLabels: &stackdriver.Labels{},


### PR DESCRIPTION
The default timeout is `5s`.

Works towards google/exposure-notifications-verification-server#474