### PR TITLE
Fix TestIterateExposuresCursor flakes

### DIFF
--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -760,21 +760,20 @@ func TestIterateExposuresCursor(t *testing.T) {
 	sortExposureFunc := func(e1, e2 *model.Exposure) bool {
 		return e1.IntervalNumber < e2.IntervalNumber
 	}
-	if diff := cmp.Diff(exposures[:2], seen, ignoreUnexportedExposure, cmpopts.SortSlices(sortExposureFunc)); diff != "" {
-		t.Fatalf("exposures mismatch (-want, +got):\n%s", diff)
+	if want := 2; len(seen) != want {
+		t.Fatalf("cursor: got %d, want %d", len(seen), want)
 	}
 	if want := encodeCursor("2"); cursor != want {
 		t.Fatalf("cursor: got %q, want %q", cursor, want)
 	}
 	// Resume from the cursor.
 	ctx = context.Background()
-	seen = nil
 	cursor, err = testPublishDB.IterateExposures(ctx, IterateExposuresCriteria{LastCursor: cursor},
 		func(e *model.Exposure) error { seen = append(seen, e); return nil })
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(exposures[2:], seen, ignoreUnexportedExposure, cmpopts.SortSlices(sortExposureFunc)); diff != "" {
+	if diff := cmp.Diff(exposures, seen, ignoreUnexportedExposure, cmpopts.SortSlices(sortExposureFunc)); diff != "" {
 		t.Fatalf("exposures mismatch (-want, +got):\n%s", diff)
 	}
 	if cursor != "" {


### PR DESCRIPTION
This test is still flaky https://oss-prow.knative.dev/view/gs/oss-prow/pr-logs/pull/google_exposure-notifications-server/995/pull-en-server-release-unit/1306267928399712256 after https://github.com/google/exposure-notifications-server/pull/983

The root cause of this test being flaky is that testPublishDB.IterateExposures returns non-deterministic orders of output, so it's not possible to predict which 2 exposures out of 3 are iterated first
