### PR TITLE
Increase build timeout, use 32 cores

### DIFF
--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -413,3 +413,5 @@ images:
 - 'gcr.io/${PROJECT_ID}/${_REPO}/key-rotation:${_TAG}'
 - 'gcr.io/${PROJECT_ID}/${_REPO}/migrate:${_TAG}'
 - 'gcr.io/${PROJECT_ID}/${_REPO}/mirror:${_TAG}'
+
+timeout: '900s'

--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -16,8 +16,7 @@
 # Builds a container image.
 #
 options:
-  # N1_HIGHCPU_32 builds faster, but takes much longer to provision.
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'N1_HIGHCPU_32'
   env:
   - 'GOPATH=/go'
   - 'GO111MODULE=on'


### PR DESCRIPTION
We've added enough services that we're exhausting all 8 CPUs.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Bump builder to use 32 CPUs when building.
```