### PR TITLE
Make sure map is initialized

### DIFF
--- a/internal/export/database/export.go
+++ b/internal/export/database/export.go
@@ -425,7 +425,7 @@ func (db *ExportDB) LatestExportBatchEnd(ctx context.Context, ec *model.ExportCo
 // ListLatestExportBatchEnds returns a map of export config IDs to their latest
 // batch end times.
 func (db *ExportDB) ListLatestExportBatchEnds(ctx context.Context) (map[int64]*time.Time, error) {
-	var ts map[int64]*time.Time
+	ts := make(map[int64]*time.Time, 8)
 
 	if err := db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ensure map is initialized preventing runtime panic
```