### PR TITLE
Exclude regions in export.

### DIFF
--- a/internal/admin/exports/form_test.go
+++ b/internal/admin/exports/form_test.go
@@ -1,0 +1,26 @@
+package exports
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitRegions(t *testing.T) {
+	tests := []struct {
+		r string
+		e []string
+	}{
+		{"", []string{}},
+		{"  test  ", []string{"test"}},
+		{"test\n\rfoo", []string{"foo", "test"}},
+		{"test\n\rfoo bar\n\r", []string{"foo bar", "test"}},
+		{"test\n\rfoo bar\n\r  ", []string{"foo bar", "test"}},
+		{"test\nfoo\n", []string{"foo", "test"}},
+	}
+
+	for i, test := range tests {
+		if res := splitRegions(test.r); !reflect.DeepEqual(res, test.e) {
+			t.Errorf("[%d] splitRegions(%v) = %v, expected %v", i, test.r, res, test.e)
+		}
+	}
+}

--- a/internal/export/model/export_model.go
+++ b/internal/export/model/export_model.go
@@ -39,6 +39,7 @@ type ExportConfig struct {
 	Period           time.Duration
 	OutputRegion     string
 	InputRegions     []string
+	ExcludeRegions   []string
 	IncludeTravelers bool
 	From             time.Time
 	Thru             time.Time
@@ -53,6 +54,10 @@ func (ec *ExportConfig) EffectiveInputRegions() []string {
 
 func (ec *ExportConfig) InputRegionsOnePerLine() string {
 	return strings.Join(ec.InputRegions, "\n")
+}
+
+func (ec *ExportConfig) ExcludeRegionsOnePerLine() string {
+	return strings.Join(ec.ExcludeRegions, "\n")
 }
 
 func (ec *ExportConfig) Validate() error {
@@ -105,6 +110,7 @@ type ExportBatch struct {
 	OutputRegion     string
 	InputRegions     []string
 	IncludeTravelers bool
+	ExcludeRegions   []string
 	Status           string
 	LeaseExpires     time.Time
 	SignatureInfoIDs []int64
@@ -123,6 +129,7 @@ type ExportFile struct {
 	OutputRegion     string
 	InputRegions     []string
 	IncludeTravelers bool
+	ExcludeRegions   []string
 	BatchNum         int
 	BatchSize        int
 	Status           string

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -120,7 +120,8 @@ func (s *Server) exportBatch(ctx context.Context, eb *model.ExportBatch, emitInd
 		UntilTimestamp:      eb.EndTimestamp,
 		IncludeRegions:      eb.EffectiveInputRegions(),
 		IncludeTravelers:    eb.IncludeTravelers, // Travelers are included from "any" region.
-		OnlyLocalProvenance: false,               // include federated ids
+		ExcludeRegions:      eb.ExcludeRegions,
+		OnlyLocalProvenance: false, // include federated ids
 		OnlyRevisedKeys:     false,
 	}
 

--- a/migrations/000043_ReAddExcludeRegions.down.sql
+++ b/migrations/000043_ReAddExcludeRegions.down.sql
@@ -1,0 +1,26 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE exportconfig
+    DROP COLUMN exclude_regions;
+
+ALTER TABLE exportbatch
+    DROP COLUMN exclude_regions;
+
+ALTER TABLE exportfile
+    DROP COLUMN exclude_regions;
+
+END;

--- a/migrations/000043_ReAddExcludeRegions.up.sql
+++ b/migrations/000043_ReAddExcludeRegions.up.sql
@@ -1,0 +1,26 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE exportconfig
+    ADD COLUMN exclude_regions VARCHAR(5) [];
+
+ALTER TABLE exportbatch
+    ADD COLUMN exclude_regions VARCHAR(5) [];
+
+ALTER TABLE exportfile
+    ADD COLUMN exclude_regions VARCHAR(5) [];
+
+END;

--- a/tools/admin-console/templates/export.html
+++ b/tools/admin-console/templates/export.html
@@ -59,6 +59,16 @@
       </div>
 
       <div class="form-label-group">
+        <textarea name="ExcludeRegions" id="exclude-regions" rows="3"
+          placeholder="Exclude regions" class="form-control">{{.export.ExcludeRegionsOnePerLine}}</textarea>
+        <label for="exclude-regions">Exclude regions</label>
+        <small class="form-text text-muted">
+          One per line, leave blank for only using the output region (above).
+		  Allows you to exclude travelers from certain regions.
+        </small>
+      </div>
+
+      <div class="form-label-group">
         <input type="text" name="BucketName" id="bucket-name" value="{{.export.BucketName}}"
           placeholder="Cloud storage bucket" class="form-control">
         <label for="bucket-name">Cloud Storage bucket</label>


### PR DESCRIPTION
Recreate the ability to exclude regions from the exports.


Updates #1054

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Recreate ExcludeRegions in exports. This will allow situations where traveling users can be excluded in an export.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Recreate ExcludeRegions in exports. This will allow situations where traveling users can be excluded in an export.

```