### PR TITLE
Unify custom domain logic

### DIFF
--- a/terraform-e2e/main.tf
+++ b/terraform-e2e/main.tf
@@ -32,26 +32,25 @@ module "en" {
   kms_export_signing_key_ring_name  = "export-signing-${random_string.suffix.result}"
   kms_revision_tokens_key_ring_name = "revision-tokens-${random_string.suffix.result}"
 
-  cleanup_export_worker_cron_schedule = "* * * * *"
+  cleanup_export_worker_cron_schedule   = "* * * * *"
   cleanup_exposure_worker_cron_schedule = "* * * * *"
-  export_worker_cron_schedule = "* * * * *"
-  export_create_batches_cron_schedule = "* * * * *"
+  export_worker_cron_schedule           = "* * * * *"
+  export_create_batches_cron_schedule   = "* * * * *"
 
   create_env_file = true
-  deploy_debugger = true
 
   service_environment = {
     export = {
       TRUNCATE_WINDOW = "1s"
-      MIN_WINDOW_AGE = "1s"
+      MIN_WINDOW_AGE  = "1s"
 
       LOG_DEBUG = "true"
     }
 
     exposure = {
-      TRUNCATE_WINDOW = "1s"
+      TRUNCATE_WINDOW             = "1s"
       DEBUG_RELEASE_SAME_DAY_KEYS = true
-      LOG_DEBUG = "true"
+      LOG_DEBUG                   = "true"
     }
 
     generate = {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -100,6 +100,14 @@ operation**, Terraform will also migrate the database schema and build/deploy
 the initial set of services on Cloud Run. Terraform does not manage the
 lifecycle of those resources beyond their initial creation.
 
+### Custom hosts
+
+Using custom hosts (domains) for the services requires a manual step of updating
+DNS entries. Run Terraform once and get the `lb_ip` entry. Then, update your DNS
+provider to point the A records to that IP address. Give DNS time to propagate
+and then re-apply Terraform. DNS must be working for the certificates to
+provision.
+
 ### Local development and testing example deployment
 
 The default Terraform deployment is a production-ready, high traffic deployment.

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -1,0 +1,204 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  all_hosts = toset(concat(var.debugger_hosts, var.export_hosts, var.exposure_hosts, var.federationout_hosts))
+  enable_lb = length(local.all_hosts) > 0
+}
+
+resource "google_compute_global_address" "key-server" {
+  count = local.enable_lb ? 1 : 0
+
+  name    = "key-server-address"
+  project = var.project
+}
+
+# Redirects all requests to https
+resource "google_compute_url_map" "urlmap-http" {
+  count = local.enable_lb ? 1 : 0
+
+  name     = "https-redirect"
+  provider = google-beta
+  project  = var.project
+
+  default_url_redirect {
+    strip_query    = false
+    https_redirect = true
+  }
+}
+
+resource "google_compute_url_map" "urlmap-https" {
+  count = local.enable_lb ? 1 : 0
+
+  name            = "key-server"
+  provider        = google-beta
+  project         = var.project
+  default_service = google_compute_backend_service.exposure[0].id
+
+  // debugger
+  dynamic "host_rule" {
+    for_each = length(var.debugger_hosts) > 0 ? [1] : []
+
+    content {
+      path_matcher = "debugger"
+      hosts        = var.debugger_hosts
+    }
+  }
+
+  dynamic "path_matcher" {
+    for_each = length(var.debugger_hosts) > 0 ? [1] : []
+
+    content {
+      name            = "debugger"
+      default_service = google_compute_backend_service.debugger[0].id
+    }
+  }
+
+  // export
+  dynamic "host_rule" {
+    for_each = length(var.export_hosts) > 0 ? [1] : []
+
+    content {
+      path_matcher = "export"
+      hosts        = var.export_hosts
+    }
+  }
+
+  dynamic "path_matcher" {
+    for_each = length(var.export_hosts) > 0 ? [1] : []
+
+    content {
+      name            = "export"
+      default_service = google_compute_backend_bucket.export[0].id
+    }
+  }
+
+  // exposure
+  dynamic "host_rule" {
+    for_each = length(var.exposure_hosts) > 0 ? [1] : []
+
+    content {
+      path_matcher = "exposure"
+      hosts        = var.exposure_hosts
+    }
+  }
+
+  dynamic "path_matcher" {
+    for_each = length(var.exposure_hosts) > 0 ? [1] : []
+
+    content {
+      name            = "exposure"
+      default_service = google_compute_backend_service.exposure[0].id
+    }
+  }
+
+  // federationout
+  dynamic "host_rule" {
+    for_each = length(var.federationout_hosts) > 0 ? [1] : []
+
+    content {
+      path_matcher = "federationout"
+      hosts        = var.federationout_hosts
+    }
+  }
+
+  dynamic "path_matcher" {
+    for_each = length(var.federationout_hosts) > 0 ? [1] : []
+
+    content {
+      name            = "federationout"
+      default_service = google_compute_backend_service.federationout[0].id
+    }
+  }
+}
+
+resource "google_compute_target_http_proxy" "http" {
+  count = local.enable_lb ? 1 : 0
+
+  provider = google-beta
+  name     = "key-server"
+  project  = var.project
+
+  url_map = google_compute_url_map.urlmap-http[0].id
+}
+
+resource "google_compute_target_https_proxy" "https" {
+  count = local.enable_lb ? 1 : 0
+
+  name    = "key-server"
+  project = var.project
+
+  url_map          = google_compute_url_map.urlmap-https[0].id
+  ssl_certificates = [google_compute_managed_ssl_certificate.default[0].id]
+}
+
+resource "google_compute_global_forwarding_rule" "http" {
+  count = local.enable_lb ? 1 : 0
+
+  provider = google-beta
+  name     = "key-server-http"
+  project  = var.project
+
+  ip_protocol           = "TCP"
+  ip_address            = google_compute_global_address.key-server[0].address
+  load_balancing_scheme = "EXTERNAL"
+  port_range            = "80"
+  target                = google_compute_target_http_proxy.http[0].id
+}
+
+resource "google_compute_global_forwarding_rule" "https" {
+  count = local.enable_lb ? 1 : 0
+
+  provider = google-beta
+  name     = "key-server-https"
+  project  = var.project
+
+  ip_protocol           = "TCP"
+  ip_address            = google_compute_global_address.key-server[0].address
+  load_balancing_scheme = "EXTERNAL"
+  port_range            = "443"
+  target                = google_compute_target_https_proxy.https[0].id
+}
+
+resource "random_id" "certs" {
+  count = local.enable_lb ? 1 : 0
+
+  byte_length = 4
+
+  keepers = {
+    domains = join(",", local.all_hosts)
+  }
+}
+
+resource "google_compute_managed_ssl_certificate" "default" {
+  count = local.enable_lb ? 1 : 0
+
+  provider = google-beta
+  name     = "key-certificates-${random_id.certs[0].hex}"
+  project  = var.project
+
+  managed {
+    domains = local.all_hosts
+  }
+
+  # This is to prevent destroying the cert while it's still attached to the load
+  # balancer.
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+output "lb_ip" {
+  value = google_compute_global_address.key-server[0].address
+}

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -133,21 +133,6 @@ resource "google_cloud_run_service" "exposure" {
   }
 }
 
-resource "google_cloud_run_domain_mapping" "exposure" {
-  count    = var.exposure_custom_domain != "" ? 1 : 0
-  location = var.cloudrun_location
-  name     = var.exposure_custom_domain
-
-  metadata {
-    namespace = var.project
-  }
-
-  spec {
-    route_name     = google_cloud_run_service.exposure.name
-    force_override = true
-  }
-}
-
 resource "google_cloud_run_service_iam_member" "exposure-public" {
   location = google_cloud_run_service.exposure.location
   project  = google_cloud_run_service.exposure.project
@@ -156,6 +141,37 @@ resource "google_cloud_run_service_iam_member" "exposure-public" {
   member   = "allUsers"
 }
 
-output "exposure_url" {
-  value = var.exposure_custom_domain != "" ? "https://${var.exposure_custom_domain}" : google_cloud_run_service.exposure.status.0.url
+#
+# Custom domains and load balancer
+#
+
+resource "google_compute_region_network_endpoint_group" "exposure" {
+  count = length(var.exposure_hosts) > 0 ? 1 : 0
+
+  name     = "exposure"
+  provider = google-beta
+  project  = var.project
+  region   = var.region
+
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_service.exposure.name
+  }
+}
+
+resource "google_compute_backend_service" "exposure" {
+  count = length(var.exposure_hosts) > 0 ? 1 : 0
+
+  provider = google-beta
+  name     = "exposure"
+  project  = var.project
+
+  backend {
+    group = google_compute_region_network_endpoint_group.exposure[0].id
+  }
+}
+
+output "exposure_urls" {
+  value = concat([google_cloud_run_service.exposure.status.0.url], formatlist("https://%s", var.exposure_hosts))
 }

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -47,6 +47,14 @@ resource "google_storage_bucket_iam_member" "public" {
   member = "allUsers"
 }
 
+resource "google_compute_backend_bucket" "export" {
+  count = length(var.export_hosts) > 0 ? 1 : 0
+
+  name        = "export-backend-bucket"
+  bucket_name = google_storage_bucket.export.name
+  enable_cdn  = var.enable_cdn_for_exports
+}
+
 output "export_bucket" {
   value = google_storage_bucket.export.name
 }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -174,11 +174,18 @@ variable "generate_regions" {
   description = "List of regions for which to generate data."
 }
 
-variable "deploy_debugger" {
+variable "enable_cdn_for_exports" {
   type    = bool
   default = false
 
-  description = "Deploy the service debugger. Use only in testing."
+  description = "Enable Cloud CDN on the export bucket."
+}
+
+variable "debugger_invokers" {
+  type    = list(string)
+  default = []
+
+  description = "List of IAM entities that can invoke the debugger. This should be of the form user:[email], serviceAccount:[email], or group:[email]."
 }
 
 variable "service_environment" {
@@ -188,18 +195,32 @@ variable "service_environment" {
   description = "Per-service environment overrides."
 }
 
-variable "exposure_custom_domain" {
-  type    = string
-  default = ""
+variable "debugger_hosts" {
+  type    = list(string)
+  default = []
 
-  description = "Custom domain to map for exposures. This domain must already be verified by Google, and you must have a DNS CNAME record pointing to ghs.googlehosted.com in advance. If not provided, no domain mapping is created."
+  description = "List of domains upon which the debugger is served."
 }
 
-variable "federationout_custom_domain" {
-  type    = string
-  default = ""
+variable "export_hosts" {
+  type    = list(string)
+  default = []
 
-  description = "Custom domain to map for federationin. This domain must already be verified by Google, and you must have a DNS CNAME record pointing to ghs.googlehosted.com in advance. If not provided, no domain mapping is created."
+  description = "List of domains upon which exports should be served."
+}
+
+variable "exposure_hosts" {
+  type    = list(string)
+  default = []
+
+  description = "List of domains upon which the exposure uploads are served."
+}
+
+variable "federationout_hosts" {
+  type    = list(string)
+  default = []
+
+  description = "List of domains upon which the federationout service is served."
 }
 
 variable "vpc_access_connector_max_throughput" {


### PR DESCRIPTION
Also adds the ability to set groups/users that can invoke the debugger and fronts the Cloud Storage bucket with the load balancer too (so users can enable the CDN and a custom domain if they want)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
**Warning** - changes in the Terraform configuration will cause SSL certificates to re-provision which could cause minor downtime.
```