### PR TITLE
Fix the metric missing issue caused by repeated metric point upload.

### DIFF
--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/api/option"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
-	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 )
 
@@ -107,8 +106,6 @@ func (e *stackdriverExporter) StartExporter() error {
 	})
 	trace.RegisterExporter(e.exporter)
 
-	view.RegisterExporter(e.exporter)
-
 	return nil
 }
 
@@ -122,7 +119,6 @@ func (e *stackdriverExporter) Close() error {
 
 	// Unregister the exporter
 	trace.UnregisterExporter(e.exporter)
-	view.UnregisterExporter(e.exporter)
 
 	return nil
 }


### PR DESCRIPTION
See
https://github.com/google/exposure-notifications-verification-server/issues/474#issuecomment-700351001
for an explanation.