### PR TITLE
Add timeutils from exposure notification verification server

### DIFF
--- a/pkg/timeutil/midnight.go
+++ b/pkg/timeutil/midnight.go
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package timeutils defines functions to close the gaps present in Golang's
+// default implementation of Time.
+package timeutils
+
+import "time"
+
+// LocalMidnight returns the local midnight of the given time.
+func LocalMidnight(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.Local)
+}
+
+// UTCMidnight converts the given time to UTC, and returns the UTC time.
+func UTCMidnight(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// Midnight returns the midnight of the given time.
+func Midnight(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}


### PR DESCRIPTION
We will be removing this package from that tree, and depending on it
from this location.

NB: This package is NOT used yet in this codebase, although it will be.
