### PR TITLE
adjust symptom onset handling

### DIFF
--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -45,7 +45,8 @@ type Config struct {
 	MaxSameStartIntervalKeys     uint          `env:"MAX_SAME_START_INTERVAL_KEYS, default=2"`
 	SimulateSameDayRelease       bool          `env:"SIMULATE_SAME_DAY_RELEASE, default=false"`
 	MaxIntervalAge               time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
-	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=21"`
+	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=14"`
+	MaxSypmtomOnsetReportDays    uint          `env:"MAX_VALID_SYMPOTOM_ONSET_REPORT_DAYS, default=28"`
 	CreatedAtTruncateWindow      time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 	DefaultRegion                string        `env:"DEFAULT_REGION, default=US"`
 	ChanceOfKeyRevision          int           `env:"CHANCE_OF_KEY_REVISION, default=30"` // 0-100 are valid values.
@@ -73,6 +74,10 @@ func (c *Config) TruncateWindow() time.Duration {
 
 func (c *Config) MaxSymptomOnsetDays() uint {
 	return c.MaxMagnitudeSymptomOnsetDays
+}
+
+func (c *Config) MaxValidSymptomOnsetReportDays() uint {
+	return c.MaxSypmtomOnsetReportDays
 }
 
 func (c *Config) UseDefaultSymptomOnsetDays() bool {

--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -52,8 +52,7 @@ type Config struct {
 	ChanceOfKeyRevision          int           `env:"CHANCE_OF_KEY_REVISION, default=30"` // 0-100 are valid values.
 	ChanceOfTraveler             int           `env:"CHANCE_OF_TRAVELER, default=20"`     // 0-100 are valid values
 	KeyRevisionDelay             time.Duration `env:"KEY_REVISION_DELAY, default=2h"`     // key revision will be forward dates this amount.
-	UseDefaultSymptomOnset       bool          `env:"USE_DEFAULT_SYMPTOM_ONSET_DAYS, default=true"`
-	SymptomOnsetDays             uint          `env:"DEFAULT_SYMPTOM_ONSET_DAYS, default=10"`
+	SymptomOnsetDaysAgo          uint          `env:"DEFAULT_SYMPTOM_ONSET_DAYS_AGO, default=4"`
 }
 
 func (c *Config) MaxExposureKeys() uint {
@@ -80,12 +79,8 @@ func (c *Config) MaxValidSymptomOnsetReportDays() uint {
 	return c.MaxSypmtomOnsetReportDays
 }
 
-func (c *Config) UseDefaultSymptomOnsetDays() bool {
-	return c.UseDefaultSymptomOnset
-}
-
-func (c *Config) DefaultSymptomOnsetDays() int32 {
-	return int32(c.SymptomOnsetDays)
+func (c *Config) DefaultSymptomOnsetDaysAgo() uint {
+	return c.SymptomOnsetDaysAgo
 }
 
 func (c *Config) DebugReleaseSameDayKeys() bool {

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -215,7 +215,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	publishConfig.MaxKeysOnPublish = 15
 	publishConfig.MaxSameStartIntervalKeys = 2
 	publishConfig.MaxIntervalAge = 360 * time.Hour
-	publishConfig.CreatedAtTruncateWindow = 1 * time.Second
+	publishConfig.CreatedAtTruncateWindow = time.Second
 	publishConfig.ReleaseSameDayKeys = true
 	publishConfig.RevisionKeyCacheDuration = time.Second
 

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -218,7 +218,6 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	publishConfig.CreatedAtTruncateWindow = 1 * time.Second
 	publishConfig.ReleaseSameDayKeys = true
 	publishConfig.RevisionKeyCacheDuration = time.Second
-	publishConfig.UseDefaultSymptomOnset = false
 
 	publishHandler, err := publish.NewHandler(ctx, &publishConfig, env)
 	if err != nil {

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -207,18 +207,20 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	}
 	mux.Handle("/key-rotation/", http.StripPrefix("/key-rotation", rotationServer.Routes(ctx)))
 
-	// Publish
-	publishConfig := &publish.Config{
-		RevisionToken:            revConfig,
-		MaxKeysOnPublish:         15,
-		MaxSameStartIntervalKeys: 2,
-		MaxIntervalAge:           360 * time.Hour,
-		CreatedAtTruncateWindow:  1 * time.Second,
-		ReleaseSameDayKeys:       true,
-		RevisionKeyCacheDuration: time.Second,
-	}
+	// Parse the config to load default values.
+	publishConfig := publish.Config{}
+	envconfig.ProcessWith(ctx, &publishConfig, envconfig.OsLookuper())
+	// Make overrides.
+	publishConfig.RevisionToken = revConfig
+	publishConfig.MaxKeysOnPublish = 15
+	publishConfig.MaxSameStartIntervalKeys = 2
+	publishConfig.MaxIntervalAge = 360 * time.Hour
+	publishConfig.CreatedAtTruncateWindow = 1 * time.Second
+	publishConfig.ReleaseSameDayKeys = true
+	publishConfig.RevisionKeyCacheDuration = time.Second
+	publishConfig.UseDefaultSymptomOnset = false
 
-	publishHandler, err := publish.NewHandler(ctx, publishConfig, env)
+	publishHandler, err := publish.NewHandler(ctx, &publishConfig, env)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -427,8 +427,7 @@ func exportedKeysFrom(tb testing.TB, keys []verifyapi.ExposureKey) []*export.Tem
 			KeyData:                    decoded,
 			TransmissionRiskLevel:      proto.Int32(int32(key.TransmissionRisk)),
 			RollingStartIntervalNumber: proto.Int32(key.IntervalNumber),
-			ReportType:                 export.TemporaryExposureKey_CONFIRMED_TEST.Enum(),
-		}
+			ReportType:                 export.TemporaryExposureKey_CONFIRMED_TEST.Enum()}
 	}
 
 	sortTEKs(s)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -417,6 +417,9 @@ func getExposures(db *database.DB, criteria publishdb.IterateExposuresCriteria) 
 // output).
 func exportedKeysFrom(tb testing.TB, keys []verifyapi.ExposureKey) []*export.TemporaryExposureKey {
 	s := make([]*export.TemporaryExposureKey, len(keys))
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].IntervalNumber >= keys[j].IntervalNumber
+	})
 	for i, key := range keys {
 		decoded, err := base64util.DecodeString(key.Key)
 		if err != nil {
@@ -427,7 +430,10 @@ func exportedKeysFrom(tb testing.TB, keys []verifyapi.ExposureKey) []*export.Tem
 			KeyData:                    decoded,
 			TransmissionRiskLevel:      proto.Int32(int32(key.TransmissionRisk)),
 			RollingStartIntervalNumber: proto.Int32(key.IntervalNumber),
-			ReportType:                 export.TemporaryExposureKey_CONFIRMED_TEST.Enum()}
+			ReportType:                 export.TemporaryExposureKey_CONFIRMED_TEST.Enum(),
+			// Keys are generated 1 day ago and then -1 day for each additional.
+			DaysSinceOnsetOfSymptoms: proto.Int32(int32(3 - i)),
+		}
 	}
 
 	sortTEKs(s)

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -65,10 +65,9 @@ type Config struct {
 	// that range would be subject to the default symptom onset flags (see below).
 	MaxSypmtomOnsetReportDays uint `env:"MAX_VALID_SYMPOTOM_ONSET_REPORT_DAYS, default=28"`
 
-	// If set, TEKs that arrive without a days since symptom onset (i.e. no symptom onset date)
-	// will be set to the default symptom onset days.
-	UseDefaultSymptomOnset bool `env:"USE_DEFAULT_SYMPTOM_ONSET_DAYS, default=true"`
-	SymptomOnsetDays       uint `env:"DEFAULT_SYMPTOM_ONSET_DAYS, default=10"`
+	// TEKs that arrive without a days since symptom onset (i.e. no symptom onset date),
+	// then the upload date minus DEFAULT_SYMPTOM_ONSET_DAYS_AGO is used.
+	SymptomOnsetDaysAgo uint `env:"DEFAULT_SYMPTOM_ONSET_DAYS_AGO, default=4"`
 
 	ResponsePaddingMinBytes int64 `env:"RESPONSE_PADDING_MIN_BYTES, default=1024"`
 	ResponsePaddingRange    int64 `env:"RESPONSE_PADDING_RANGE, default=1024"`
@@ -139,12 +138,8 @@ func (c *Config) MaxValidSymptomOnsetReportDays() uint {
 	return c.MaxSypmtomOnsetReportDays
 }
 
-func (c *Config) UseDefaultSymptomOnsetDays() bool {
-	return c.UseDefaultSymptomOnset
-}
-
-func (c *Config) DefaultSymptomOnsetDays() int32 {
-	return int32(c.SymptomOnsetDays)
+func (c *Config) DefaultSymptomOnsetDaysAgo() uint {
+	return c.SymptomOnsetDaysAgo
 }
 
 func (c *Config) DebugReleaseSameDayKeys() bool {

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -560,8 +560,9 @@ func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Pu
 		BatchWindow:           t.truncateWindow,
 	}
 
-	// For validating the
+	// For validating key timing information, can't be newer than now.
 	currentInterval := IntervalNumber(batchTime)
+	// For validating the passed in symptom interval, relative to current time.
 	minSymptomInterval := IntervalNumber(
 		timeutils.UTCMidnight(timeutils.SubtractDays(batchTime, t.maxValidSymptomOnsetReportDays)))
 

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -94,6 +94,10 @@ func NewHandler(ctx context.Context, config *Config, env *serverenv.ServerEnv) (
 		return nil, fmt.Errorf("revision.New: %w", err)
 	}
 
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("config validation: %w", err)
+	}
+
 	return &PublishHandler{
 		serverenv:             env,
 		transformer:           transformer,

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -431,6 +431,8 @@ func TestPublishWithBypass(t *testing.T) {
 				config.RevisionToken.KeyID = keyID
 				config.ResponsePaddingMinBytes = 100
 				config.ResponsePaddingRange = 100
+				config.MaxMagnitudeSymptomOnsetDays = 14
+				config.MaxSypmtomOnsetReportDays = 28
 				env := serverenv.New(ctx,
 					serverenv.WithDatabase(testDB),
 					serverenv.WithAuthorizedAppProvider(aaProvider),

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/util"
 	"github.com/jackc/pgx/v4"
+	"github.com/sethvargo/go-envconfig"
 
 	testutil "github.com/google/exposure-notifications-server/internal/utils"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
@@ -743,6 +744,7 @@ func TestKeyRevision(t *testing.T) {
 
 	// And set up publish handler up front.
 	config := Config{}
+	envconfig.ProcessWith(ctx, &config, envconfig.OsLookuper())
 	config.AuthorizedApp.CacheDuration = time.Nanosecond
 	config.CreatedAtTruncateWindow = time.Second
 	config.MaxKeysOnPublish = 20
@@ -750,6 +752,7 @@ func TestKeyRevision(t *testing.T) {
 	config.MaxIntervalAge = 14 * 24 * time.Hour
 	config.ResponsePaddingMinBytes = 100
 	config.ResponsePaddingRange = 100
+	config.UseDefaultSymptomOnset = false
 	aaProvider, err := authorizedapp.NewDatabaseProvider(ctx, testDB, config.AuthorizedAppConfig())
 	if err != nil {
 		t.Fatal(err)

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -1110,7 +1109,6 @@ func TestKeyRevision(t *testing.T) {
 				sort.Slice(tc.Publish.Keys, func(i, j int) bool {
 					return tc.Publish.Keys[i].IntervalNumber >= tc.Publish.Keys[j].IntervalNumber
 				})
-				log.Printf("KEYS %+v", tc.Publish.Keys)
 				for i, k := range tc.Publish.Keys {
 					expectedKeys[i] = k.Key
 					keyBytes, err := base64util.DecodeString(k.Key)

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -757,6 +757,7 @@ func TestKeyRevision(t *testing.T) {
 	config.ResponsePaddingMinBytes = 100
 	config.ResponsePaddingRange = 100
 	config.SymptomOnsetDaysAgo = defaultSymptomOnsetDaysAgo
+	config.AllowPartialRevisions = false
 	aaProvider, err := authorizedapp.NewDatabaseProvider(ctx, testDB, config.AuthorizedAppConfig())
 	if err != nil {
 		t.Fatal(err)
@@ -1090,7 +1091,7 @@ func TestKeyRevision(t *testing.T) {
 				}
 
 				if response.Code != tc.RevErrorCode {
-					t.Fatalf("wrong code on revision, want %#v, got %#v", tc.RevErrorCode, response.Code)
+					t.Fatalf("wrong code on revision, want %#v, got %#v", tc.RevErrorCode, response)
 				}
 
 				if tc.RevErrorCode == "" {

--- a/pkg/timeutils/math.go
+++ b/pkg/timeutils/math.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package timeutils defines functions to close the gaps present in Golang's
+// default implementation of Time.
+package timeutils
+
+import "time"
+
+// SubtractDays subtracts the specified number of days from the given time.
+func SubtractDays(t time.Time, days uint) time.Time {
+	return t.Add(time.Hour * 24 * time.Duration(days) * -1)
+}

--- a/pkg/timeutils/math_test.go
+++ b/pkg/timeutils/math_test.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package timeutils defines functions to close the gaps present in Golang's
+// default implementation of Time.
+package timeutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSubtractDays(t *testing.T) {
+	day := time.Date(2020, 10, 31, 4, 15, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		days uint
+		want time.Time
+	}{
+		{
+			name: "zero",
+			days: 0,
+			want: day,
+		},
+		{
+			name: "fortnight",
+			days: 14,
+			want: time.Date(2020, 10, 17, 4, 15, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SubtractDays(day, tc.days)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/timeutils/midnight_test.go
+++ b/pkg/timeutils/midnight_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package timeutils defines functions to close the gaps present in Golang's
+// default implementation of Time.
+package timeutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLocalMidnight(t *testing.T) {
+	day := time.Date(2020, 10, 31, 4, 15, 0, 0, time.Local)
+	want := time.Date(2020, 10, 31, 0, 0, 0, 0, time.Local)
+	got := LocalMidnight(day)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+
+	got = Midnight(day)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestUTCMidnight(t *testing.T) {
+	day := time.Date(2020, 10, 31, 4, 15, 0, 0, time.Local)
+	want := time.Date(2020, 10, 31, 0, 0, 0, 0, time.UTC)
+	got := UTCMidnight(day)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Proposed Changes

* "unreasonable" symptom onset intervals < 28d ago by default will be treated as if 0 is passed in. 
* keys with a valid symptom onset interval but fall outside the range of -14d..14d will be dropped (restores old / correct behavior.) THIS IS A CHANGE - currently those keys would get adjusted to nil, which would cause default
* if NO symptom onset date is passed in, we tread the symptom onset day as 4 days ago and adjust the data on the TEKs accordingly

This modeling is being adjusted in consultation with the Apple+Google clinical teams working on EN.

**Release Note**

```release-note
BEHAVIOR CHANGE: The handling of symptom onset intervals is changing. Any symptom onsets older than 28 days ago (rounded down to UTC midnight) will be treated as invalid and as if 0 was passed in. Keys with a valid symptom onset days outside of -14..14 will be dropped. If there is not symptom onset passed, the symptom onset interval is set to 4 days ago.
Timing flags can be adjusted via environment variables. Default values are recommended.
```