### PR TITLE
restore previous handling of too large symptom onset

### DIFF
--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -480,10 +480,15 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		// Set days since onset, either from the API or from the verified claims (see above).
 		if onsetInterval > 0 {
 			daysSince := DaysFromSymptomOnset(onsetInterval, exposure.IntervalNumber)
+			// Check if the magnitude of this value is too large. If it is too large, we won't want to set
+			// a days since symptom onset value ont he TEK itself, but we do want to warn the application devloper
+			// that this value (not TEK) was dropped.
+			// There are launched applications using this sever that rely on this behavior.
 			if abs := math.Abs(float64(daysSince)); abs > t.maxSymptomOnsetDays {
 				logger.Debugw("setting days since symptom onset to null on key due to symptom onset magnitude too high", "daysSince", daysSince)
 				transformErrors = multierror.Append(transformErrors, fmt.Errorf("key %d symptom onset is too large, %v > %v - saving without days since symptom onset", i, abs, t.maxSymptomOnsetDays))
 			} else {
+				// The value is within acceptable range, save it.
 				exposure.SetDaysSinceSymptomOnset(daysSince)
 			}
 		}

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -481,11 +481,11 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		if onsetInterval > 0 {
 			daysSince := DaysFromSymptomOnset(onsetInterval, exposure.IntervalNumber)
 			if abs := math.Abs(float64(daysSince)); abs > t.maxSymptomOnsetDays {
-				logger.Debugw("dropping key due to symptom onset magnitude too high", "daysSince", daysSince)
-				transformErrors = multierror.Append(transformErrors, fmt.Errorf("key %d cannot be imported: days from symptom onset is too large, %v > %v", i, abs, t.maxSymptomOnsetDays))
-				continue
+				logger.Debugw("setting days since symptom onset to null on key due to symptom onset magnitude too high", "daysSince", daysSince)
+				transformErrors = multierror.Append(transformErrors, fmt.Errorf("key %d symptom onset is too large, %v > %v - saving without days since symptom onset", i, abs, t.maxSymptomOnsetDays))
+			} else {
+				exposure.SetDaysSinceSymptomOnset(daysSince)
 			}
-			exposure.SetDaysSinceSymptomOnset(daysSince)
 		}
 		exposure.Traveler = inData.Traveler
 		entities = append(entities, exposure)

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -761,8 +761,21 @@ func TestTransform(t *testing.T) {
 					DaysSinceSymptomOnset: int32Ptr(12),
 					HealthAuthorityID:     int64Ptr(27),
 				},
+				{
+					ExposureKey:           testKeys[7],
+					IntervalNumber:        intervalNumber - (1 * verifyapi.MaxIntervalCount),
+					IntervalCount:         verifyapi.MaxIntervalCount,
+					TransmissionRisk:      verifyapi.TransmissionRiskClinical,
+					AppPackageName:        appPackage,
+					Regions:               wantRegions,
+					CreatedAt:             batchTimeRounded,
+					LocalProvenance:       true,
+					ReportType:            verifyapi.ReportTypeClinical,
+					DaysSinceSymptomOnset: nil, // dropped since it was too large.
+					HealthAuthorityID:     int64Ptr(27),
+				},
 			},
-			PartialError: "key 1 cannot be imported: days from symptom onset is too large, 15 > 14",
+			PartialError: "key 1 symptom onset is too large, 15 > 14 - saving without days since symptom onset",
 		},
 	}
 


### PR DESCRIPTION
## Proposed Changes

* restore previous server behavior of zeroing out days since symptom onset when the value is outside the acceptable range
* continue to return these inside a partial success error message so that developers can catch this

**Release Note**

```release-note
If a calculated days since symptom onset is too large in magnitude (config based, default of 14 days), then the days since symptom onset value will be set to null in exports rather than having that key dropped entirely. This restores the pre v0.6.0 functionality.
```