### PR TITLE
don't attempt to write key revision data on generated keys

### DIFF
--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -478,20 +478,18 @@ func ensureMinNumExposures(exposures []*publishmodel.Exposure, region string, mi
 		}
 
 		ek := &publishmodel.Exposure{
-			ExposureKey:                  eKey,
-			TransmissionRisk:             exposures[fromIdx].TransmissionRisk,
-			AppPackageName:               exportAppPackageName,
-			Regions:                      exposures[fromIdx].Regions,
-			Traveler:                     exposures[fromIdx].Traveler,
-			IntervalNumber:               exposures[fromIdx].IntervalNumber,
-			IntervalCount:                exposures[fromIdx].IntervalCount,
-			CreatedAt:                    createdAt,
-			LocalProvenance:              true,
-			ReportType:                   exposures[fromIdx].ReportType,
-			DaysSinceSymptomOnset:        exposures[fromIdx].DaysSinceSymptomOnset,
-			RevisedAt:                    exposures[fromIdx].RevisedAt,
-			RevisedReportType:            exposures[fromIdx].RevisedReportType,
-			RevisedDaysSinceSymptomOnset: exposures[fromIdx].RevisedDaysSinceSymptomOnset,
+			ExposureKey:           eKey,
+			TransmissionRisk:      exposures[fromIdx].TransmissionRisk,
+			AppPackageName:        exportAppPackageName,
+			Regions:               exposures[fromIdx].Regions,
+			Traveler:              exposures[fromIdx].Traveler,
+			IntervalNumber:        exposures[fromIdx].IntervalNumber,
+			IntervalCount:         exposures[fromIdx].IntervalCount,
+			CreatedAt:             createdAt,
+			LocalProvenance:       true,
+			ReportType:            exposures[fromIdx].ReportType,
+			DaysSinceSymptomOnset: exposures[fromIdx].DaysSinceSymptomOnset,
+			// key revision fields are not used here - generated data only covers primary keys.
 			// The rest of the publishmodel.Exposure fields are not used in the export file.
 		}
 		generated = append(generated, ek)


### PR DESCRIPTION
Fixes #1140 

## Proposed Changes

* Don't write revision data when persisting generated data on export

**Release Note**

```release-note
BUG FIX, release v0.15.1 introduced a bug when using key revision and export padding. This fixes that bug by not attempting to generate revised keys (original intent of the previous change).
```