### PR TITLE
Revert "Add stack driver debug logging (#1021)"

### DIFF
--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -71,11 +71,8 @@ type StackdriverConfig struct {
 	// uses https://google.golang.org/api/support/bundler, these two options
 	// control the max delay/count for batching the data points into one
 	// stackdriver request.
-	// DebugLogging: if true, use a special http.Client when interact with
-	// Cloud Monitoring API, and print request/response body in debug log.
 	ReportingInterval    time.Duration `env:"STACKDRIVER_REPORTING_INTERVAL, default=2m"`
 	BundleDelayThreshold time.Duration `env:"STACKDRIVER_BUNDLE_DELAY_THRESHOLD, default=2s"`
 	BundleCountThreshold uint          `env:"STACKDRIVER_BUNDLE_COUNT_THRESHOLD, default=50"`
 	Timeout              time.Duration `env:"STACKDRIVER_TIMEOUT, default=5s"`
-	DebugLogging         bool          `env:"STACKDRIVER_DEBUG_LOGGING, default=false"`
 }


### PR DESCRIPTION
This reverts commit 193c045af3e241c5a9cc457e9e90cb82b440fe82.

The OpenCensus Stackdriver exporter uses gRPC connection to API endpoint
and is incompatible with WithHTTPClient option.