### PR TITLE
E2E test: hook up with verification

### DIFF
--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -70,8 +70,9 @@ func TestIntegration(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			env, client, jwtCfg, exportDir, exportRoot := NewTestServer(t, 2*time.Second)
+			env, client := NewTestServer(t)
 			db := env.Database()
+			jwtCfg, exportDir, exportRoot := Seed(t, ctx, db, 2*time.Second)
 
 			// Set query criteria (used throughout)
 			criteria := publishdb.IterateExposuresCriteria{

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -74,8 +74,9 @@ func TestExport(t *testing.T) {
 	makoQuickstore, cancel := setup(t)
 	defer cancel(context.Background())
 
-	env, client, jwtCfg, exportDir, exportRoot := integration.NewTestServer(t, exportPeriod)
+	env, client := integration.NewTestServer(t)
 	db := env.Database()
+	jwtCfg, exportDir, exportRoot := integration.Seed(t, ctx, db, 2*time.Second)
 	keys := util.GenerateExposureKeys(keysPerPublish, -1, false)
 	payload := &verifyapi.Publish{
 		Keys:              keys,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -135,6 +135,7 @@ func InitalizeVerificationDB(ctx context.Context, tb testing.TB, db *database.DB
 	if hak != nil {
 		if sk == nil {
 			tb.Fatal("test cases that have health authority keys registered must provide a signingKey as well")
+			return
 		}
 		// Join in the public key.
 		hak.PublicKeyPEM = sk.PublicKey

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -124,13 +124,17 @@ func IssueJWT(t *testing.T, cfg *JWTConfig) (jwtText, hmacKey string) {
 // InitalizeVerificationDB links the vdb, HA and SigningKeys together
 func InitalizeVerificationDB(ctx context.Context, tb testing.TB, db *database.DB, ha *vm.HealthAuthority, hak *vm.HealthAuthorityKey, sk *SigningKey) {
 	verDB := vdb.New(db)
+	exist, err := verDB.GetHealthAuthority(context.Background(), ha.Issuer)
+	if exist != nil && err == nil {
+		return
+	}
+
 	if err := verDB.AddHealthAuthority(ctx, ha); err != nil {
 		tb.Fatal(err)
 	}
 	if hak != nil {
 		if sk == nil {
 			tb.Fatal("test cases that have health authority keys registered must provide a signingKey as well")
-			return
 		}
 		// Join in the public key.
 		hak.PublicKeyPEM = sk.PublicKey

--- a/terraform-e2e/main.tf
+++ b/terraform-e2e/main.tf
@@ -37,10 +37,15 @@ module "en" {
 
   service_environment = {
     export = {
+      TRUNCATE_WINDOW = "1s"
+      MIN_WINDOW_AGE = "1s"
+
       LOG_DEBUG = "true"
     }
 
     exposure = {
+      TRUNCATE_WINDOW = "1s"
+      DEBUG_RELEASE_SAME_DAY_KEYS = true
       LOG_DEBUG = "true"
     }
 


### PR DESCRIPTION
Also refactor integration test to be able to share more code with e2e test:
- Separate server setup from data seeding
- Authorized app provider backed by db instead of memory
