### PR TITLE
Terraform e2e: add back custom db deletion step

### DIFF
--- a/scripts/ci-terraform.sh
+++ b/scripts/ci-terraform.sh
@@ -131,6 +131,8 @@ function destroy() {
   if [[ -n "${db_inst_name}" ]]; then
     echo "Deleting db ${db_inst_name}"
     gcloud sql instances delete ${db_inst_name} -q --project=${PROJECT_ID}
+    # There still might be open connection between vpc and db, wait to improve destroy
+    sleep 120
   fi
   # Clean up states after manual DB delete
   terraform state rm module.en.google_sql_user.user || best_effort

--- a/scripts/ci-terraform.sh
+++ b/scripts/ci-terraform.sh
@@ -121,6 +121,21 @@ function deploy() {
 function destroy() {
   pushd "${ROOT}/terraform-e2e-ci" > /dev/null
   init
+
+  # DB always failed to be destroyed by terraform as it's set to not to destroy,
+  # so delete it manually
+  local db_inst_name
+  # Fetching databases from previous terraform deployment output is not always reliable,
+  # especially when previous terraform deployment failed. So grepping from terraform state instead.
+  db_inst_name="$(terraform state show module.en.google_sql_database_instance.db-inst | grep -Eo 'en-server-[a-zA-Z0-9]+' | uniq)"
+  if [[ -n "${db_inst_name}" ]]; then
+    echo "Deleting db ${db_inst_name}"
+    gcloud sql instances delete ${db_inst_name} -q --project=${PROJECT_ID}
+  fi
+  # Clean up states after manual DB delete
+  terraform state rm module.en.google_sql_user.user || best_effort
+  terraform state rm module.en.google_sql_ssl_cert.db-cert || best_effort
+
   terraform destroy -auto-approve
   popd > /dev/null
 }

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -64,11 +64,6 @@ resource "google_sql_database_instance" "db-inst" {
 
   depends_on = [
     google_project_service.services["sql-component.googleapis.com"],
-    # Explicitly label dependencies of db instance, so that destroy won't
-    # delete db instance first, and leave the following resources orphaned.
-    google_sql_database.db,
-    google_sql_ssl_cert.db-cert,
-    google_sql_user.user,
   ]
 }
 


### PR DESCRIPTION
Unfortunately terraform doesn't like #1097 , saying cycling dependencies:

```
Error: Cycle: module.en.google_sql_user.user, module.en.google_sql_database.db, module.en.google_sql_database_instance.db-inst, module.en.google_sql_ssl_cert.db-cert
```

https://prow.k8s.io/view/gcs/oss-prow/logs/ci-en-server-terraform-smoke/1318009362538565632#1:build-log.txt%3A88

Restore custom db deletion step to make terraform smoke test work