### PR TITLE
Require TLS 1.2+

### DIFF
--- a/terraform/lb.tf
+++ b/terraform/lb.tf
@@ -17,6 +17,12 @@ locals {
   enable_lb = length(local.all_hosts) > 0
 }
 
+resource "google_compute_ssl_policy" "one-two-ssl-policy" {
+  name            = "one-two-ssl-policy"
+  profile         = "MODERN"
+  min_tls_version = "TLS_1_2"
+}
+
 resource "google_compute_global_address" "key-server" {
   count = local.enable_lb ? 1 : 0
 
@@ -141,6 +147,7 @@ resource "google_compute_target_https_proxy" "https" {
 
   url_map          = google_compute_url_map.urlmap-https[0].id
   ssl_certificates = [google_compute_managed_ssl_certificate.default[0].id]
+  ssl_policy       = google_compute_ssl_policy.one-two-ssl-policy.id
 }
 
 resource "google_compute_global_forwarding_rule" "http" {


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Require client connections use TLS 1.2+
```