### PR TITLE
E2e test: export test

### DIFF
--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -20,18 +20,23 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	exportapi "github.com/google/exposure-notifications-server/internal/export"
 	"github.com/google/exposure-notifications-server/internal/integration"
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
+	"github.com/google/exposure-notifications-server/internal/storage"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/google/exposure-notifications-server/pkg/util"
 	"github.com/sethvargo/go-envconfig"
+	"github.com/sethvargo/go-retry"
 
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	testutil "github.com/google/exposure-notifications-server/internal/utils"
@@ -39,11 +44,10 @@ import (
 )
 
 type testConfig struct {
-	DbName       string `env:"DB_NAME"`
-	ExposureURL  string `env:"EXPOSURE_URL"`
-	ExportBucket string `env:"EXPORT_BUCKET"`
-	ProjectID    string `env:"PROJECT_ID"`
-	DBConfig     *database.Config
+	DbName      string `env:"DB_NAME"`
+	ExposureURL string `env:"EXPOSURE_URL"`
+	ProjectID   string `env:"PROJECT_ID"`
+	DBConfig    *database.Config
 }
 
 func initConfig(tb testing.TB, ctx context.Context) *testConfig {
@@ -109,7 +113,8 @@ func TestPublishEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to connect to database: %v", err)
 	}
-	jwtCfg, _, _, appName := integration.Seed(t, ctx, db, 2*time.Second)
+	jwtCfg, bucketName, filenameRoot, appName := integration.Seed(t, ctx, db, 2*time.Minute)
+
 	keys := util.GenerateExposureKeys(3, -1, false)
 
 	// Publish 3 keys
@@ -146,6 +151,104 @@ func TestPublishEndpoint(t *testing.T) {
 			t.Fatalf("Want published key %q not exist in exposures", want.Key)
 		}
 	}
