### PR TITLE
Get the keys from the DB while handling a HA JWKS update.

### DIFF
--- a/pkg/jwks/jwks.go
+++ b/pkg/jwks/jwks.go
@@ -191,6 +191,13 @@ func (mgr *Manager) updateHA(ctx context.Context, ha *model.HealthAuthority) err
 	// Create the hadb once to save allocations
 	haDB := hadb.New(mgr.db)
 
+	// Get the keys for the health authority
+	if keys, err := haDB.GetHealthAuthorityKeys(ctx, ha); err != nil {
+		return fmt.Errorf("error getting keys: %v", err)
+	} else {
+		ha.Keys = keys
+	}
+
 	resp, err := mgr.getKeys(ctx, ha)
 	if err != nil {
 		return err

--- a/pkg/jwks/jwks_test.go
+++ b/pkg/jwks/jwks_test.go
@@ -175,7 +175,8 @@ func TestUpdateHA(t *testing.T) {
 
 			// Add the HealthAuthority & Keys to the DB. Note, we need to remove all
 			// keys from the testing HealthAuthority before adding it to the DB as it's
-			// checked for empty.
+			// checked for empty. Also the function we're calling below (updateHA)
+			// expects the keys to be empty in the HealthAuthority.
 			var keys []*model.HealthAuthorityKey
 			keys, test.ha.Keys = test.ha.Keys, nil
 			haDB := hadb.New(mgr.db)
@@ -188,7 +189,6 @@ func TestUpdateHA(t *testing.T) {
 					t.Fatalf("[%d] error adding key: %v", i, err)
 				}
 			}
-			test.ha.Keys = keys
 
 			// Now, run the whole flow for a HealthAuthority.
 			if err := mgr.updateHA(ctx, &test.ha); err != nil {


### PR DESCRIPTION

Fixes #1129

