### PR TITLE
E2E test: fix flakes by increasing db connection idle waiting time

### DIFF
--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -108,6 +108,8 @@ func TestPublishEndpoint(t *testing.T) {
 	if tc.ExposureURL == "" {
 		t.Skip()
 	}
+	// Increase this so that the db connection won't be canceled while polling for exported files
+	tc.DBConfig.PoolMaxConnIdle = 5 * time.Minute
 
 	db, err := database.NewFromEnv(ctx, tc.DBConfig)
 	if err != nil {


### PR DESCRIPTION
DB connection cancelled at exactly 2 minutes after initial set up, which is not sufficient in some e2e test cases, which makes it very flaky. Increase the idle time to make it more stable

