### PR TITLE
write generated export padding to the database, ensure overlapping ex…

### DIFF
--- a/internal/database/lock.go
+++ b/internal/database/lock.go
@@ -52,9 +52,7 @@ func (db *DB) MultiLock(ctx context.Context, lockIDs []string, ttl time.Duration
 	var expires time.Time
 	err := db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
 		for _, lockID := range lockOrder {
-			row := tx.QueryRow(ctx, `
-			SELECT AcquireLock($1, $2)
-		`, lockID, int(ttl.Seconds()))
+			row := tx.QueryRow(ctx, `SELECT AcquireLock($1, $2)`, lockID, int(ttl.Seconds()))
 			if err := row.Scan(&expires); err != nil {
 				return err
 			}
@@ -76,9 +74,7 @@ func makeMultiUnlockFn(ctx context.Context, db *DB, lockIDs []string, expires ti
 		return db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
 			for i := len(lockIDs) - 1; i >= 0; i-- {
 				lockID := lockIDs[i]
-				row := tx.QueryRow(ctx, `
-				SELECT ReleaseLock($1, $2)
-			`, lockID, expires)
+				row := tx.QueryRow(ctx, `SELECT ReleaseLock($1, $2)`, lockID, expires)
 				var released bool
 				if err := row.Scan(&released); err != nil {
 					return err

--- a/internal/database/lock.go
+++ b/internal/database/lock.go
@@ -36,12 +36,16 @@ var (
 // UnlockFn can be deferred to release a lock.
 type UnlockFn func() error
 
+// MultiLock obtains multiple locks in a single transaction. Either all locks are obtained, or
+// the transaction is rolled back.
+// The lockIDs are sorted by normal ascending string sort order before obtaining the locks.
 func (db *DB) MultiLock(ctx context.Context, lockIDs []string, ttl time.Duration) (UnlockFn, error) {
 	if len(lockIDs) == 0 {
 		return nil, fmt.Errorf("no lockIDs presented")
 	}
 
 	lockOrder := make([]string, len(lockIDs))
+	// Make a copy of the slice so that we have a stable slice in the unlcok function.
 	copy(lockOrder, lockIDs)
 	sort.Strings(lockOrder)
 

--- a/internal/export/config.go
+++ b/internal/export/config.go
@@ -42,15 +42,16 @@ type Config struct {
 	Storage               storage.Config
 	ObservabilityExporter observability.Config
 
-	Port           string        `env:"PORT, default=8080"`
-	CreateTimeout  time.Duration `env:"CREATE_BATCHES_TIMEOUT, default=5m"`
-	WorkerTimeout  time.Duration `env:"WORKER_TIMEOUT, default=5m"`
-	MinRecords     int           `env:"EXPORT_FILE_MIN_RECORDS, default=1000"`
-	PaddingRange   int           `env:"EXPORT_FILE_PADDING_RANGE, default=100"`
-	MaxRecords     int           `env:"EXPORT_FILE_MAX_RECORDS, default=30000"`
-	TruncateWindow time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
-	MinWindowAge   time.Duration `env:"MIN_WINDOW_AGE, default=2h"`
-	TTL            time.Duration `env:"CLEANUP_TTL, default=336h"`
+	Port               string        `env:"PORT, default=8080"`
+	CreateTimeout      time.Duration `env:"CREATE_BATCHES_TIMEOUT, default=5m"`
+	WorkerTimeout      time.Duration `env:"WORKER_TIMEOUT, default=5m"`
+	MinRecords         int           `env:"EXPORT_FILE_MIN_RECORDS, default=1000"`
+	PaddingRange       int           `env:"EXPORT_FILE_PADDING_RANGE, default=100"`
+	MaxRecords         int           `env:"EXPORT_FILE_MAX_RECORDS, default=30000"`
+	MaxInsertBatchSize int           `env:"MAX_INSERT_BATCH_SIZE, default=100"`
+	TruncateWindow     time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
+	MinWindowAge       time.Duration `env:"MIN_WINDOW_AGE, default=2h"`
+	TTL                time.Duration `env:"CLEANUP_TTL, default=336h"`
 }
 
 func (c *Config) BlobstoreConfig() *storage.Config {

--- a/internal/export/worker_test.go
+++ b/internal/export/worker_test.go
@@ -15,11 +15,17 @@
 package export
 
 import (
+	"context"
 	"testing"
+	"time"
 
-	"github.com/google/exposure-notifications-server/internal/publish/model"
+	"github.com/google/exposure-notifications-server/internal/database"
+	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
+	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
+	"github.com/google/exposure-notifications-server/internal/serverenv"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 	"github.com/google/exposure-notifications-server/pkg/util"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -47,19 +53,22 @@ func TestRandomInt(t *testing.T) {
 }
 
 func TestDoNotPadZeroLength(t *testing.T) {
-	exposures := make([]*model.Exposure, 0)
-	exposures, err := ensureMinNumExposures(exposures, "US", 1000, 100)
+	exposures := make([]*publishmodel.Exposure, 0)
+	exposures, generated, err := ensureMinNumExposures(exposures, "US", 1000, 100, time.Now())
 	if err != nil {
 		t.Fatalf("unepected error: %v", err)
 	}
 	if len(exposures) != 0 {
 		t.Errorf("empty exposure list got padded, shouldn't have.")
 	}
+	if len(generated) != 0 {
+		t.Errorf("generated data returned, should be empty")
+	}
 }
 
 func TestEnsureMinExposures(t *testing.T) {
 	// Insert a few exposures - that will be used to base the interval information off of.
-	exposures := []*model.Exposure{
+	exposures := []*publishmodel.Exposure{
 		{
 			TransmissionRisk:      verifyapi.TransmissionRiskConfirmedStandard,
 			IntervalNumber:        123456,
@@ -99,12 +108,16 @@ func TestEnsureMinExposures(t *testing.T) {
 	m[123456+144] = 1
 
 	// pad the download.
-	exposures, err := ensureMinNumExposures(exposures, "US", numKeys, variance)
+	inputSize := len(exposures)
+	exposures, generated, err := ensureMinNumExposures(exposures, "US", numKeys, variance, time.Now())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(exposures) < numKeys || len(exposures) > numKeys+variance {
 		t.Errorf("wrong number of exposures, want: >=%v and <=%v, got: %v", numKeys, numKeys+variance, len(exposures))
+	}
+	if l, exp := len(generated), numKeys-inputSize; l < exp {
+		t.Errorf("want keys >= %d, got: %d", exp, l)
 	}
 
 	for _, e := range exposures {
@@ -113,6 +126,206 @@ func TestEnsureMinExposures(t *testing.T) {
 	for k, v := range m {
 		if v < 20 {
 			t.Errorf("distribution not random, expected >= 30 keys with start interval %v, got %v", k, v)
+		}
+	}
+}
+
+func getKey(t *testing.T) []byte {
+	t.Helper()
+	eKey, err := util.RandomBytes(verifyapi.KeyLength)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return eKey
+}
+
+func TestBatchExposures(t *testing.T) {
+	t.Parallel()
+
+	testDB := database.NewTestDatabase(t)
+	testPublishDB := publishdb.New(testDB)
+	ctx := context.Background()
+
+	config := Config{
+		MinRecords:         5,
+		PaddingRange:       0,
+		TruncateWindow:     time.Hour,
+		MaxInsertBatchSize: 100,
+	}
+	server := Server{
+		config: &config,
+		env:    serverenv.New(ctx, serverenv.WithDatabase(testDB)),
+	}
+
+	// Using a 1 hour truncate window
+	// * one export batch lineage w/ 1 hour window
+	// * one export batch wiuth 4 hour window
+	baseTime := time.Date(2020, 10, 28, 1, 0, 0, 0, time.UTC).Truncate(time.Hour)
+	exposures := make([]*publishmodel.Exposure, 12)
+	for i := 0; i < 4; i++ {
+		// home country non-traveler
+		exposures[i*3] = &publishmodel.Exposure{
+			ExposureKey:     getKey(t),
+			Regions:         []string{"US"},
+			IntervalNumber:  100,
+			IntervalCount:   144,
+			CreatedAt:       baseTime.Add(time.Duration(i) * time.Hour),
+			LocalProvenance: true,
+			Traveler:        false,
+		}
+		// foreign country traveler
+		exposures[i*3+1] = &publishmodel.Exposure{
+			ExposureKey:     getKey(t),
+			Regions:         []string{"CA"},
+			IntervalNumber:  100,
+			IntervalCount:   144,
+			CreatedAt:       baseTime.Add(time.Duration(i) * time.Hour),
+			LocalProvenance: false,
+			Traveler:        true,
+		}
+		// foreign country non-traveler
+		exposures[i*3+2] = &publishmodel.Exposure{
+			ExposureKey:     getKey(t),
+			Regions:         []string{"CA"},
+			IntervalNumber:  100,
+			IntervalCount:   144,
+			CreatedAt:       baseTime.Add(time.Duration(i) * time.Hour),
+			LocalProvenance: false,
+			Traveler:        false,
+		}
+	}
+	if _, err := testPublishDB.InsertAndReviseExposures(ctx, &publishdb.InsertAndReviseExposuresRequest{
+		Incoming:     exposures,
+		RequireToken: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	homePlusTraveler := make(map[string]struct{})
+	// Create the home country + traveler exports. 4, 1 per hour.
+	for i := 0; i < 4; i++ {
+		// Build the iteration criteria for the incremental batches.
+		criteria := publishdb.IterateExposuresCriteria{
+			SinceTimestamp:      baseTime.Add(time.Duration(i) * time.Hour),
+			UntilTimestamp:      baseTime.Add(time.Duration(i) * time.Hour).Add(time.Hour),
+			IncludeRegions:      []string{"US"},
+			IncludeTravelers:    true,
+			OnlyLocalProvenance: true,
+		}
+
+		groups, err := server.batchExposures(ctx, criteria, "US")
+		if err != nil {
+			t.Fatalf("failed to read exposures: %v", err)
+		}
+		if len(groups) == 0 {
+			t.Fatalf("export batch should have found some keys")
+		}
+
+		for _, group := range groups {
+			for _, exp := range group.exposures {
+				b64 := exp.ExposureKeyBase64()
+				if _, ok := homePlusTraveler[b64]; ok {
+					t.Fatalf("hourly batch included duplicate key")
+				}
+				homePlusTraveler[b64] = struct{}{}
+			}
+		}
+	}
+
+	foreignNonTraveler := make(map[string]struct{})
+	// Create the foreign, non traveler export.
+	for i := 0; i < 4; i++ {
+		// Build the iteration criteria for the incremental batches.
+		criteria := publishdb.IterateExposuresCriteria{
+			SinceTimestamp:      baseTime.Add(time.Duration(i) * time.Hour),
+			UntilTimestamp:      baseTime.Add(time.Duration(i) * time.Hour).Add(time.Hour),
+			IncludeRegions:      []string{"CA"}, // current list of foreign countries
+			OnlyNonTravelers:    true,
+			OnlyLocalProvenance: false,
+		}
+
+		groups, err := server.batchExposures(ctx, criteria, "REMOTE")
+		if err != nil {
+			t.Fatalf("failed to read exposures: %v", err)
+		}
+		if len(groups) == 0 {
+			t.Fatalf("export batch should have found some keys")
+		}
+
+		for _, group := range groups {
+			for _, exp := range group.exposures {
+				b64 := exp.ExposureKeyBase64()
+				if _, ok := foreignNonTraveler[b64]; ok {
+					t.Fatalf("hourly batch included duplicate key")
+				}
+				foreignNonTraveler[b64] = struct{}{}
+			}
+		}
+	}
+
+	// Run the 4 hour export for home+traveler
+	{
+		criteria := publishdb.IterateExposuresCriteria{
+			SinceTimestamp:      baseTime,
+			UntilTimestamp:      baseTime.Add(4 * time.Hour),
+			IncludeRegions:      []string{"US"},
+			IncludeTravelers:    true,
+			OnlyLocalProvenance: true,
+		}
+		groups, err := server.batchExposures(ctx, criteria, "US")
+		if err != nil {
+			t.Fatalf("failed to read exposures: %v", err)
+		}
+		if len(groups) == 0 {
+			t.Fatalf("export batch should have keys")
+		}
+
+		homePlusTravelerRollup := make(map[string]struct{})
+		for _, group := range groups {
+			for _, exp := range group.exposures {
+				b64 := exp.ExposureKeyBase64()
+				if _, ok := homePlusTravelerRollup[b64]; ok {
+					t.Fatalf("home rollup included duplicate key")
+				}
+				homePlusTravelerRollup[b64] = struct{}{}
+			}
+		}
+
+		if diff := cmp.Diff(homePlusTraveler, homePlusTravelerRollup); diff != "" {
+			t.Errorf("ReadExposures mismatch (-want, +got):\n%s", diff)
+		}
+	}
+
+	// Run the 4 hour foreign, non-traveler
+	{
+		criteria := publishdb.IterateExposuresCriteria{
+			SinceTimestamp:      baseTime,
+			UntilTimestamp:      baseTime.Add(4 * time.Hour),
+			IncludeRegions:      []string{"CA"}, // current list of foreign countries
+			OnlyNonTravelers:    true,
+			OnlyLocalProvenance: false,
+		}
+		groups, err := server.batchExposures(ctx, criteria, "REMOTE")
+		if err != nil {
+			t.Fatalf("failed to read exposures: %v", err)
+		}
+		if len(groups) == 0 {
+			t.Fatalf("export batch should have keys")
+		}
+
+		foreignNonTravelerRollup := make(map[string]struct{})
+		for _, group := range groups {
+			for _, exp := range group.exposures {
+				b64 := exp.ExposureKeyBase64()
+				if _, ok := foreignNonTravelerRollup[b64]; ok {
+					t.Fatalf("home rollup included duplicate key")
+				}
+				foreignNonTravelerRollup[b64] = struct{}{}
+			}
+		}
+
+		if diff := cmp.Diff(foreignNonTraveler, foreignNonTravelerRollup); diff != "" {
+			t.Errorf("ReadExposures mismatch (-want, +got):\n%s", diff)
 		}
 	}
 }

--- a/internal/pb/federation/federation.pb.go
+++ b/internal/pb/federation/federation.pb.go
@@ -116,8 +116,7 @@ type FederationFetchRequest struct {
 	MaxExposureKeys uint32 `protobuf:"varint,5,opt,name=maxExposureKeys,proto3" json:"maxExposureKeys,omitempty"`
 	// region, includeTravelers, onlyTravelers must be stable to send a fetchToken.
 	// initial query should send an empty fetch state token.
-	State            *FetchState `protobuf:"bytes,6,opt,name=state,proto3" json:"state,omitempty"`
-	OnlyNonTravelers bool        `protobuf:"varint,7,opt,name=onlyNonTravelers,proto3" json:"onlyNonTravelers,omitempty"`
+	State *FetchState `protobuf:"bytes,6,opt,name=state,proto3" json:"state,omitempty"`
 }
 
 func (x *FederationFetchRequest) Reset() {


### PR DESCRIPTION
…ports contain same data

## Proposed Changes

* Ensures that exports with overlapping time periods contain the same generated data by persisting the data to the database
* Obtain a lock over export regions when creating exports, all region locks are required, and they are sorted and obtained in order
* Batches are attempted to be processed in an order such that padding for earlier batches should be generated and thus included in later batches

**Release Note**

```release-note
Export padding is persisted to the database to ensure stability over time.
```