### PR TITLE
change default to fail on audience mismatch

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -82,7 +82,7 @@ type Config struct {
 	DefaultRegion string `env:"DEFAULT_REGION"`
 
 	// Feature flags - eventually these are removed as features become default behavior
-	FailOnCertificateAudienceMismatch bool `env:"FEATURE_FAIL_ON_CERTIFICATE_AUDIENCE_MISMATCH, default=false"`
+	FailOnCertificateAudienceMismatch bool `env:"FEATURE_FAIL_ON_CERTIFICATE_AUDIENCE_MISMATCH, default=true"`
 
 	// Flags for local development and testing. This will cause still valid keys
 	// to not be embargoed.


### PR DESCRIPTION
Fixes #1126 

## Proposed Changes

* `FEATURE_FAIL_ON_CERTIFICATE_AUDIENCE_MISMATCH`  set to true by default

**Release Note**

```release-note
ATTENTION SERVER OPERATORS:
This changes verification certificate enforcement to require an exact match on the AUD field. Servers running v0.15.1 will see advisory ERROR log messages indicating a mismatch. Please address these errors with your verification server operating partners before upgrading to v0.16.0
```

