### PR TITLE
Add a grace period between removal from the export indices, and deletion

### DIFF
--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -34,6 +34,10 @@ import (
 
 const (
 	minTTL = 10 * 24 * time.Hour
+
+	// exportTTLGrace is the window of time between when a file will be listed in
+	// the export batch, and when it will actually be deleted.
+	exportTTLGrace = 1 * time.Hour
 )
 
 // NewExposureHandler creates a http.Handler for deleting exposure keys
@@ -167,5 +171,5 @@ func cutoffDate(ctx context.Context, d time.Duration, overrideMinTTL bool) (time
 			return time.Time{}, fmt.Errorf("cleanup ttl is less than configured minimum ttl")
 		}
 	}
-	return time.Now().Add(-d), nil
+	return time.Now().Add(-(d + exportTTLGrace)), nil
 }

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -147,7 +147,7 @@ func TestCutoffDate(t *testing.T) {
 			} else if err != nil {
 				t.Errorf("%q: got error %v", test.d, err)
 			} else {
-				want := now.Add(-test.wantDur)
+				want := now.Add(-(test.wantDur + exportTTLGrace))
 				diff := got.Sub(want)
 				if diff < 0 {
 					diff = -diff


### PR DESCRIPTION
Fixes #1148

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add a 1 hour grace time between when a file is no longer included in the export file list, and when it's actually deleted.
```