### PR TITLE
take user provided symptom onset in publish

### DIFF
--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -561,7 +561,7 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 
 	onsetInterval := inData.SymptomOnsetInterval
 	// If the symtom onset interval provided on publish is too old to be relevant
-	// and one was provided in the verificaiton certificate, take that one.
+	// and one was provided in the verification certificate, take that one.
 	if onsetInterval < settings.MinStartInterval && claims != nil && claims.SymptomOnsetInterval > 0 {
 		onsetInterval = int32(claims.SymptomOnsetInterval)
 	}

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -544,11 +544,6 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		return nil, nil, fmt.Errorf(msg)
 	}
 
-	onsetInterval := inData.SymptomOnsetInterval
-	if claims != nil && claims.SymptomOnsetInterval > 0 {
-		onsetInterval = int32(claims.SymptomOnsetInterval)
-	}
-
 	defaultCreatedAt := TruncateWindow(batchTime, t.truncateWindow)
 	entities := make([]*Exposure, 0, len(inData.Keys))
 
@@ -562,6 +557,13 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		CreatedAt:             defaultCreatedAt,
 		ReleaseStillValidKeys: t.debugReleaseSameDay,
 		BatchWindow:           t.truncateWindow,
+	}
+
+	onsetInterval := inData.SymptomOnsetInterval
+	// If the symtom onset interval provided on publish is too old to be relevant
+	// and one was provided in the verificaiton certificate, take that one.
+	if onsetInterval < settings.MinStartInterval && claims != nil && claims.SymptomOnsetInterval > 0 {
+		onsetInterval = int32(claims.SymptomOnsetInterval)
 	}
 
 	// Regions are a multi-value property, uppercase them for storage.

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -766,6 +766,77 @@ func TestTransform(t *testing.T) {
 			},
 		},
 		{
+			Name: "user_provided_symptom_onset",
+			Publish: &verifyapi.Publish{
+				Keys: []verifyapi.ExposureKey{
+					{
+						Key:            encodeKey(testKeys[3]),
+						IntervalNumber: intervalNumber,
+						IntervalCount:  verifyapi.MaxIntervalCount,
+					},
+					{
+						Key:            encodeKey(testKeys[4]),
+						IntervalNumber: intervalNumber + verifyapi.MaxIntervalCount,
+						IntervalCount:  verifyapi.MaxIntervalCount,
+					},
+					{
+						Key:            encodeKey(testKeys[5]),
+						IntervalNumber: intervalNumber + 2*verifyapi.MaxIntervalCount,
+						IntervalCount:  verifyapi.MaxIntervalCount,
+					},
+				},
+				HealthAuthorityID:    appPackage,
+				SymptomOnsetInterval: int32(intervalNumber + 1*verifyapi.MaxIntervalCount),
+			},
+			Regions: wantRegions,
+			Claims: &verification.VerifiedClaims{
+				HealthAuthorityID:    27,
+				ReportType:           verifyapi.ReportTypeClinical,
+				SymptomOnsetInterval: uint32(intervalNumber + 2*verifyapi.MaxIntervalCount),
+			},
+			Want: []*Exposure{
+				{
+					ExposureKey:           testKeys[3],
+					IntervalNumber:        intervalNumber,
+					IntervalCount:         verifyapi.MaxIntervalCount,
+					TransmissionRisk:      verifyapi.TransmissionRiskClinical,
+					AppPackageName:        appPackage,
+					Regions:               wantRegions,
+					CreatedAt:             batchTimeRounded,
+					LocalProvenance:       true,
+					ReportType:            verifyapi.ReportTypeClinical,
+					DaysSinceSymptomOnset: int32Ptr(-1),
+					HealthAuthorityID:     int64Ptr(27),
+				},
+				{
+					ExposureKey:           testKeys[4],
+					IntervalNumber:        intervalNumber + verifyapi.MaxIntervalCount,
+					IntervalCount:         verifyapi.MaxIntervalCount,
+					TransmissionRisk:      verifyapi.TransmissionRiskClinical,
+					AppPackageName:        appPackage,
+					Regions:               wantRegions,
+					CreatedAt:             batchTimeRounded,
+					LocalProvenance:       true,
+					ReportType:            verifyapi.ReportTypeClinical,
+					DaysSinceSymptomOnset: int32Ptr(0),
+					HealthAuthorityID:     int64Ptr(27),
+				},
+				{
+					ExposureKey:           testKeys[5],
+					IntervalNumber:        intervalNumber + 2*verifyapi.MaxIntervalCount,
+					IntervalCount:         verifyapi.MaxIntervalCount,
+					TransmissionRisk:      verifyapi.TransmissionRiskClinical,
+					AppPackageName:        appPackage,
+					Regions:               wantRegions,
+					CreatedAt:             batchTimeRounded,
+					LocalProvenance:       true,
+					ReportType:            verifyapi.ReportTypeClinical,
+					DaysSinceSymptomOnset: int32Ptr(1),
+					HealthAuthorityID:     int64Ptr(27),
+				},
+			},
+		},
+		{
 			Name: "symptom_onset_too_large",
 			Publish: &verifyapi.Publish{
 				Keys: []verifyapi.ExposureKey{


### PR DESCRIPTION
Fixes #1102 

## Proposed Changes

* Change from preferring verification certificate symptom onset and prefer app provided one if it is reasonable

**Release Note**

```release-note
API Behavior Change :: SymptomOnsetInterval from the publish request will be used if present and valid even if the verification certificate contains a symptom onset date. This allows apps to ask users their symptom onset date as well.
```