### PR TITLE
Terraform: services deployments depdend on DB migration

### DIFF
--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -165,5 +165,7 @@ resource "google_cloud_scheduler_job" "cleanup-export-worker" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.cleanup-export-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
+    null_resource.build,
+    null_resource.migrate,
   ]
 }

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -112,6 +112,7 @@ resource "google_cloud_run_service" "cleanup-export" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.cleanup-export-db,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {
@@ -165,7 +166,5 @@ resource "google_cloud_scheduler_job" "cleanup-export-worker" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.cleanup-export-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
-    null_resource.build,
-    null_resource.migrate,
   ]
 }

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -106,6 +106,7 @@ resource "google_cloud_run_service" "cleanup-exposure" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.cleanup-exposure-db,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {
@@ -159,7 +160,5 @@ resource "google_cloud_scheduler_job" "cleanup-exposure-worker" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.cleanup-exposure-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
-    null_resource.build,
-    null_resource.migrate,
   ]
 }

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -159,5 +159,7 @@ resource "google_cloud_scheduler_job" "cleanup-exposure-worker" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.cleanup-exposure-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
+    null_resource.build,
+    null_resource.migrate,
   ]
 }

--- a/terraform/service_debugger.tf
+++ b/terraform/service_debugger.tf
@@ -116,6 +116,7 @@ resource "google_cloud_run_service" "debugger" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.debugger-db,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -120,6 +120,7 @@ resource "google_cloud_run_service" "export" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.export-db,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {
@@ -200,7 +201,5 @@ resource "google_cloud_scheduler_job" "export-create-batches" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.export-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
-    null_resource.build,
-    null_resource.migrate,
   ]
 }

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -200,5 +200,7 @@ resource "google_cloud_scheduler_job" "export-create-batches" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.export-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
+    null_resource.build,
+    null_resource.migrate,
   ]
 }

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -122,6 +122,7 @@ resource "google_cloud_run_service" "exposure" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.exposure-db,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -106,6 +106,7 @@ resource "google_cloud_run_service" "federationin" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.federationin,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -106,6 +106,7 @@ resource "google_cloud_run_service" "federationout" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.federationout-db,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -161,5 +161,7 @@ resource "google_cloud_scheduler_job" "generate-worker" {
   depends_on = [
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.generate-invoker,
+    null_resource.build,
+    null_resource.migrate,
   ]
 }

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -106,6 +106,7 @@ resource "google_cloud_run_service" "generate" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.generate-db,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {
@@ -161,7 +162,5 @@ resource "google_cloud_scheduler_job" "generate-worker" {
   depends_on = [
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.generate-invoker,
-    null_resource.build,
-    null_resource.migrate,
   ]
 }

--- a/terraform/service_jwks.tf
+++ b/terraform/service_jwks.tf
@@ -106,6 +106,7 @@ resource "google_cloud_run_service" "jwks" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.jwks-db,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {
@@ -159,7 +160,5 @@ resource "google_cloud_scheduler_job" "jwks-worker" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.jwks-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
-    null_resource.build,
-    null_resource.migrate,
   ]
 }

--- a/terraform/service_jwks.tf
+++ b/terraform/service_jwks.tf
@@ -159,5 +159,7 @@ resource "google_cloud_scheduler_job" "jwks-worker" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.jwks-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
+    null_resource.build,
+    null_resource.migrate,
   ]
 }

--- a/terraform/service_keyrotation.tf
+++ b/terraform/service_keyrotation.tf
@@ -179,5 +179,7 @@ resource "google_cloud_scheduler_job" "key-rotation-worker" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.key-rotation-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
+    null_resource.build,
+    null_resource.migrate,
   ]
 }

--- a/terraform/service_keyrotation.tf
+++ b/terraform/service_keyrotation.tf
@@ -122,6 +122,7 @@ resource "google_cloud_run_service" "key-rotation" {
     google_project_service.services["run.googleapis.com"],
     google_secret_manager_secret_iam_member.key-rotation-db,
     null_resource.build,
+    null_resource.migrate,
   ]
 
   lifecycle {
@@ -179,7 +180,5 @@ resource "google_cloud_scheduler_job" "key-rotation-worker" {
     google_app_engine_application.app,
     google_cloud_run_service_iam_member.key-rotation-invoker,
     google_project_service.services["cloudscheduler.googleapis.com"],
-    null_resource.build,
-    null_resource.migrate,
   ]
 }


### PR DESCRIPTION
To prevent race condition that service deployed before DB migration is done, which could fail terrafrom deployment

/assign @sethvargo @icco 