+
+	blobStore, err := storage.NewGoogleCloudStorage(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotExported := make(map[string]bool)
+	integration.Eventually(t, 30, func() error {
+		// // List batchfiles
+		// var exportedFiles []string
+		// if err := db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
+		// 	rows, err := tx.Query(ctx, `
+		// 		SELECT
+		// 			filename
+		// 		FROM
+		// 			ExportFile
+		// 		LIMIT 100
+		// 	`)
+		// 	if err != nil {
+		// 		return fmt.Errorf("failed to list: %w", err)
+		// 	}
+		// 	defer rows.Close()
+
+		// 	for rows.Next() {
+		// 		if err := rows.Err(); err != nil {
+		// 			return fmt.Errorf("failed to iterate: %w", err)
+		// 		}
+
+		// 		var id string
+		// 		if err := rows.Scan(&id); err != nil {
+		// 			return err
+		// 		}
+		// 		exportedFiles = append(exportedFiles, id)
+		// 	}
+
+		// 	return nil
+		// }); err != nil {
+		// 	t.Fatalf("List batches: %v", err)
+		// }
+
+		// t.Logf("Batches: %v", exportedFiles)
+
+		// if l := len(exportedFiles); l > 0 {
+		// 	t.Log("Done")
+		// }
+
+		// time.Sleep(5 * time.Second)
+
+		// Attempt to get the index
+		index, err := blobStore.GetObject(ctx, bucketName, integration.IndexFilePath(filenameRoot))
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return retry.RetryableError(fmt.Errorf("Can not find index file: %v", err))
+			}
+			return err
+		}
+
+		// Find the latest file in the index
+		lines := strings.Split(string(index), "\n")
+		latest := ""
+		for _, entry := range lines {
+			if strings.HasSuffix(entry, "zip") {
+				if entry > latest {
+					latest = entry
+				}
+			}
+		}
+		if latest == "" {
+			return retry.RetryableError(fmt.Errorf("failed to find latest export"))
+		}
+
+		// Download the latest export file contents
+		data, err := blobStore.GetObject(ctx, bucketName, latest)
+		if err != nil {
+			return fmt.Errorf("failed to open %s/%s: %w", bucketName, latest, err)
+		}
+
+		// Process contents as an export
+		key, _, err := exportapi.UnmarshalExportFile(data)
+		if err != nil {
+			return fmt.Errorf("failed to extract export data: %w", err)
+		}
+
+		for _, k := range key.Keys {
+			gotExported[base64.StdEncoding.EncodeToString(k.KeyData)] = true
+		}
+		allExported := true
+		for _, want := range wantExport {
+			if _, ok := gotExported[want]; !ok {
+				allExported = false
+			}
+		}
+		if !allExported {
+			defer time.Sleep(5 * time.Second)
+			return retry.RetryableError(errors.New("Not all keys are exported yet, keep waiting"))
+		}
+
+		return nil
+	})
 }
 
 // getExposures finds the exposures that match the given criteria.

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -243,6 +243,7 @@ func Seed(tb testing.TB, ctx context.Context, db *database.DB, exportPeriod time
 
 	if v := os.Getenv("GOOGLE_CLOUD_BUCKET"); v != "" && !testing.Short() {
 		bucketName = v
+		tb.Logf("Bucket name is %q", bucketName)
 	}
 
 	// create a signing key
@@ -371,9 +372,9 @@ func testRandomID(tb testing.TB, size int) string {
 // Eventually retries the given function n times, sleeping 1s between each
 // invocation. To mark an error as retryable, wrap it in retry.RetryableError.
 // Non-retryable errors return immediately.
-func Eventually(tb testing.TB, times uint64, f func() error) {
+func Eventually(tb testing.TB, times uint64, interval time.Duration, f func() error) {
 	ctx := context.Background()
-	b, err := retry.NewConstant(1 * time.Second)
+	b, err := retry.NewConstant(interval)
 	if err != nil {
 		tb.Fatalf("failed to create retry: %v", err)
 	}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -122,7 +122,7 @@ func TestIntegration(t *testing.T) {
 
 			// Get the exported exposures
 			var exported *export.TemporaryExposureKeyExport
-			Eventually(t, 30, func() error {
+			Eventually(t, 30, time.Second, func() error {
 				// Trigger an export
 				if err := client.ExportBatches(); err != nil {
 					return err
@@ -290,7 +290,7 @@ func TestIntegration(t *testing.T) {
 
 			// Wait for the export to be created and get the list of files
 			var batchFiles []string
-			Eventually(t, 30, func() error {
+			Eventually(t, 30, time.Second, func() error {
 				// Trigger an export
 				if err := client.ExportBatches(); err != nil {
 					return err
@@ -358,7 +358,7 @@ func TestIntegration(t *testing.T) {
 			}
 
 			// Ensure the export was deleted
-			Eventually(t, 30, func() error {
+			Eventually(t, 30, time.Second, func() error {
 				// Trigger cleanup
 				if err := client.CleanupExports(); err != nil {
 					return err

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -165,7 +165,7 @@ func TestExport(t *testing.T) {
 
 	// Start measurement
 	startTime := time.Now()
-	integration.Eventually(t, 30, func() error {
+	integration.Eventually(t, 30, time.Second, func() error {
 		// Export batch again to make the rest of batches
 		if err := client.ExportBatches(); err != nil {
 			t.Fatal(err)
@@ -245,7 +245,7 @@ func TestExport(t *testing.T) {
 	}
 
 	var remainings []string
-	integration.Eventually(t, 30, func() error {
+	integration.Eventually(t, 30, time.Second, func() error {
 		index, err := env.Blobstore().GetObject(ctx, exportDir,
 			path.Join(exportRoot, "index.txt"))
 		if err != nil {

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -49,7 +49,6 @@ function incremental() {
   export_terraform_output db_user DB_USER
   export_terraform_output db_password DB_PASSWORD
   export_terraform_output exposure_url EXPOSURE_URL
-  
   export DB_PASSWORD="secret://${DB_PASSWORD}"
   export DB_SSLMODE=disable
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -48,6 +48,7 @@ function incremental() {
   export_terraform_output db_name DB_NAME
   export_terraform_output db_user DB_USER
   export_terraform_output db_password DB_PASSWORD
+  export_terraform_output export_bucket GOOGLE_CLOUD_BUCKET
   export_terraform_output exposure_url EXPOSURE_URL
   export DB_PASSWORD="secret://${DB_PASSWORD}"
   export DB_SSLMODE=disable

--- a/terraform-e2e/main.tf
+++ b/terraform-e2e/main.tf
@@ -32,6 +32,11 @@ module "en" {
   kms_export_signing_key_ring_name  = "export-signing-${random_string.suffix.result}"
   kms_revision_tokens_key_ring_name = "revision-tokens-${random_string.suffix.result}"
 
+  cleanup_export_worker_cron_schedule = "* * * * *"
+  cleanup_exposure_worker_cron_schedule = "* * * * *"
+  export_worker_cron_schedule = "* * * * *"
+  export_create_batches_cron_schedule = "* * * * *"
+
   create_env_file = true
   deploy_debugger = true
 

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -145,7 +145,7 @@ resource "google_cloud_run_service_iam_member" "cleanup-export-invoker" {
 resource "google_cloud_scheduler_job" "cleanup-export-worker" {
   name             = "cleanup-export-worker"
   region           = var.cloudscheduler_location
-  schedule         = "0 */6 * * *"
+  schedule         = var.cleanup_export_worker_cron_schedule
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -139,7 +139,7 @@ resource "google_cloud_run_service_iam_member" "cleanup-exposure-invoker" {
 resource "google_cloud_scheduler_job" "cleanup-exposure-worker" {
   name             = "cleanup-exposure-worker"
   region           = var.cloudscheduler_location
-  schedule         = "0 */4 * * *"
+  schedule         = var.cleanup_exposure_worker_cron_schedule
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -153,7 +153,7 @@ resource "google_cloud_run_service_iam_member" "export-invoker" {
 resource "google_cloud_scheduler_job" "export-worker" {
   name             = "export-worker"
   region           = var.cloudscheduler_location
-  schedule         = "* * * * *"
+  schedule         = var.export_worker_cron_schedule
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 
@@ -180,7 +180,7 @@ resource "google_cloud_scheduler_job" "export-worker" {
 resource "google_cloud_scheduler_job" "export-create-batches" {
   name             = "export-create-batches"
   region           = var.cloudscheduler_location
-  schedule         = "*/5 * * * *"
+  schedule         = var.export_create_batches_cron_schedule
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -46,3 +46,7 @@ resource "google_storage_bucket_iam_member" "public" {
   role   = "roles/storage.objectViewer"
   member = "allUsers"
 }
+
+output "export_bucket" {
+  value = google_storage_bucket.export.name
+}

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -132,6 +132,34 @@ variable "cloudsql_backup_location" {
   description = "Location in which to backup the database."
 }
 
+variable "export_worker_cron_schedule" {
+  type    = string
+  default = "* * * * *"
+
+  description = "Schedule to execute the export worker service."
+}
+
+variable "export_create_batches_cron_schedule" {
+  type    = string
+  default = "*/5 * * * *"
+
+  description = "Schedule to execute the export create batches service."
+}
+
+variable "cleanup_exposure_worker_cron_schedule" {
+  type    = string
+  default = "0 */4 * * *"
+
+  description = "Schedule to execute the cleanup exposure worker service."
+}
+
+variable "cleanup_export_worker_cron_schedule" {
+  type    = string
+  default = "0 */6 * * *"
+
+  description = "Schedule to execute the cleanup export worker service."
+}
+
 variable "generate_cron_schedule" {
   type    = string
   default = "0 0 1 1 0"


### PR DESCRIPTION
As export endpoints are not publicly available, testing exporting by relying on cloud scheduler:

- Make cloud scheduler cron string configurable, and each runs every minute in e2e test
- Worst case scenario is 60 seconds for export batch, and another 60 seconds for export file, let e2e test wait 150 seconds to allow this happen
