### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/docs/design/verification_protocol.md
+++ b/docs/design/verification_protocol.md
@@ -81,7 +81,7 @@ Base64 encoded string property.
   server, if no transmission risk values are set, the report type is used to
   assign transmission risk for compatibility with older apps/clients.
   This is the __only__ way set reportType on TEKs is through a verification certificate.
-* `symptomOnsetInterval` : _OPTIONAL_ uses the same 10 minute interval timing as TEKs use. If an interval is provided that isn not the start of a UTC day, then it will be rounded down to the beginning of that UTC day. And from there the days +/- symptom onset will be calculated. Int property.
+* `symptomOnsetInterval` : _OPTIONAL_ uses the same 10 minute interval timing as TEKs use. If an interval is provided that is not the start of a UTC day, then it will be rounded down to the beginning of that UTC day. And from there the days +/- symptom onset will be calculated. Int property.
 
 Standard JWT headers must be provided.
 
@@ -114,7 +114,7 @@ key1.rp1.rpc1.tr1,key2.rp2.rpc2.tr2
 For newer clients that are not assigning transmission risk values, the 4th
 segment of the per-TEK segment can be omitted. If this is done, then a value
 of 0 (zero) must be passed on the publish request at the key server, or the
-transmission risk must be omitted entirerly. That would make the clear text
+transmission risk must be omitted entirely. That would make the clear text
 portion look like:
 
 ```

--- a/docs/getting-started/downloading-export-batches-keys.md
+++ b/docs/getting-started/downloading-export-batches-keys.md
@@ -4,7 +4,7 @@ layout: default
 
 # Temporary Exposure Key (TEK) Downloading via Batches
 
-This page explains how to retrieve publihsed temporary exposure keys (TEKs)
+This page explains how to retrieve published temporary exposure keys (TEKs)
 from the server by generating batches that can be downloaded by a mobile
 application. These batches are logical groupings of TEKs published to the
 server. Keys can be grouped by region and the frequency of batching is

--- a/docs/getting-started/publishing-temporary-exposure-keys.md
+++ b/docs/getting-started/publishing-temporary-exposure-keys.md
@@ -130,7 +130,7 @@ There are two bypass settings that can make development easier for your app deve
 * Health Authority Verification Disabled: Must be set to _false_ in production environments. Can
   be set to _true_ for testing
 
-_Health Authority Certifictes to Accept:_ Check the certificate you configured earlier. This allows
+_Health Authority Certificates to Accept:_ Check the certificate you configured earlier. This allows
 this health authority to trust verification certificates from that verification server.
 
 For more information on diagnosis verification, see:

--- a/internal/verification/phaverify.go
+++ b/internal/verification/phaverify.go
@@ -14,7 +14,7 @@
 
 // Package verification provides the ability to verify the diagnosis certificates
 // (JWTs) coming from public health authorities that are responsible for verifying
-// diagnosis pin codes and verifying the TEKs.
+// diagnosis pin codes and certifying the TEKs.
 package verification
 
 import (

--- a/internal/verification/phaverify.go
+++ b/internal/verification/phaverify.go
@@ -14,7 +14,7 @@
 
 // Package verification provides the ability to verify the diagnosis certificates
 // (JWTs) coming from public health authorities that are responsible for verifying
-// diagnosis pin codes and ceritfying the TEKs.
+// diagnosis pin codes and verifying the TEKs.
 package verification
 
 import (

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -14,7 +14,7 @@
 
 // Package verification provides the ability to verify the diagnosis certificates
 // (JWTs) coming from public health authorities that are responsible for verifying
-// diagnosis pin codes and verifying the TEKs.
+// diagnosis pin codes and certifying the TEKs.
 package verification
 
 import (

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -14,7 +14,7 @@
 
 // Package verification provides the ability to verify the diagnosis certificates
 // (JWTs) coming from public health authorities that are responsible for verifying
-// diagnosis pin codes and ceritfying the TEKs.
+// diagnosis pin codes and verifying the TEKs.
 package verification
 
 import (

--- a/pkg/api/v1/exposure_types.go
+++ b/pkg/api/v1/exposure_types.go
@@ -94,7 +94,7 @@ const (
 // Padding: random base64 encoded data to obscure the request size. The server will
 // not process this data in any way. The recommendation is that padding be
 // at least 1kb in size with a random jitter of at least 1kb. Maximum overall
-// request size is capped at 64kb for the serialzied JSON.
+// request size is capped at 64kb for the serialized JSON.
 //
 // Partial success: If at least one of the Keys passed in is valid, then the publish
 // request will accept those keys, return a response code of 200 (OK) AND also

--- a/pkg/api/v1alpha1/exposure_types.go
+++ b/pkg/api/v1alpha1/exposure_types.go
@@ -63,7 +63,7 @@ const (
 // Padding: random base64 encoded data to obscure the request size.
 // The recommendation is that padding be at least 1kb in size with a random
 // jitter of at least 1kb. Maximum overall request size is capped at 64kb for
-// the serialzied JSON.
+// the serialized JSON.
 //
 // The following fields are deprecated, but accepted for backwards-compatibility:
 // DeviceVerificationPayload: (attestation)

--- a/pkg/api/v1alpha1/verification_types.go
+++ b/pkg/api/v1alpha1/verification_types.go
@@ -53,7 +53,7 @@ const (
 )
 
 // TransmissionRiskVector is an additional set of claims that can be
-// included in the verification / certification for a diagnosis as received
+// included in the verification certificate for a diagnosis as received
 // from a trusted public health authority.
 // DEPRECATED - If received at a server, these values are ignored. Will be removed in v0.3
 type TransmissionRiskVector []TransmissionRiskOverride

--- a/pkg/api/v1alpha1/verification_types.go
+++ b/pkg/api/v1alpha1/verification_types.go
@@ -53,7 +53,7 @@ const (
 )
 
 // TransmissionRiskVector is an additional set of claims that can be
-// included in the verification certificatin for a diagnosis as received
+// included in the verification / certification for a diagnosis as received
 // from a trusted public health authority.
 // DEPRECATED - If received at a server, these values are ignored. Will be removed in v0.3
 type TransmissionRiskVector []TransmissionRiskOverride
@@ -61,7 +61,7 @@ type TransmissionRiskVector []TransmissionRiskOverride
 // Compile time check that TransmissionRiskVector implements the sort interface.
 var _ sort.Interface = TransmissionRiskVector{}
 
-// TransmissionRiskOverride is an indvidual transmission risk override.
+// TransmissionRiskOverride is an individual transmission risk override.
 type TransmissionRiskOverride struct {
 	TransmissionRisk     int   `json:"tr"`
 	SinceRollingInterval int32 `json:"sinceRollingInterval"`

--- a/pkg/api/v1alpha1/verification_types.go
+++ b/pkg/api/v1alpha1/verification_types.go
@@ -53,7 +53,7 @@ const (
 )
 
 // TransmissionRiskVector is an additional set of claims that can be
-// included in the verification certificate for a diagnosis as received
+// included in the verification / certificate for a diagnosis as received
 // from a trusted public health authority.
 // DEPRECATED - If received at a server, these values are ignored. Will be removed in v0.3
 type TransmissionRiskVector []TransmissionRiskOverride

--- a/pkg/api/v1alpha1/verification_types.go
+++ b/pkg/api/v1alpha1/verification_types.go
@@ -53,7 +53,7 @@ const (
 )
 
 // TransmissionRiskVector is an additional set of claims that can be
-// included in the verification / certificate for a diagnosis as received
+// included in the verification certificate for a diagnosis as received
 // from a trusted public health authority.
 // DEPRECATED - If received at a server, these values are ignored. Will be removed in v0.3
 type TransmissionRiskVector []TransmissionRiskOverride

--- a/pkg/keys/hashicorp_vault.go
+++ b/pkg/keys/hashicorp_vault.go
@@ -40,7 +40,7 @@ var _ crypto.Signer = (*HashiCorpVaultSigner)(nil)
 // HashiCorpVault implements the keys.KeyManager interface and can be used to
 // sign export files and encrypt/decrypt data.
 //
-// For encryption keys, when using valut, the keys must be created with
+// For encryption keys, when using value, the keys must be created with
 //   `derived=true`
 type HashiCorpVault struct {
 	client *vaultapi.Client

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -35,14 +35,14 @@ import (
 type KeyManager interface {
 	NewSigner(ctx context.Context, keyID string) (crypto.Signer, error)
 
-	// Encrypt wile enctypt a byte array along with accompaning Additional Authenticated Data (AAD).
+	// Encrypt will encrypt a byte array along with accompanying Additional Authenticated Data (AAD).
 	// The ability for AAD to be empty, depends on the implementation being used.
 	//
 	// Currently Google Cloud KMS, Hashicorp Vault and AWS KMS support AAD
 	// The Azure Key Vault implementation does not.
 	Encrypt(ctx context.Context, keyID string, plaintext []byte, aad []byte) ([]byte, error)
 
-	// Decrypt will descrypt a previously encrypted byte array along with accompaning Additional
+	// Decrypt will descrypt a previously encrypted byte array along with accompanying Additional
 	// Authenticated Data (AAD).
 	// If AAD was passed in on the encryption, the same AAD must be passed in to decrypt.
 	//

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -42,7 +42,7 @@ type KeyManager interface {
 	// The Azure Key Vault implementation does not.
 	Encrypt(ctx context.Context, keyID string, plaintext []byte, aad []byte) ([]byte, error)
 
-	// Decrypt will descrypt a previously encrypted byte array along with accompanying Additional
+	// Decrypt will decrypt a previously encrypted byte array along with accompanying Additional
 	// Authenticated Data (AAD).
 	// If AAD was passed in on the encryption, the same AAD must be passed in to decrypt.
 	//


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

There were typos in comments and docs so I decided to fix it.

**Release Note**

```release-note
NONE
```