### PR TITLE
handle nil jwks URI in database

### DIFF
--- a/internal/admin/healthauthority/form.go
+++ b/internal/admin/healthauthority/form.go
@@ -34,7 +34,7 @@ func (f *formData) PopulateHealthAuthority(ha *model.HealthAuthority) {
 	ha.Issuer = f.Issuer
 	ha.Audience = f.Audience
 	ha.Name = f.Name
-	ha.JwksURI = f.JwksURI
+	ha.SetJWKS(f.JwksURI)
 }
 
 type keyFormData struct {

--- a/internal/verification/database/health_authority_db_test.go
+++ b/internal/verification/database/health_authority_db_test.go
@@ -42,6 +42,7 @@ func TestAddRetrieveHealthAuthority(t *testing.T) {
 		Issuer:   "doh.mystate.gov",
 		Audience: "ens.usacovid.org",
 		Name:     "My State Department of Healthiness",
+		JwksURI:  nil,
 	}
 
 	haDB := New(testDB)
@@ -79,6 +80,7 @@ func TestAddRetrieveHealthAuthorityKeys(t *testing.T) {
 		Audience: "ens.usacovid.org",
 		Name:     "My State Department of Healthiness",
 	}
+	want.SetJWKS("https://www.example.com/.auth/keys.json")
 
 	haDB := New(testDB)
 	if err := haDB.AddHealthAuthority(ctx, want); err != nil {

--- a/internal/verification/model/health_authority.go
+++ b/internal/verification/model/health_authority.go
@@ -32,7 +32,15 @@ type HealthAuthority struct {
 	Audience string
 	Name     string
 	Keys     []*HealthAuthorityKey
-	JwksURI  string
+	JwksURI  *string
+}
+
+func (ha *HealthAuthority) SetJWKS(uri string) {
+	if uri == "" {
+		ha.JwksURI = nil
+		return
+	}
+	ha.JwksURI = &uri
 }
 
 // Validate returns an error if the HealthAuthority struct is not valid.

--- a/pkg/jwks/jwks_test.go
+++ b/pkg/jwks/jwks_test.go
@@ -132,7 +132,8 @@ func TestUpdateHA(t *testing.T) {
 			if err != nil {
 				t.Fatalf("[%d] unexpected error: %v", i, err)
 			}
-			ha := &model.HealthAuthority{JwksURI: ts.URL}
+			jwksURI := ts.URL
+			ha := &model.HealthAuthority{JwksURI: &jwksURI}
 
 			// Test networking.
 			rxKeys, err := mgr.getKeys(ctx, ha)
@@ -170,7 +171,7 @@ func TestUpdateHA(t *testing.T) {
 			//
 			// Now test end-to-end.
 			//
-			test.ha.JwksURI = ts.URL
+			test.ha.JwksURI = &jwksURI
 
 			// Add the HealthAuthority & Keys to the DB. Note, we need to remove all
 			// keys from the testing HealthAuthority before adding it to the DB as it's


### PR DESCRIPTION
## Proposed Changes

* Handle nil jwks_uri columns in the healthauthority table - migrated rows have a null column value.

**Release Note**

```release-note
bugfix: handle nil JWKS URI values.
```