### PR TITLE
certificate verification improvements

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -81,6 +81,9 @@ type Config struct {
 	// Should only be set if a server is being operated in a single region.
 	DefaultRegion string `env:"DEFAULT_REGION"`
 
+	// Feature flags - eventually these are removed as features become default behaviour
+	FailOnCertificateAudienceMismatch bool `env:"FEATURE_FAIL_ON_CERTIFICATE_AUDIENCE_MISMATCH, default=false"`
+
 	// Flags for local development and testing. This will cause still valid keys
 	// to not be embargoed.
 	// Normally "still valid" keys can be accepted, but are embargoed.

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -81,7 +81,7 @@ type Config struct {
 	// Should only be set if a server is being operated in a single region.
 	DefaultRegion string `env:"DEFAULT_REGION"`
 
-	// Feature flags - eventually these are removed as features become default behaviour
+	// Feature flags - eventually these are removed as features become default behavior
 	FailOnCertificateAudienceMismatch bool `env:"FEATURE_FAIL_ON_CERTIFICATE_AUDIENCE_MISMATCH, default=false"`
 
 	// Flags for local development and testing. This will cause still valid keys

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -277,7 +277,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 	}
 
 	// Perform health authority certificate verification.
-	verifiedClaims, err := h.verifier.VerifyDiagnosisCertificate(ctx, appConfig, data)
+	verifiedClaims, err := h.verifier.VerifyDiagnosisCertificate(ctx, appConfig, data, h.config.FailOnCertificateAudienceMismatch)
 	if err != nil {
 		if appConfig.BypassHealthAuthorityVerification {
 			logger.Warnf("bypassing health authority certificate verification health authority: %v", appConfig.AppPackageName)

--- a/internal/verification/database/health_authority_db.go
+++ b/internal/verification/database/health_authority_db.go
@@ -27,6 +27,10 @@ import (
 	pgx "github.com/jackc/pgx/v4"
 )
 
+var (
+	ErrHealthAuthorityNotFound = errors.New("health authority not found")
+)
+
 // HealthAuthorityDB allows for opreations against authorized health authorities
 // for diagnosis signature verification.
 type HealthAuthorityDB struct {
@@ -141,10 +145,13 @@ func (db *HealthAuthorityDB) GetHealthAuthority(ctx context.Context, issuer stri
 		var err error
 		ha, err = scanOneHealthAuthority(row)
 		if err != nil {
-			return fmt.Errorf("failed to parse: %w", err)
+			return err
 		}
 		return nil
 	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrHealthAuthorityNotFound
+		}
 		return nil, fmt.Errorf("get health authority: %w", err)
 	}
 

--- a/internal/verification/database/health_authority_db_test.go
+++ b/internal/verification/database/health_authority_db_test.go
@@ -47,7 +47,6 @@ func TestMissingHealthAuthority(t *testing.T) {
 	if !errors.Is(err, ErrHealthAuthorityNotFound) {
 		t.Fatalf("wrong error want: %v got: %v", ErrHealthAuthorityNotFound, err)
 	}
-
 }
 
 func TestAddRetrieveHealthAuthority(t *testing.T) {

--- a/internal/verification/database/health_authority_db_test.go
+++ b/internal/verification/database/health_authority_db_test.go
@@ -16,6 +16,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -31,6 +32,23 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEA+k9YktDK3UpOhBIy+O17biuwd/g
 IBSEEHOdgpAynz0yrHpkWL6vxjNHxRdWcImZxPgL0NVHMdY4TlsL7qaxBQ==
 -----END PUBLIC KEY-----`
 )
+
+func TestMissingHealthAuthority(t *testing.T) {
+	t.Parallel()
+
+	testDB := database.NewTestDatabase(t)
+	haDB := New(testDB)
+	ctx := context.Background()
+
+	_, err := haDB.GetHealthAuthority(ctx, "does-not-exist")
+	if err == nil {
+		t.Fatal("missing error")
+	}
+	if !errors.Is(err, ErrHealthAuthorityNotFound) {
+		t.Fatalf("wrong error want: %v got: %v", ErrHealthAuthorityNotFound, err)
+	}
+
+}
 
 func TestAddRetrieveHealthAuthority(t *testing.T) {
 	t.Parallel()

--- a/internal/verification/phaverify.go
+++ b/internal/verification/phaverify.go
@@ -61,7 +61,7 @@ type VerifiedClaims struct {
 // VerifyDiagnosisCertificate accepts a publish request (from which is extracts the JWT),
 // fully verifies the JWT and signture against what the passed in authorrized app is allowed
 // to use. Returns any transmission risk overrides if they are present.
-func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamodel.AuthorizedApp, publish *verifyapi.Publish) (*VerifiedClaims, error) {
+func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamodel.AuthorizedApp, publish *verifyapi.Publish, enforceAudienceMatch bool) (*VerifiedClaims, error) {
 	logger := logging.FromContext(ctx)
 	// These get assigned during the ParseWithClaims closure.
 	var healthAuthorityID int64
@@ -110,9 +110,12 @@ func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamo
 
 		// Advisory check the aud.
 		if claims.Audience != ha.Audience {
+			// TODO(mikehelmick) - clean up feature flag casing.
 			logger.Errorw("certifice audience mismatch - will be a failure in the next release", "claims.Aud", claims.Audience, "allowed", ha.Audience, "iss", ha.Issuer)
-			// Hard error will start in next release.
-			// return nil, fmt.Errorf("audience mismatch for issuer: %v", ha.Issuer)
+			if enforceAudienceMatch {
+				// This flag guarding will be removed in a future release.
+				return nil, fmt.Errorf("audience mismatch for issuer: %v", ha.Issuer)
+			}
 		}
 
 		// Find a key version.

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -53,6 +53,7 @@ func TestVerifyCertificate(t *testing.T) {
 		MacKeyAdjustment string
 		ChangeIssuer     string
 		ChangeAudience   string
+		EnforceAudience  bool // TODO(mikehelmick) Remove when removing feature flag
 		Error            string
 	}{
 		{
@@ -64,10 +65,15 @@ func TestVerifyCertificate(t *testing.T) {
 			Error:        "issuer not found",
 		},
 		{
-			Name:           "bad_audience",
-			ChangeAudience: "bar",
-			// Currently a warning, hard error will start in next release.
-			// Error:          "audience mismatch for issuer",
+			Name:            "bad_audience_off",
+			ChangeAudience:  "bar",
+			EnforceAudience: false,
+		},
+		{
+			Name:            "bad_audience",
+			ChangeAudience:  "bar",
+			Error:           "audience mismatch for issuer",
+			EnforceAudience: true,
 		},
 		{
 			Name:  "past",
@@ -249,7 +255,7 @@ func TestVerifyCertificate(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish)
+					verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish, tc.EnforceAudience)
 					if err != nil {
 						if tc.Error == "" {
 							t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Fixes #1121

## Proposed Changes

* Cache not found issuers the same as found issuers
* Give an advisory warning for mismatched audience fields
* Prep for next release where audience fields are missing
* also, considerably speeds up the pha verify tests by reusing the database for all test cases

**Release Note**

```release-note
ATTENTION SERVER OPERATORS:
This release will print ERROR level log messages if there are verification certificates where the issuer matches, but the audience field does not match. In the next release these mismatches will be hard failures. If you find a mismatch, work with your verification server operators to resolve any issues before deploying the release after this one.
```