### PR TITLE
allow for default days since symptom onset

### DIFF
--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	DefaultRegion                string        `env:"DEFAULT_REGION, default=US"`
 	ChanceOfKeyRevision          int           `env:"CHANCE_OF_KEY_REVISION, default=30"` // 0-100 are valid values.
 	KeyRevisionDelay             time.Duration `env:"KEY_REVISION_DELAY, default=2h"`     // key revision will be forward dates this amount.
-	UseDefaultSymptomOnset       bool          `env:"USE_DEFAULT_SYMPTOM_ONSET_DAYS, default true"`
+	UseDefaultSymptomOnset       bool          `env:"USE_DEFAULT_SYMPTOM_ONSET_DAYS, default=true"`
 	SymptomOnsetDays             uint          `env:"DEFAULT_SYMPTOM_ONSET_DAYS, default=10"`
 }
 

--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -50,6 +50,8 @@ type Config struct {
 	DefaultRegion                string        `env:"DEFAULT_REGION, default=US"`
 	ChanceOfKeyRevision          int           `env:"CHANCE_OF_KEY_REVISION, default=30"` // 0-100 are valid values.
 	KeyRevisionDelay             time.Duration `env:"KEY_REVISION_DELAY, default=2h"`     // key revision will be forward dates this amount.
+	UseDefaultSymptomOnset       bool          `env:"USE_DEFAULT_SYMPTOM_ONSET_DAYS, default true"`
+	SymptomOnsetDays             uint          `env:"DEFAULT_SYMPTOM_ONSET_DAYS, default=10"`
 }
 
 func (c *Config) MaxExposureKeys() uint {
@@ -70,6 +72,14 @@ func (c *Config) TruncateWindow() time.Duration {
 
 func (c *Config) MaxSymptomOnsetDays() uint {
 	return c.MaxMagnitudeSymptomOnsetDays
+}
+
+func (c *Config) UseDefaultSymptomOnsetDays() bool {
+	return c.UseDefaultSymptomOnset
+}
+
+func (c *Config) DefaultSymptomOnsetDays() int32 {
+	return int32(c.SymptomOnsetDays)
 }
 
 func (c *Config) DebugReleaseSameDayKeys() bool {

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -58,7 +58,7 @@ type Config struct {
 
 	// If set, TEKs that arrive without a days since symptom onset (i.e. no symptom onset date)
 	// will be set to the default symptom onset days.
-	UseDefaultSymptomOnset bool `env:"USE_DEFAULT_SYMPTOM_ONSET_DAYS, default true"`
+	UseDefaultSymptomOnset bool `env:"USE_DEFAULT_SYMPTOM_ONSET_DAYS, default=true"`
 	SymptomOnsetDays       uint `env:"DEFAULT_SYMPTOM_ONSET_DAYS, default=10"`
 
 	ResponsePaddingMinBytes int64 `env:"RESPONSE_PADDING_MIN_BYTES, default=1024"`

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -53,8 +53,13 @@ type Config struct {
 	// Provides compatibility w/ 1.5 release.
 	MaxSameStartIntervalKeys     uint          `env:"MAX_SAME_START_INTERVAL_KEYS, default=3"`
 	MaxIntervalAge               time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
-	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=14"`
+	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=10"`
 	CreatedAtTruncateWindow      time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
+
+	// If set, TEKs that arrive without a days since symptom onset (i.e. no symptom onset date)
+	// will be set to the default symptom onset days.
+	UseDefaultSymptomOnset bool `env:"USE_DEFAULT_SYMPTOM_ONSET_DAYS, default true"`
+	SymptomOnsetDays       uint `env:"DEFAULT_SYMPTOM_ONSET_DAYS, default=10"`
 
 	ResponsePaddingMinBytes int64 `env:"RESPONSE_PADDING_MIN_BYTES, default=1024"`
 	ResponsePaddingRange    int64 `env:"RESPONSE_PADDING_RANGE, default=1024"`
@@ -101,6 +106,14 @@ func (c *Config) TruncateWindow() time.Duration {
 
 func (c *Config) MaxSymptomOnsetDays() uint {
 	return c.MaxMagnitudeSymptomOnsetDays
+}
+
+func (c *Config) UseDefaultSymptomOnsetDays() bool {
+	return c.UseDefaultSymptomOnset
+}
+
+func (c *Config) DefaultSymptomOnsetDays() int32 {
+	return int32(c.SymptomOnsetDays)
 }
 
 func (c *Config) DebugReleaseSameDayKeys() bool {


### PR DESCRIPTION
Fixes #1055

## Proposed Changes

* By default, if no value is known for days since symptom onset is known, set it to the default value in the system.
* 10 is the agreed upon default by the Google and Apple clinical teams

**Release Note**


```release-note
BEHAVIOR CHANGE: 
Two new environment variables, USE_DEFAULT_SYMPTOM_ONSET_DAYS and DEFAULT_SYMPTOM_ONSET_DAYS. 
If enabled, TEKs that previously would have a null value for days since symptom onset will receive the default value.

This new functionality is enabled by default in this release.
```