### PR TITLE
Fix incremental e2e test by use new health authority

### DIFF
--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -109,13 +109,13 @@ func TestPublishEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to connect to database: %v", err)
 	}
-	jwtCfg, _, _ := integration.Seed(t, ctx, db, 2*time.Second)
+	jwtCfg, _, _, appName := integration.Seed(t, ctx, db, 2*time.Second)
 	keys := util.GenerateExposureKeys(3, -1, false)
 
 	// Publish 3 keys
 	payload := &verifyapi.Publish{
 		Keys:              keys,
-		HealthAuthorityID: "com.example.app",
+		HealthAuthorityID: appName,
 	}
 	jwtCfg.ExposureKeys = keys
 	jwtCfg.JWTWarp = time.Duration(0)

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -285,12 +285,12 @@ func Seed(tb testing.TB, ctx context.Context, db *database.DB, exportPeriod time
 	if exist == nil || err != nil {
 		tb.Log("Creating a new authorized app")
 		if err := authorizedappdb.New(db).InsertAuthorizedApp(context.Background(), &authorizedappmodel.AuthorizedApp{
-			AppPackageName: "com.example.app",
+			AppPackageName: appName,
 			AllowedRegions: map[string]struct{}{
 				"TEST": {},
 			},
 			AllowedHealthAuthorityIDs: map[int64]struct{}{
-				1: {},
+				haID: {},
 			},
 
 			BypassHealthAuthorityVerification: false,

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -237,7 +237,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	return env, enClient
 }
 
-func Seed(tb testing.TB, ctx context.Context, db *database.DB, exportPeriod time.Duration) (*testutil.JWTConfig, string, string) {
+func Seed(tb testing.TB, ctx context.Context, db *database.DB, exportPeriod time.Duration) (*testutil.JWTConfig, string, string, string) {
 	bucketName := testRandomID(tb, 32)
 	filenameRoot := testRandomID(tb, 32)
 
@@ -251,14 +251,14 @@ func Seed(tb testing.TB, ctx context.Context, db *database.DB, exportPeriod time
 	// create a health authority
 	ha := &vm.HealthAuthority{
 		Audience: "exposure-notifications-service",
-		Issuer:   "Department of Health",
+		Issuer:   fmt.Sprintf("Department of Health %s", testRandomID(tb, 32)[:6]),
 		Name:     "Integration Test HA",
 	}
 	haKey := &vm.HealthAuthorityKey{
 		Version: "v1",
 		From:    time.Now().Add(-1 * time.Minute),
 	}
-	testutil.InitalizeVerificationDB(ctx, tb, db, ha, haKey, sk)
+	haID := testutil.InitalizeVerificationDB(ctx, tb, db, ha, haKey, sk)
 	jwtCfg := &testutil.JWTConfig{
 		HealthAuthority:    ha,
 		HealthAuthorityKey: haKey,
@@ -266,8 +266,22 @@ func Seed(tb testing.TB, ctx context.Context, db *database.DB, exportPeriod time
 		ReportType:         verifyapi.ReportTypeConfirmed,
 	}
 
+	appName := fmt.Sprintf("com.%s.app", testRandomID(tb, 32)[:6])
 	// Create an authorized app
-	exist, err := authorizedappdb.New(db).GetAuthorizedApp(context.Background(), "com.example.app")
+	authorizedapp := &authorizedappmodel.AuthorizedApp{
+		AppPackageName: appName,
+		AllowedRegions: map[string]struct{}{
+			"TEST": {},
+		},
+		AllowedHealthAuthorityIDs: map[int64]struct{}{
+			haID: {},
+		},
+
+		// TODO: hook up verification and revision
+		BypassHealthAuthorityVerification: false,
+		BypassRevisionToken:               false,
+	}
+	exist, err := authorizedappdb.New(db).GetAuthorizedApp(context.Background(), authorizedapp.AppPackageName)
 	if exist == nil || err != nil {
 		tb.Log("Creating a new authorized app")
 		if err := authorizedappdb.New(db).InsertAuthorizedApp(context.Background(), &authorizedappmodel.AuthorizedApp{
@@ -310,7 +324,7 @@ func Seed(tb testing.TB, ctx context.Context, db *database.DB, exportPeriod time
 		tb.Fatal(err)
 	}
 
-	return jwtCfg, bucketName, filenameRoot
+	return jwtCfg, bucketName, filenameRoot, appName
 }
 
 type prefixRoundTripper struct {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -72,7 +72,7 @@ func TestIntegration(t *testing.T) {
 			ctx := context.Background()
 			env, client := NewTestServer(t)
 			db := env.Database()
-			jwtCfg, exportDir, exportRoot := Seed(t, ctx, db, 2*time.Second)
+			jwtCfg, exportDir, exportRoot, appName := Seed(t, ctx, db, 2*time.Second)
 
 			// Set query criteria (used throughout)
 			criteria := publishdb.IterateExposuresCriteria{
@@ -84,7 +84,7 @@ func TestIntegration(t *testing.T) {
 			// Publish 3 keys
 			payload := &verifyapi.Publish{
 				Keys:              keys,
-				HealthAuthorityID: "com.example.app",
+				HealthAuthorityID: appName,
 			}
 			jwtCfg.ExposureKeys = keys
 			jwtCfg.JWTWarp = tc.JWTWrap

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -76,11 +76,11 @@ func TestExport(t *testing.T) {
 
 	env, client := integration.NewTestServer(t)
 	db := env.Database()
-	jwtCfg, exportDir, exportRoot := integration.Seed(t, ctx, db, exportPeriod)
+	jwtCfg, exportDir, exportRoot, appName := integration.Seed(t, ctx, db, exportPeriod)
 	keys := util.GenerateExposureKeys(keysPerPublish, -1, false)
 	payload := &verifyapi.Publish{
 		Keys:              keys,
-		HealthAuthorityID: "com.example.app",
+		HealthAuthorityID: appName,
 	}
 	jwtCfg.ExposureKeys = keys
 	verification, salt := testutil.IssueJWT(t, jwtCfg)


### PR DESCRIPTION
Health authority keys generated from each e2e test are different, which fails incremental e2e tests if using existing health authority. This PR updates e2e to create new health authority for every test to make sure incremental test work