### PR TITLE
Add OnlyNonTravelers to exports.

### DIFF
--- a/internal/admin/exports/form.go
+++ b/internal/admin/exports/form.go
@@ -16,6 +16,7 @@
 package exports
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -25,10 +26,13 @@ import (
 	"github.com/google/exposure-notifications-server/internal/export/model"
 )
 
+var ErrCannotSetBothTravelers = errors.New("cannot have both 'include travelers', and 'only non-travelers' set")
+
 type formData struct {
 	OutputRegion     string        `form:"OutputRegion"`
 	InputRegions     string        `form:"InputRegions"`
 	IncludeTravelers bool          `form:"IncludeTravelers"`
+	OnlyNonTravelers bool          `form:"OnlyNonTravelers"`
 	ExcludeRegions   string        `form:"ExcludeRegions"`
 	BucketName       string        `form:"BucketName"`
 	FilenameRoot     string        `form:"FilenameRoot"`
@@ -63,6 +67,9 @@ func (f *formData) PopulateExportConfig(ec *model.ExportConfig) error {
 	if err != nil {
 		return err
 	}
+	if f.IncludeTravelers && f.OnlyNonTravelers {
+		return ErrCannotSetBothTravelers
+	}
 
 	ec.BucketName = strings.TrimSpace(f.BucketName)
 	ec.FilenameRoot = strings.TrimSpace(f.FilenameRoot)
@@ -70,6 +77,7 @@ func (f *formData) PopulateExportConfig(ec *model.ExportConfig) error {
 	ec.OutputRegion = strings.TrimSpace(f.OutputRegion)
 	ec.InputRegions = splitRegions(f.InputRegions)
 	ec.IncludeTravelers = f.IncludeTravelers
+	ec.OnlyNonTravelers = f.OnlyNonTravelers
 	ec.ExcludeRegions = splitRegions(f.ExcludeRegions)
 	ec.From = from
 	ec.Thru = thru

--- a/internal/export/batcher.go
+++ b/internal/export/batcher.go
@@ -132,6 +132,8 @@ func (s *Server) maybeCreateBatches(ctx context.Context, ec *model.ExportConfig,
 			OutputRegion:     ec.OutputRegion,
 			InputRegions:     ec.InputRegions,
 			IncludeTravelers: ec.IncludeTravelers,
+			OnlyNonTravelers: ec.OnlyNonTravelers,
+			ExcludeRegions:   ec.ExcludeRegions,
 			Status:           model.ExportBatchOpen,
 			SignatureInfoIDs: infoIds,
 		})

--- a/internal/export/model/export_model.go
+++ b/internal/export/model/export_model.go
@@ -41,6 +41,7 @@ type ExportConfig struct {
 	InputRegions     []string
 	ExcludeRegions   []string
 	IncludeTravelers bool
+	OnlyNonTravelers bool
 	From             time.Time
 	Thru             time.Time
 	SignatureInfoIDs []int64
@@ -110,6 +111,7 @@ type ExportBatch struct {
 	OutputRegion     string
 	InputRegions     []string
 	IncludeTravelers bool
+	OnlyNonTravelers bool
 	ExcludeRegions   []string
 	Status           string
 	LeaseExpires     time.Time
@@ -129,6 +131,7 @@ type ExportFile struct {
 	OutputRegion     string
 	InputRegions     []string
 	IncludeTravelers bool
+	OnlyNonTravelers bool
 	ExcludeRegions   []string
 	BatchNum         int
 	BatchSize        int

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -120,6 +120,7 @@ func (s *Server) exportBatch(ctx context.Context, eb *model.ExportBatch, emitInd
 		UntilTimestamp:      eb.EndTimestamp,
 		IncludeRegions:      eb.EffectiveInputRegions(),
 		IncludeTravelers:    eb.IncludeTravelers, // Travelers are included from "any" region.
+		OnlyNonTravelers:    eb.OnlyNonTravelers,
 		ExcludeRegions:      eb.ExcludeRegions,
 		OnlyLocalProvenance: false, // include federated ids
 		OnlyRevisedKeys:     false,

--- a/internal/pb/federation/federation.pb.go
+++ b/internal/pb/federation/federation.pb.go
@@ -116,7 +116,8 @@ type FederationFetchRequest struct {
 	MaxExposureKeys uint32 `protobuf:"varint,5,opt,name=maxExposureKeys,proto3" json:"maxExposureKeys,omitempty"`
 	// region, includeTravelers, onlyTravelers must be stable to send a fetchToken.
 	// initial query should send an empty fetch state token.
-	State *FetchState `protobuf:"bytes,6,opt,name=state,proto3" json:"state,omitempty"`
+	State            *FetchState `protobuf:"bytes,6,opt,name=state,proto3" json:"state,omitempty"`
+	OnlyNonTravelers bool        `protobuf:"varint,7,opt,name=onlyNonTravelers,proto3" json:"onlyNonTravelers,omitempty"`
 }
 
 func (x *FederationFetchRequest) Reset() {

--- a/internal/publish/database/exposure.go
+++ b/internal/publish/database/exposure.go
@@ -73,6 +73,7 @@ func New(db *database.DB) *PublishDB {
 type IterateExposuresCriteria struct {
 	IncludeRegions   []string
 	IncludeTravelers bool // Include records in the IncludeRegions OR travalers
+	OnlyNonTravelers bool
 	OnlyTravelers    bool // Only includes records marked as travelers.
 	ExcludeRegions   []string
 	SinceTimestamp   time.Time
@@ -233,6 +234,11 @@ func generateExposureQuery(criteria IterateExposuresCriteria) (string, []interfa
 
 	if criteria.OnlyTravelers {
 		args = append(args, true)
+		q += fmt.Sprintf(" AND traveler = $%d", len(args))
+	}
+
+	if criteria.OnlyNonTravelers {
+		args = append(args, false)
 		q += fmt.Sprintf(" AND traveler = $%d", len(args))
 	}
 

--- a/migrations/000046_AddOnlyNonTravelers.down.sql
+++ b/migrations/000046_AddOnlyNonTravelers.down.sql
@@ -1,0 +1,26 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE exportconfig
+    DROP COLUMN only_non_travelers;
+
+ALTER TABLE exportbatch
+    DROP COLUMN only_non_travelers;
+
+ALTER TABLE exportfile
+    DROP COLUMN only_non_travelers;
+
+END;

--- a/migrations/000046_AddOnlyNonTravelers.up.sql
+++ b/migrations/000046_AddOnlyNonTravelers.up.sql
@@ -1,0 +1,26 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE exportconfig
+    ADD COLUMN only_non_travelers BOOL DEFAULT FALSE;
+
+ALTER TABLE exportbatch
+    ADD COLUMN only_non_travelers BOOL DEFAULT FALSE;
+
+ALTER TABLE exportfile
+    ADD COLUMN only_non_travelers BOOL DEFAULT FALSE;
+
+END;

--- a/tools/admin-console/templates/export.html
+++ b/tools/admin-console/templates/export.html
@@ -58,6 +58,19 @@
         </small>
       </div>
 
+      <div class="form-group">
+        <label for="only-non-travelers">Only Non Travelers</label>
+        <select name="OnlyNonTravelers" id="only-non-travelers" class="form-control custom-select">
+          <option value="true" {{if .export.OnlyNonTravelers}}selected{{end}}>Yes</option>
+          <option value="false" {{if not .export.OnlyNonTravelers}}selected{{end}}>No</option>
+        </select>
+        <small class="form-text text-muted">
+		  Should only federeated-in non-traveler keys be included in this
+		  export. Note, setting this with 'Include Travelers' will result in an
+		  error.
+        </small>
+      </div>
+
       <div class="form-label-group">
         <textarea name="ExcludeRegions" id="exclude-regions" rows="3"
           placeholder="Exclude regions" class="form-control">{{.export.ExcludeRegionsOnePerLine}}</textarea>


### PR DESCRIPTION
Fixes #1054


<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add OnlyNonTravelers to Exports -- exports only non-traveling external users.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adds ability to only export non-travelers.
```