### PR TITLE
Set Content-Type response header as application/json on publish responses

### DIFF
--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -517,6 +517,11 @@ func TestPublishWithBypass(t *testing.T) {
 					t.Fatal(err)
 				}
 
+				// Response content type should always be application/json
+				if got, want := resp.Header.Get("Content-Type"), "application/json"; got != want {
+					t.Errorf("expected %#v to be %#v", got, want)
+				}
+
 				// For non success status, check that they body contains the expected message
 				defer resp.Body.Close()
 				respBytes, err := ioutil.ReadAll(resp.Body)

--- a/internal/publish/publish_v1.go
+++ b/internal/publish/publish_v1.go
@@ -83,10 +83,13 @@ func (h *PublishHandler) Handle() http.Handler {
 
 			data, err := json.Marshal(response.pubResponse)
 			if err != nil {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprintf(w, "{\"error\": \"%v\"}", err.Error())
 				return
 			}
+
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(response.status)
 			fmt.Fprintf(w, "%s", data)
 		}))

--- a/internal/publish/publish_v1alpha1.go
+++ b/internal/publish/publish_v1alpha1.go
@@ -108,10 +108,13 @@ func (h *PublishHandler) HandleV1Alpha1() http.Handler {
 
 			data, err := json.Marshal(&alpha1Response)
 			if err != nil {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprintf(w, "{\"error\": \"%v\"}", err.Error())
 				return
 			}
+
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(response.status)
 			fmt.Fprintf(w, "%s", data)
 		}))


### PR DESCRIPTION

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Set Content-Type response header as `application/json` on publish responses
```