### PR TITLE
update instructions for export signing and key ordering

### DIFF
--- a/internal/admin/exports/form.go
+++ b/internal/admin/exports/form.go
@@ -16,6 +16,7 @@
 package exports
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -62,6 +63,9 @@ func (f *formData) PopulateExportConfig(ec *model.ExportConfig) error {
 	ec.From = from
 	ec.Thru = thru
 	ec.SignatureInfoIDs = f.SigInfoIDs
+	if len(ec.SignatureInfoIDs) > 10 {
+		return fmt.Errorf("too many signing keys selected, there is a limit of 10")
+	}
 
 	return nil
 }

--- a/internal/export/database/export.go
+++ b/internal/export/database/export.go
@@ -317,6 +317,8 @@ func (db *ExportDB) LookupSignatureInfos(ctx context.Context, ids []int64, valid
 				SignatureInfo
 			WHERE
 				id = any($1) AND (thru_timestamp is NULL OR thru_timestamp >= $2)
+			ORDER BY
+				id DESC
 		`, ids, validUntil)
 		if err != nil {
 			return fmt.Errorf("failed to list: %w", err)

--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -83,7 +83,7 @@ func TestLookupSignatureInfos(t *testing.T) {
 	ctx := context.Background()
 
 	testTime := time.Now().UTC()
-	want := []*model.SignatureInfo{
+	create := []*model.SignatureInfo{
 		{
 			SigningKey:        "/kms/project/key/version/1",
 			SigningKeyVersion: "1",
@@ -102,10 +102,15 @@ func TestLookupSignatureInfos(t *testing.T) {
 			SigningKeyID:      "310",
 		},
 	}
-	for _, si := range want {
+	for _, si := range create {
 		if err := New(testDB).AddSignatureInfo(ctx, si); err != nil {
 			t.Fatalf("failed to add signature info %v: %v", si, err)
 		}
+	}
+	// create a 'reverse' order list.
+	want := make([]*model.SignatureInfo, len(create))
+	for i := 0; i < len(create); i++ {
+		want[i] = create[len(create)-1-i]
 	}
 
 	ids := []int64{want[0].ID, want[1].ID, want[2].ID}
@@ -114,8 +119,8 @@ func TestLookupSignatureInfos(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The first entry (want[0]) is expired and won't be returned.
-	want = want[1:]
+	// The last entry (want[len-1]) is expired and won't be returned.
+	want = want[:2]
 
 	if diff := cmp.Diff(want, got, approxTime); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%v", diff)

--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -107,20 +107,19 @@ func TestLookupSignatureInfos(t *testing.T) {
 			t.Fatalf("failed to add signature info %v: %v", si, err)
 		}
 	}
-	// create a 'reverse' order list.
-	want := make([]*model.SignatureInfo, len(create))
-	for i := 0; i < len(create); i++ {
-		want[i] = create[len(create)-1-i]
-	}
 
-	ids := []int64{want[0].ID, want[1].ID, want[2].ID}
+	ids := []int64{create[0].ID, create[1].ID, create[2].ID}
 	got, err := New(testDB).LookupSignatureInfos(ctx, ids, testTime)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// The last entry (want[len-1]) is expired and won't be returned.
-	want = want[:2]
+	// Specify the IDs we expect to be returned as effective based on
+	// what was just created.
+	want := []*model.SignatureInfo{
+		create[2],
+		create[1],
+	}
 
 	if diff := cmp.Diff(want, got, approxTime); diff != "" {
 		t.Errorf("mismatch (-want, +got):\n%v", diff)

--- a/internal/pb/export/export.pb.go
+++ b/internal/pb/export/export.pb.go
@@ -133,6 +133,10 @@ type TemporaryExposureKeyExport struct {
 	BatchNum  *int32 `protobuf:"varint,4,opt,name=batch_num,json=batchNum" json:"batch_num,omitempty"`
 	BatchSize *int32 `protobuf:"varint,5,opt,name=batch_size,json=batchSize" json:"batch_size,omitempty"`
 	// Information about signatures
+	// If there are multiple entries, they must be ordered in descending
+	// time order by signing key effective time (most recent one first).
+	// There is a limit of 10 signature infos per export file (mobile OS may
+	// not check anything after that).
 	SignatureInfos []*SignatureInfo `protobuf:"bytes,6,rep,name=signature_infos,json=signatureInfos" json:"signature_infos,omitempty"`
 	// The TemporaryExposureKeys for initial release of keys.
 	// Keys should be included in this list for initial release,
@@ -411,6 +415,11 @@ type TEKSignatureList struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// When their are multiple signatures, they must be sorted in time order
+	// by first effective date for the signing key in descending order.
+	// The most recent effective signing key must appear first.
+	// There is a limit of 10 signature infos per export file (mobile OS may
+	// not check anything after that).
 	Signatures []*TEKSignature `protobuf:"bytes,1,rep,name=signatures" json:"signatures,omitempty"`
 }
 

--- a/internal/pb/export/export.pb.go
+++ b/internal/pb/export/export.pb.go
@@ -415,7 +415,7 @@ type TEKSignatureList struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// When their are multiple signatures, they must be sorted in time order
+	// When there are multiple signatures, they must be sorted in time order
 	// by first effective date for the signing key in descending order.
 	// The most recent effective signing key must appear first.
 	// There is a limit of 10 signature infos per export file (mobile OS may

--- a/internal/pb/export/export.proto
+++ b/internal/pb/export/export.proto
@@ -107,7 +107,7 @@ message TemporaryExposureKey {
 }
 
 message TEKSignatureList {
-  // When their are multiple signatures, they must be sorted in time order
+  // When there are multiple signatures, they must be sorted in time order
   // by first effective date for the signing key in descending order.
   // The most recent effective signing key must appear first.
   // There is a limit of 10 signature infos per export file (mobile OS may

--- a/internal/pb/export/export.proto
+++ b/internal/pb/export/export.proto
@@ -39,6 +39,10 @@ message TemporaryExposureKeyExport {
   optional int32 batch_size = 5;
 
   // Information about signatures
+  // If there are multiple entries, they must be ordered in descending
+  // time order by signing key effective time (most recent one first).
+  // There is a limit of 10 signature infos per export file (mobile OS may
+  // not check anything after that).
   repeated SignatureInfo signature_infos = 6;
 
   // The TemporaryExposureKeys for initial release of keys.
@@ -103,6 +107,11 @@ message TemporaryExposureKey {
 }
 
 message TEKSignatureList {
+  // When their are multiple signatures, they must be sorted in time order
+  // by first effective date for the signing key in descending order.
+  // The most recent effective signing key must appear first.
+  // There is a limit of 10 signature infos per export file (mobile OS may
+  // not check anything after that).
   repeated TEKSignature signatures = 1;
 }
 

--- a/tools/admin-console/templates/export.html
+++ b/tools/admin-console/templates/export.html
@@ -106,10 +106,12 @@
 
 	<hr/>
 	<div class="alert alert-info" role="alert">
-	  Select the keys used to sign exports of this type. It is possible to have more than one
-		selected at a time. Having multiple signers is the correct way to rotate a signing key.
-		The old one should not be decomissions until Apple and Google have confirmed that the
-		new public key has been rolled out.
+	  <p>Select the keys used to sign exports of this type. It is possible to have more than one
+	  selected at a time. Having multiple signers is the correct way to rotate a signing key.
+	  The old one should not be decomissions until Apple and Google have confirmed that the
+	  new public key has been rolled out.
+	  </p>
+	  <p>There is a limit of 10 active signing keys per export configuration.</p>
 	</div>
 
 	{{if .siginfos}}


### PR DESCRIPTION
Fixes #1010

## Proposed Changes

* Document ordering of signatures on export files when there is more than one
* Document limit (soft) on export signatures
* Update server for this ordering

**Release Note**

```release-note
Export file signatures will be ordered with the most recently created one first. Documented updated expectations around files with multiple signers.
```