### PR TITLE
AllowPartialRevisions set to default on

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	// revision token where only a subset of the keys are in the token. In that
 	// case, only the incoming exposure keys that match the revision token are
 	// uploaded and the remainder are discarded.
-	AllowPartialRevisions bool `env:"ALLOW_PARTIAL_REVISIONS, default=false"`
+	AllowPartialRevisions bool `env:"ALLOW_PARTIAL_REVISIONS, default=true"`
 
 	// API Versions.
 	EnableV1Alpha1API bool `env:"ENABLE_V1ALPHA1_API, default=true"`


### PR DESCRIPTION

## Proposed Changes

* Allow partial revisions by default

**Release Note**

```release-note
DEFAULT CHANGE: Allow partial revisions is now on by default. This enabled some roaming / app / region changing scenarios when there is a shared server.
```

/assign @sethvargo 
/hold