### PR TITLE
change default max records on export file to 500,000

### DIFF
--- a/internal/export/config.go
+++ b/internal/export/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	WorkerTimeout      time.Duration `env:"WORKER_TIMEOUT, default=5m"`
 	MinRecords         int           `env:"EXPORT_FILE_MIN_RECORDS, default=1000"`
 	PaddingRange       int           `env:"EXPORT_FILE_PADDING_RANGE, default=100"`
-	MaxRecords         int           `env:"EXPORT_FILE_MAX_RECORDS, default=30000"`
+	MaxRecords         int           `env:"EXPORT_FILE_MAX_RECORDS, default=500000"`
 	MaxInsertBatchSize int           `env:"MAX_INSERT_BATCH_SIZE, default=100"`
 	TruncateWindow     time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 	MinWindowAge       time.Duration `env:"MIN_WINDOW_AGE, default=2h"`


### PR DESCRIPTION
## Proposed Changes

* The 30k number was based on daily infection rate in the US back in April. The theoretical max is more like 750,000 keys per export file, moving to 500k

**Release Note**

```release-note
DEFAULT CHANGE: Max records per export file default changed from 30,000 to 500,000
```