### PR TITLE
Fix e2e terraform deployment by supplying hosts

### DIFF
--- a/terraform-e2e/main.tf
+++ b/terraform-e2e/main.tf
@@ -39,6 +39,11 @@ module "en" {
 
   create_env_file = true
 
+  debugger_hosts      = ["debugger.todo"]
+  export_hosts        = ["export.todo"]
+  exposure_hosts      = ["exposure.todo"]
+  federationout_hosts = ["federationout.todo"]
+
   service_environment = {
     export = {
       TRUNCATE_WINDOW = "1s"


### PR DESCRIPTION
Terraform smoke test failed due to index out of bound error at https://github.com/google/exposure-notifications-server/blob/5e41925d7b2c441185979827f7ae58dc29991429/terraform/lb.tf#L203