### PR TITLE
Don't fail terraform if there is no custom domain supplied

### DIFF
--- a/terraform-e2e/main.tf
+++ b/terraform-e2e/main.tf
@@ -39,11 +39,6 @@ module "en" {
 
   create_env_file = true
 
-  debugger_hosts      = ["debugger.todo"]
-  export_hosts        = ["export.todo"]
-  exposure_hosts      = ["exposure.todo"]
-  federationout_hosts = ["federationout.todo"]
-
   service_environment = {
     export = {
       TRUNCATE_WINDOW = "1s"

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -200,5 +200,5 @@ resource "google_compute_managed_ssl_certificate" "default" {
 }
 
 output "lb_ip" {
-  value = local.enable_lb ? google_compute_global_address.key-server[0].address : ""
+  value = google_compute_global_address.key-server.*.address
 }

--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -200,5 +200,5 @@ resource "google_compute_managed_ssl_certificate" "default" {
 }
 
 output "lb_ip" {
-  value = google_compute_global_address.key-server[0].address
+  value = local.enable_lb ? google_compute_global_address.key-server[0].address : ""
 }


### PR DESCRIPTION
By the way remove custom domain from e2e test, as google api requires valid domain name for creating ssl cert. 

See terraform smoke test failure: https://prow.k8s.io/view/gcs/oss-prow/logs/ci-en-server-terraform-smoke/1313591663427325952#1:build-log.txt%3A13898