### PR TITLE
Fixed a spelling mistake

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,5 +55,5 @@ Key Server here:
 
 You can open a
 [GitHub Issue](https://github.com/google/exposure-notifications-server/issues/new).
-or reach out privately by emailing exposure-notifications-feedback@google.com.
+Or reach out privately by emailing exposure-notifications-feedback@google.com.
 Please include as much detail as you can to help in addressing your concern.


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* There was a spelling mistake in [this](https://github.com/google/exposure-notifications-server/blob/main/docs/index.md) file so I fixed it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```