### PR TITLE
Log HealthAuthority when publishing.

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -179,9 +179,11 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 	ctx, span := trace.StartSpan(ctx, "(*publish.PublishHandler).process")
 	defer span.End()
 
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).With("health_authority_id", data.HealthAuthorityID)
 	metrics := h.serverenv.MetricsExporter(ctx)
 	metricsMiddleWare := metricsware.NewMiddleWare(&metrics)
+
+	logger.Info("publish API request")
 
 	appConfig, err := h.authorizedAppProvider.AppConfig(ctx, data.HealthAuthorityID)
 	if err != nil {
@@ -259,7 +261,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 	// generous defaults. If there isn't a region set, then the TEKs
 	// won't be retrievable, so we ensure there is something set.
 	if len(regions) == 0 {
-		logger.Errorf("No regions present in request or configured for healthAuthorityID: %v", data.HealthAuthorityID)
+		logger.Errorf("No regions present in request or configured for HealthAuthorityID: %v", data.HealthAuthorityID)
 		message := fmt.Sprintf("unknown health authority regions for %v", data.HealthAuthorityID)
 		span.SetStatus(trace.Status{Code: trace.StatusCodePermissionDenied, Message: message})
 		return &response{


### PR DESCRIPTION
Increase the logging (by including the HealthAuthority's id) in the publish API.

Fixes #1011
