### PR TITLE
allow a revised key to come in again, as long is it no changey

### DIFF
--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -577,6 +577,9 @@ func TestReviseExposures(t *testing.T) {
 			t.Errorf("expected %d to be %d: %#v", got, want, reviseResp)
 		}
 
+		// Change report, type, attempt to revise again.
+		exposure.ReportType = verifyapi.ReportTypeNegative
+
 		// Attempt to revise the same key again - this should fail.
 		if _, err := pubDB.InsertAndReviseExposures(ctx, &InsertAndReviseExposuresRequest{
 			Incoming:     []*model.Exposure{exposure},

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -173,6 +173,10 @@ func (e *Exposure) Revise(in *Exposure) (bool, error) {
 	if e.ReportType == in.ReportType {
 		return false, nil
 	}
+	// Key is being published again, but has already been revised to target report type.
+	if e.RevisedAt != nil && e.RevisedReportType != nil && *e.RevisedReportType == in.ReportType {
+		return false, nil
+	}
 	if !e.LocalProvenance {
 		nonLocalOK := false
 		if e.ExportImportID != nil {

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -1536,6 +1536,42 @@ func TestExposureReview(t *testing.T) {
 			needsRevision: true,
 			err:           "",
 		},
+		{
+			name: "double_revise",
+			previous: &Exposure{
+				ReportType:            verifyapi.ReportTypeClinical,
+				LocalProvenance:       true,
+				HealthAuthorityID:     int64Ptr(2),
+				Regions:               []string{"US", "CA"},
+				TransmissionRisk:      4,
+				CreatedAt:             createdAt,
+				DaysSinceSymptomOnset: int32Ptr(-1),
+				RevisedAt:             &createdAt,
+				RevisedReportType:     stringPtr(verifyapi.ReportTypeConfirmed),
+			},
+			incoming: &Exposure{
+				ReportType:            verifyapi.ReportTypeConfirmed,
+				HealthAuthorityID:     int64Ptr(3),
+				Regions:               []string{"MX"},
+				TransmissionRisk:      5,
+				CreatedAt:             revisedAt,
+				DaysSinceSymptomOnset: int32Ptr(0),
+			},
+			want: &Exposure{
+				ReportType:                   verifyapi.ReportTypeClinical,
+				LocalProvenance:              true,
+				HealthAuthorityID:            int64Ptr(3),
+				Regions:                      []string{"US", "CA", "MX"},
+				TransmissionRisk:             4,
+				CreatedAt:                    createdAt,
+				DaysSinceSymptomOnset:        int32Ptr(-1),
+				RevisedReportType:            stringPtr(verifyapi.ReportTypeConfirmed),
+				RevisedAt:                    &revisedAt,
+				RevisedDaysSinceSymptomOnset: int32Ptr(0),
+				RevisedTransmissionRisk:      intPtr(5),
+			},
+			needsRevision: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -862,9 +862,9 @@ func TestKeyRevision(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				// Revise them
+				// Revise them to negative - test will try to revise to positive.
 				for _, key := range incoming {
-					key.ReportType = verifyapi.ReportTypeConfirmed
+					key.ReportType = verifyapi.ReportTypeNegative
 				}
 				if _, err := pubDB.InsertAndReviseExposures(ctx, &pubdb.InsertAndReviseExposuresRequest{
 					Incoming: incoming,


### PR DESCRIPTION
## Proposed Changes

* If a revised key is uploaded again and the reportType hasn't changed, don't error.

**Release Note**

```release-note
 If a revised key is uploaded again and the reportType hasn't changed, don't error.
```