### PR TITLE
Add export-importer image in cloudbuild config

### DIFF
--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -378,6 +378,7 @@ images:
 - 'gcr.io/${PROJECT_ID}/${_REPO}/cleanup-exposure:${_TAG}'
 - 'gcr.io/${PROJECT_ID}/${_REPO}/debugger:${_TAG}'
 - 'gcr.io/${PROJECT_ID}/${_REPO}/export:${_TAG}'
+- 'gcr.io/${PROJECT_ID}/${_REPO}/export-importer:${_TAG}'
 - 'gcr.io/${PROJECT_ID}/${_REPO}/exposure:${_TAG}'
 - 'gcr.io/${PROJECT_ID}/${_REPO}/federationin:${_TAG}'
 - 'gcr.io/${PROJECT_ID}/${_REPO}/federationout:${_TAG}'


### PR DESCRIPTION
Missing this failed terraform smoke test, due to export-importer image missing
