### PR TITLE
Allow server to bind to addresses and ports

### DIFF
--- a/cmd/cleanup-export/main.go
+++ b/cmd/cleanup-export/main.go
@@ -68,7 +68,7 @@ func realMain(ctx context.Context) error {
 	mux.Handle("/", handler)
 	mux.Handle("/health", server.HandleHealthz(ctx))
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/cleanup-exposure/main.go
+++ b/cmd/cleanup-exposure/main.go
@@ -68,7 +68,7 @@ func realMain(ctx context.Context) error {
 	mux.Handle("/", handler)
 	mux.Handle("/health", server.HandleHealthz(ctx))
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -62,7 +62,7 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("export.NewServer: %w", err)
 	}
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/export-importer/main.go
+++ b/cmd/export-importer/main.go
@@ -62,7 +62,7 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("exportimport.NewServer: %w", err)
 	}
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -63,7 +63,7 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("export.NewServer: %w", err)
 	}
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -75,7 +75,7 @@ func realMain(ctx context.Context) error {
 		mux.Handle("/", handler.HandleV1Alpha1())
 	}
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/federationin/main.go
+++ b/cmd/federationin/main.go
@@ -65,7 +65,7 @@ func realMain(ctx context.Context) error {
 	mux.Handle("/", handler)
 	mux.Handle("/health", server.HandleHealthz(ctx))
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/federationout/main.go
+++ b/cmd/federationout/main.go
@@ -83,7 +83,7 @@ func realMain(ctx context.Context) error {
 	grpcServer := grpc.NewServer(sopts...)
 	federation.RegisterFederationServer(grpcServer, federationServer)
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -69,7 +69,7 @@ func realMain(ctx context.Context) error {
 	mux.Handle("/", handler)
 	mux.Handle("/health", server.HandleHealthz(ctx))
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/jwks-updater/main.go
+++ b/cmd/jwks-updater/main.go
@@ -63,7 +63,7 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("jwks.NewServer: %w", err)
 	}
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/key-rotation/main.go
+++ b/cmd/key-rotation/main.go
@@ -63,7 +63,7 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("keyrotation.NewServer: %w", err)
 	}
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/mirror/main.go
+++ b/cmd/mirror/main.go
@@ -62,7 +62,7 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("mirror.NewServer: %w", err)
 	}
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(":" + config.Port)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -224,7 +224,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	}
 	mux.Handle("/publish", publishHandler.Handle())
 
-	srv, err := server.New("")
+	srv, err := server.New(":0")
 	if err != nil {
 		tb.Fatal(err)
 	}


### PR DESCRIPTION
This is a **breaking change** to the server to allow specifying the bind address in address and port. 

It also fixes an issue when binding to the IPv4 or IPv6 loopback addresses, where the returned IP would be the anycast IP (0.0.0.0) instead of loopback (127.0.0.1).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Accept address _and_ port in `server.New()`
```