### PR TITLE
factor out generate regions, add traveler generate

### DIFF
--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	CreatedAtTruncateWindow      time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 	DefaultRegion                string        `env:"DEFAULT_REGION, default=US"`
 	ChanceOfKeyRevision          int           `env:"CHANCE_OF_KEY_REVISION, default=30"` // 0-100 are valid values.
+	ChanceOfTraveler             int           `env:"CHANCE_OF_TRAVELER, default=20"`     // 0-100 are valid values
 	KeyRevisionDelay             time.Duration `env:"KEY_REVISION_DELAY, default=2h"`     // key revision will be forward dates this amount.
 	UseDefaultSymptomOnset       bool          `env:"USE_DEFAULT_SYMPTOM_ONSET_DAYS, default=true"`
 	SymptomOnsetDays             uint          `env:"DEFAULT_SYMPTOM_ONSET_DAYS, default=10"`


### PR DESCRIPTION
## Proposed Changes

* Generate service will only put keys in 1 region, each region passed in will have distinct keys
* introduce random change of a key being assigned traveler status.

**Release Note**

```release-note
Generate service mirrors v1 API more closely now.
```