### PR TITLE
Move key server specific view registration to a separate function.

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/observability"
+	"github.com/google/exposure-notifications-server/pkg/observability/en"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/sethvargo/go-envconfig"
 )
@@ -176,7 +177,7 @@ func SetupWith(ctx context.Context, config interface{}, l envconfig.Lookuper) (*
 		if err != nil {
 			return nil, fmt.Errorf("unable to create observability provider: %v", err)
 		}
-		if err := oe.StartExporter(); err != nil {
+		if err := oe.StartExporter(en.RegisterViews); err != nil {
 			return nil, fmt.Errorf("failed to start observability: %w", err)
 		}
 		exporter := serverenv.WithObservabilityExporter(oe)

--- a/pkg/observability/common/register.go
+++ b/pkg/observability/common/register.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"fmt"
+
+	"go.opencensus.io/plugin/ocgrpc"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/stats/view"
+)
+
+// RegisterViews registers the most common views with OpenCensus.
+func RegisterViews() error {
+	// Record the various HTTP view to collect metrics.
+	httpViews := append(ochttp.DefaultServerViews, ochttp.DefaultClientViews...)
+	if err := view.Register(httpViews...); err != nil {
+		return fmt.Errorf("failed to register http views: %w", err)
+	}
+
+	// Register the various gRPC views to collect metrics.
+	gRPCViews := append(ocgrpc.DefaultServerViews, ocgrpc.DefaultClientViews...)
+	if err := view.Register(gRPCViews...); err != nil {
+		return fmt.Errorf("failed to register grpc views: %w", err)
+	}
+	return nil
+}

--- a/pkg/observability/common/register.go
+++ b/pkg/observability/common/register.go
@@ -1,3 +1,5 @@
+// Package common contains the code to register views that's shared between the
+// key server and the verification server.
 package common
 
 import (

--- a/pkg/observability/en/register.go
+++ b/pkg/observability/en/register.go
@@ -1,0 +1,57 @@
+// Package en provide metric registration logic specific to the notification server.
+package en
+
+import (
+	"fmt"
+
+	"github.com/google/exposure-notifications-server/internal/metrics/cleanup"
+	"github.com/google/exposure-notifications-server/internal/metrics/export"
+	"github.com/google/exposure-notifications-server/internal/metrics/federationin"
+	"github.com/google/exposure-notifications-server/internal/metrics/federationout"
+	"github.com/google/exposure-notifications-server/internal/metrics/publish"
+	"github.com/google/exposure-notifications-server/internal/metrics/rotate"
+	"go.opencensus.io/plugin/ocgrpc"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/stats/view"
+)
+
+// RegisterViews registers the necessary tracing views.
+func RegisterViews() error {
+	// Record the various HTTP view to collect metrics.
+	httpViews := append(ochttp.DefaultServerViews, ochttp.DefaultClientViews...)
+	if err := view.Register(httpViews...); err != nil {
+		return fmt.Errorf("failed to register http views: %w", err)
+	}
+
+	// Register the various gRPC views to collect metrics.
+	gRPCViews := append(ocgrpc.DefaultServerViews, ocgrpc.DefaultClientViews...)
+	if err := view.Register(gRPCViews...); err != nil {
+		return fmt.Errorf("failed to register grpc views: %w", err)
+	}
+
+	if err := view.Register(cleanup.Views...); err != nil {
+		return fmt.Errorf("failed to register cleanup metrics: %w", err)
+	}
+
+	if err := view.Register(export.Views...); err != nil {
+		return fmt.Errorf("failed to register export metrics: %w", err)
+	}
+
+	if err := view.Register(federationin.Views...); err != nil {
+		return fmt.Errorf("failed to register federationin metrics: %w", err)
+	}
+
+	if err := view.Register(federationout.Views...); err != nil {
+		return fmt.Errorf("failed to register federationout metrics: %w", err)
+	}
+
+	if err := view.Register(publish.Views...); err != nil {
+		return fmt.Errorf("failed to register publish metrics: %w", err)
+	}
+
+	if err := view.Register(rotate.Views...); err != nil {
+		return fmt.Errorf("failed to register rotate metrics: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/observability/en/register.go
+++ b/pkg/observability/en/register.go
@@ -4,31 +4,22 @@ package en
 import (
 	"fmt"
 
+	"github.com/google/exposure-notifications-server/pkg/observability/common"
+
 	"github.com/google/exposure-notifications-server/internal/metrics/cleanup"
 	"github.com/google/exposure-notifications-server/internal/metrics/export"
 	"github.com/google/exposure-notifications-server/internal/metrics/federationin"
 	"github.com/google/exposure-notifications-server/internal/metrics/federationout"
 	"github.com/google/exposure-notifications-server/internal/metrics/publish"
 	"github.com/google/exposure-notifications-server/internal/metrics/rotate"
-	"go.opencensus.io/plugin/ocgrpc"
-	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats/view"
 )
 
 // RegisterViews registers the necessary tracing views.
 func RegisterViews() error {
-	// Record the various HTTP view to collect metrics.
-	httpViews := append(ochttp.DefaultServerViews, ochttp.DefaultClientViews...)
-	if err := view.Register(httpViews...); err != nil {
-		return fmt.Errorf("failed to register http views: %w", err)
+	if err := common.RegisterViews(); err != nil {
+		return fmt.Errorf("failed to register common metrics: %w", err)
 	}
-
-	// Register the various gRPC views to collect metrics.
-	gRPCViews := append(ocgrpc.DefaultServerViews, ocgrpc.DefaultClientViews...)
-	if err := view.Register(gRPCViews...); err != nil {
-		return fmt.Errorf("failed to register grpc views: %w", err)
-	}
-
 	if err := view.Register(cleanup.Views...); err != nil {
 		return fmt.Errorf("failed to register cleanup metrics: %w", err)
 	}

--- a/pkg/observability/noop.go
+++ b/pkg/observability/noop.go
@@ -27,7 +27,7 @@ func NewNoop(_ context.Context) (Exporter, error) {
 	return &noopExporter{}, nil
 }
 
-func (g *noopExporter) StartExporter() error {
+func (g *noopExporter) StartExporter(_ func() error) error {
 	return nil
 }
 

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -19,23 +19,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-
-	"github.com/google/exposure-notifications-server/internal/metrics/cleanup"
-	"github.com/google/exposure-notifications-server/internal/metrics/export"
-	"github.com/google/exposure-notifications-server/internal/metrics/federationin"
-	"github.com/google/exposure-notifications-server/internal/metrics/federationout"
-	"github.com/google/exposure-notifications-server/internal/metrics/publish"
-	"github.com/google/exposure-notifications-server/internal/metrics/rotate"
-	"go.opencensus.io/plugin/ocgrpc"
-	"go.opencensus.io/plugin/ochttp"
-	"go.opencensus.io/stats/view"
 )
 
 // Exporter defines the minimum shared functionality for an observability exporter
 // used by this application.
 type Exporter interface {
 	io.Closer
-	StartExporter() error
+	StartExporter(func() error) error
 }
 
 // NewFromEnv returns the observability exporter given the provided configuration, or an error
@@ -51,45 +41,4 @@ func NewFromEnv(ctx context.Context, config *Config) (Exporter, error) {
 	default:
 		return nil, fmt.Errorf("unknown observability exporter type %v", config.ExporterType)
 	}
-}
-
-// registerViews registers the necessary tracing views.
-func registerViews() error {
-	// Record the various HTTP view to collect metrics.
-	httpViews := append(ochttp.DefaultServerViews, ochttp.DefaultClientViews...)
-	if err := view.Register(httpViews...); err != nil {
-		return fmt.Errorf("failed to register http views: %w", err)
-	}
-
-	// Register the various gRPC views to collect metrics.
-	gRPCViews := append(ocgrpc.DefaultServerViews, ocgrpc.DefaultClientViews...)
-	if err := view.Register(gRPCViews...); err != nil {
-		return fmt.Errorf("failed to register grpc views: %w", err)
-	}
-
-	if err := view.Register(cleanup.Views...); err != nil {
-		return fmt.Errorf("failed to register cleanup metrics: %w", err)
-	}
-
-	if err := view.Register(export.Views...); err != nil {
-		return fmt.Errorf("failed to register export metrics: %w", err)
-	}
-
-	if err := view.Register(federationin.Views...); err != nil {
-		return fmt.Errorf("failed to register federationin metrics: %w", err)
-	}
-
-	if err := view.Register(federationout.Views...); err != nil {
-		return fmt.Errorf("failed to register federationout metrics: %w", err)
-	}
-
-	if err := view.Register(publish.Views...); err != nil {
-		return fmt.Errorf("failed to register publish metrics: %w", err)
-	}
-
-	if err := view.Register(rotate.Views...); err != nil {
-		return fmt.Errorf("failed to register rotate metrics: %w", err)
-	}
-
-	return nil
 }

--- a/pkg/observability/opencensus.go
+++ b/pkg/observability/opencensus.go
@@ -48,14 +48,14 @@ func NewOpenCensus(ctx context.Context, config *OpenCensusConfig) (Exporter, err
 }
 
 // StartExporter starts the exporter.
-func (e *opencensusExporter) StartExporter() error {
+func (e *opencensusExporter) StartExporter(register func() error) error {
 	trace.ApplyConfig(trace.Config{
 		DefaultSampler: trace.ProbabilitySampler(e.config.SampleRate),
 	})
 	trace.RegisterExporter(e.exporter)
 	view.RegisterExporter(e.exporter)
 
-	if err := registerViews(); err != nil {
+	if err := register(); err != nil {
 		return fmt.Errorf("failed to start opencensus exporter: %w", err)
 	}
 

--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -93,8 +93,8 @@ func NewStackdriver(ctx context.Context, config *StackdriverConfig) (Exporter, e
 }
 
 // StartExporter starts the exporter.
-func (e *stackdriverExporter) StartExporter() error {
-	if err := registerViews(); err != nil {
+func (e *stackdriverExporter) StartExporter(register func() error) error {
+	if err := register(); err != nil {
 		return fmt.Errorf("failed to register views: %w", err)
 	}
 


### PR DESCRIPTION
The exporter is shared between key server and verification server, we
should not have key server specific code in the exporter.