### PR TITLE
Update observability exporter to use a new ctx.

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -172,7 +172,7 @@ func SetupWith(ctx context.Context, config interface{}, l envconfig.Lookuper) (*
 		logger.Info("configuring observability exporter")
 
 		oeConfig := provider.ObservabilityExporterConfig()
-		oe, err := observability.NewFromEnv(ctx, oeConfig)
+		oe, err := observability.NewFromEnv(oeConfig)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create observability provider: %v", err)
 		}

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -67,8 +67,8 @@ type Exporter interface {
 // if it failed to be created.
 func NewFromEnv(config *Config) (Exporter, error) {
 	// Create a separate ctx.
-	// The main ctx will be cancelled when the server is shutting down, prevent
-	// the last batch of the metrics to be uploaded.
+	// The main ctx will be cancelled when the server is shutting down. Sharing
+	// the main ctx prevent the last batch of the metrics to be uploaded.
 	ctx := context.Background()
 	switch config.ExporterType {
 	case ExporterNoop:

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -65,7 +65,11 @@ type Exporter interface {
 
 // NewFromEnv returns the observability exporter given the provided configuration, or an error
 // if it failed to be created.
-func NewFromEnv(ctx context.Context, config *Config) (Exporter, error) {
+func NewFromEnv(config *Config) (Exporter, error) {
+	// Create a separate ctx.
+	// The main ctx will be cancelled when the server is shutting down, prevent
+	// the last batch of the metrics to be uploaded.
+	ctx := context.Background()
 	switch config.ExporterType {
 	case ExporterNoop:
 		return NewNoop(ctx)

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -67,7 +67,7 @@ type Exporter interface {
 // if it failed to be created.
 func NewFromEnv(config *Config) (Exporter, error) {
 	// Create a separate ctx.
-	// The main ctx will be cancelled when the server is shutting down. Sharing
+	// The main ctx will be canceled when the server is shutting down. Sharing
 	// the main ctx prevent the last batch of the metrics to be uploaded.
 	ctx := context.Background()
 	switch config.ExporterType {


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/912