### PR TITLE
Return warnings instead of error when symptom onset is too long ago

### DIFF
--- a/docs/getting-started/publishing-temporary-exposure-keys.md
+++ b/docs/getting-started/publishing-temporary-exposure-keys.md
@@ -72,6 +72,10 @@ The content of the revision token cannot be used to infer that a client ever upl
 what their diagnosis status is. It is recommended that clients fill this spot in memory
 with random data in advance of TEK publish.
 
+The publish response may also include a `warnings` field. These are not errors,
+but may indicate a client-side bug in key generation or processing. These
+warnings are primarily for app developers and not end-users.
+
 ## Chaff Requests
 
 It may be possible for a server operator or network observer to glean

--- a/internal/generate/handler.go
+++ b/internal/generate/handler.go
@@ -151,7 +151,7 @@ func (h *generateHandler) generate(ctx context.Context, regions []string) error 
 			SymptomOnsetInterval: uint32(publish.Keys[intervalIdx].IntervalNumber),
 		}
 
-		exposures, err := h.transformer.TransformPublish(ctx, publish, regions, &claims, batchTime)
+		exposures, _, err := h.transformer.TransformPublish(ctx, publish, regions, &claims, batchTime)
 		if err != nil {
 			return fmt.Errorf("failed to transform generated exposures: %w", err)
 		}
@@ -174,7 +174,7 @@ func (h *generateHandler) generate(ctx context.Context, regions []string) error 
 			claims.ReportType = revisedReportType
 			batchTime = batchTime.Add(h.config.KeyRevisionDelay)
 
