### PR TITLE
Terraform db instance explicitly depends_on db, cert and user

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -64,6 +64,11 @@ resource "google_sql_database_instance" "db-inst" {
 
   depends_on = [
     google_project_service.services["sql-component.googleapis.com"],
+    # Explicitly label dependencies of db instance, so that destroy won't
+    # delete db instance first, and leave the following resources orphaned.
+    google_sql_database.db,
+    google_sql_ssl_cert.db-cert,
+    google_sql_user.user,
   ]
 }
 


### PR DESCRIPTION
When terraform destroys database instance, it could happen that database instance was deleted ahead of db, cert and user, which were left orphaned and terraform didn't know how to handle them, and this prevents terraform smoke test from succeeding. Example error:

```
Error: Error when reading or editing SQL User "notification" in instance "en-server-kbcnp": googleapi: Error 400: Invalid request: Invalid request since instance is not running., invalid
```

https://prow.k8s.io/view/gcs/oss-prow/logs/ci-en-server-terraform-smoke/1317495728049754112#1:build-log.txt%3A227