### PR TITLE
still mint revision token if one was provided before, but no new data

### DIFF
--- a/internal/revision/revision.go
+++ b/internal/revision/revision.go
@@ -214,7 +214,7 @@ func buildTokenBufer(previous *pb.RevisionTokenData, eKeys []*model.Exposure) *p
 // into an encrypted protocol buffer revision token.
 // This is using envelope encryption, based on the currently active revision key.
 func (tm *TokenManager) MakeRevisionToken(ctx context.Context, previous *pb.RevisionTokenData, eKeys []*model.Exposure, aad []byte) ([]byte, error) {
-	if len(eKeys) == 0 {
+	if len(eKeys) == 0 && len(previous.RevisableKeys) == 0 {
 		return nil, fmt.Errorf("no keys to build token for")
 	}
 


### PR DESCRIPTION
Fixes #1111

## Proposed Changes

* If a publish request doesn't have any new keys, still return the revision token if one was provided on the publish request.

**Release Note**


```release-note
BUG FIX: Revision tokens will still be returned if publish happens twice on the same day and a device is not releasing same day keys. This is unlikely to have any impact on production devices based on known usage patterns.
```