-			exposures, err := h.transformer.TransformPublish(ctx, publish, regions, &claims, batchTime)
+			exposures, _, err := h.transformer.TransformPublish(ctx, publish, regions, &claims, batchTime)
 			if err != nil {
 				return fmt.Errorf("failed to transform generated exposures: %w", err)
 			}

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -412,6 +412,9 @@ func ReportTypeTransmissionRisk(reportType string, providedTR int) int {
 // * 0 exposure Keys in the requests
 // * > Transformer.maxExposureKeys in the request
 //
+// The return params are the list of exposures, a list of warnings, and any
+// errors that occur.
+//
 func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Publish, regions []string, claims *verification.VerifiedClaims, batchTime time.Time) ([]*Exposure, []string, error) {
 	logger := logging.FromContext(ctx)
 	if t.debugReleaseSameDay {

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -412,7 +412,7 @@ func ReportTypeTransmissionRisk(reportType string, providedTR int) int {
 // * 0 exposure Keys in the requests
 // * > Transformer.maxExposureKeys in the request
 //
-func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Publish, regions []string, claims *verification.VerifiedClaims, batchTime time.Time) ([]*Exposure, error) {
+func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Publish, regions []string, claims *verification.VerifiedClaims, batchTime time.Time) ([]*Exposure, []string, error) {
 	logger := logging.FromContext(ctx)
 	if t.debugReleaseSameDay {
 		logger.Errorf("DEBUG SERVER - Current day keys are not being embargoed.")
@@ -422,12 +422,12 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 	if len(inData.Keys) == 0 {
 		msg := "no exposure keys in publish request"
 		logger.Debugf(msg)
-		return nil, fmt.Errorf(msg)
+		return nil, nil, fmt.Errorf(msg)
 	}
 	if len(inData.Keys) > t.maxExposureKeys {
 		msg := fmt.Sprintf("too many exposure keys in publish: %v, max of %v is allowed", len(inData.Keys), t.maxExposureKeys)
 		logger.Debugf(msg)
-		return nil, fmt.Errorf(msg)
+		return nil, nil, fmt.Errorf(msg)
 	}
 
 	onsetInterval := inData.SymptomOnsetInterval
@@ -459,11 +459,12 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		upcaseRegions[i] = strings.ToUpper(r)
 	}
 
+	var transformWarnings []string
 	var transformErrors *multierror.Error
 	for i, exposureKey := range inData.Keys {
 		exposure, err := TransformExposureKey(exposureKey, inData.HealthAuthorityID, upcaseRegions, &settings)
 		if err != nil {
-			logger.Debugf("individual key transform failed: %v", err)
+			logger.Debugw("individual key transform failed", "error", err)
 			transformErrors = multierror.Append(transformErrors, fmt.Errorf("key %d cannot be imported: %w", i, err))
 			continue
 		}
@@ -480,13 +481,21 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		// Set days since onset, either from the API or from the verified claims (see above).
 		if onsetInterval > 0 {
 			daysSince := DaysFromSymptomOnset(onsetInterval, exposure.IntervalNumber)
-			// Check if the magnitude of this value is too large. If it is too large, we won't want to set
-			// a days since symptom onset value ont he TEK itself, but we do want to warn the application devloper
-			// that this value (not TEK) was dropped.
-			// There are launched applications using this sever that rely on this behavior.
+			// Check if the magnitude of this value is too large. If it is too large,
+			// we won't want to set a days since symptom onset value on the TEK
+			// itself, but we do want to warn the application developer that this
+			// value (not TEK) was dropped.
+			//
+			// There are launched applications using this sever that rely on this
+			// behavior.
+			//
+			// Note that previously this returned an error, but this broke the iOS
+			// implementation since it is unable to handle partial success. As such,
+			// it was converted to a warning that's a separate field in the API
+			// response.
 			if abs := math.Abs(float64(daysSince)); abs > t.maxSymptomOnsetDays {
 				logger.Debugw("setting days since symptom onset to null on key due to symptom onset magnitude too high", "daysSince", daysSince)
-				transformErrors = multierror.Append(transformErrors, fmt.Errorf("key %d symptom onset is too large, %v > %v - saving without days since symptom onset", i, abs, t.maxSymptomOnsetDays))
+				transformWarnings = append(transformWarnings, fmt.Sprintf("key %d symptom onset is too large, %v > %v - saving without days since symptom onset", i, abs, t.maxSymptomOnsetDays))
 			} else {
 				// The value is within acceptable range, save it.
 				exposure.SetDaysSinceSymptomOnset(daysSince)
@@ -498,7 +507,7 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 
 	if len(entities) == 0 {
 		// All keys in the batch are valid.
-		return nil, transformErrors.ErrorOrNil()
+		return nil, transformWarnings, transformErrors.ErrorOrNil()
 	}
 
 	// Validate the uploaded data meets configuration parameters.
@@ -534,7 +543,7 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		if ex.IntervalNumber < nextInterval {
 			msg := fmt.Sprintf("exposure keys have non aligned overlapping intervals. %v overlaps with previous key that is good from %v to %v.", ex.IntervalNumber, lastInterval, nextInterval)
 			logger.Debugf(msg)
-			return nil, fmt.Errorf(msg)
+			return nil, transformWarnings, fmt.Errorf(msg)
 		}
 		// OK, current key starts at or after the end of the previous one. Advance both variables.
 		lastInterval = ex.IntervalNumber
@@ -545,9 +554,9 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		if v > t.maxSameDayKeys {
 			msg := fmt.Sprintf("too many overlapping keys for start interval: %v want: <= %v, got: %v", k, t.maxSameDayKeys, v)
 			logger.Debugf(msg)
-			return nil, fmt.Errorf(msg)
+			return nil, transformWarnings, fmt.Errorf(msg)
 		}
 	}
 
-	return entities, transformErrors.ErrorOrNil()
+	return entities, transformWarnings, transformErrors.ErrorOrNil()
 }

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -382,6 +382,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 			pubResponse: &verifyapi.PublishResponse{
 				ErrorMessage: errorMessage,
 				Code:         errorCode,
+				Warnings:     transformWarnings,
 			},
 			metrics: func() {
 				metricsMiddleWare.RecordRevisionTokenIssue(ctx, metric)
@@ -419,6 +420,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 	publishResponse := verifyapi.PublishResponse{
 		RevisionToken:     base64.StdEncoding.EncodeToString(newToken),
 		InsertedExposures: int(resp.Inserted),
+		Warnings:          transformWarnings,
 	}
 	// If there was a partial failure on transform, add that information back into the success response.
 	if transformError != nil {

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -319,7 +319,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 	}
 
 	batchTime := time.Now()
-	exposures, transformError := h.transformer.TransformPublish(ctx, data, regions, verifiedClaims, batchTime)
+	exposures, transformWarnings, transformError := h.transformer.TransformPublish(ctx, data, regions, verifiedClaims, batchTime)
 	// Check for non-recoverable error. It is possible that individual keys are dropped, but if there
 	// are any valid ones, we will try and move forward.
 	// If at the end, there is a success, the transformError will be returned as supplemental information.
@@ -332,6 +332,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 			pubResponse: &verifyapi.PublishResponse{
 				ErrorMessage: message,
 				Code:         verifyapi.ErrorBadRequest,
+				Warnings:     transformWarnings,
 			},
 			metrics: func() {
 				metricsMiddleWare.RecordTransformFail(ctx)

--- a/internal/publish/publish_v1alpha1.go
+++ b/internal/publish/publish_v1alpha1.go
@@ -100,6 +100,7 @@ func (h *PublishHandler) HandleV1Alpha1() http.Handler {
 				InsertedExposures: response.pubResponse.InsertedExposures,
 				Error:             response.pubResponse.ErrorMessage,
 				Padding:           response.pubResponse.Padding,
+				Warnings:          response.pubResponse.Warnings,
 			}
 
 			if response.metrics != nil {

--- a/pkg/api/v1/exposure_types.go
+++ b/pkg/api/v1/exposure_types.go
@@ -125,12 +125,16 @@ type Publish struct {
 //
 // The Padding field may be populated with random data on both success and
 // error responses.
+//
+// The Warnings field may be populated with a list of warnings. These are not
+// errors, but may indicate the server mutated the response.
 type PublishResponse struct {
-	RevisionToken     string `json:"revisionToken,omitempty"`
-	InsertedExposures int    `json:"insertedExposures,omitempty"`
-	ErrorMessage      string `json:"error,omitempty"`
-	Code              string `json:"code,omitempty"`
-	Padding           string `json:"padding,omitempty"`
+	RevisionToken     string   `json:"revisionToken,omitempty"`
+	InsertedExposures int      `json:"insertedExposures,omitempty"`
+	ErrorMessage      string   `json:"error,omitempty"`
+	Code              string   `json:"code,omitempty"`
+	Padding           string   `json:"padding,omitempty"`
+	Warnings          []string `json:"warnings,omitempty"`
 }
 
 // ExposureKey is the 16 byte key, the start time of the key and the

--- a/pkg/api/v1alpha1/exposure_types.go
+++ b/pkg/api/v1alpha1/exposure_types.go
@@ -83,19 +83,23 @@ type Publish struct {
 	DeviceVerificationPayload string `json:"deviceVerificationPayload"` // DEPRECATED
 }
 
-// PublishResponse is sent back to the client on a publish request.
-// If successful, the revisionToken indicates an opaque string that must be
-// passed back if the same devices wishes to publish TEKs again.
+// PublishResponse is sent back to the client on a publish request. If
+// successful, the revisionToken indicates an opaque string that must be passed
+// back if the same devices wishes to publish TEKs again.
 //
 // On error, the error field will contain the error details.
 //
-// The Padding field may be populated with random data on both success and
-// error responses.
+// The Padding field may be populated with random data on both success and error
+// responses.
+//
+// The Warnings field may be populated with a list of warnings. These are not
+// errors, but may indicate the server mutated the response.
 type PublishResponse struct {
-	RevisionToken     string `json:"revisionToken"`
-	InsertedExposures int    `json:"insertedExposures"`
-	Error             string `json:"error"`
-	Padding           string `json:"padding"`
+	RevisionToken     string   `json:"revisionToken"`
+	InsertedExposures int      `json:"insertedExposures"`
+	Error             string   `json:"error"`
+	Padding           string   `json:"padding"`
+	Warnings          []string `json:"warnings,omitempty"`
 }
 
 // ExposureKey is the 16 byte key, the start time of the key and the


### PR DESCRIPTION
Follow-up from GH-1005

This fixes a bug in ENX on iOS which processes the 200 partial response success as an error.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Return warnings instead of error when symptom onset is too long ago
```