### PR TITLE
Add a knob to exclude certain metrics from being exported to

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -176,7 +176,7 @@ func SetupWith(ctx context.Context, config interface{}, l envconfig.Lookuper) (*
 		if err != nil {
 			return nil, fmt.Errorf("unable to create observability provider: %v", err)
 		}
-		if err := oe.StartExporter(); err != nil {
+		if err := oe.StartExporter(ctx); err != nil {
 			return nil, fmt.Errorf("failed to start observability: %w", err)
 		}
 		exporter := serverenv.WithObservabilityExporter(oe)

--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -75,4 +75,10 @@ type StackdriverConfig struct {
 	BundleDelayThreshold time.Duration `env:"STACKDRIVER_BUNDLE_DELAY_THRESHOLD, default=2s"`
 	BundleCountThreshold uint          `env:"STACKDRIVER_BUNDLE_COUNT_THRESHOLD, default=50"`
 	Timeout              time.Duration `env:"STACKDRIVER_TIMEOUT, default=5s"`
+
+	// The Cloud Run services are exporting many metrics that we get for free
+	// from the OpenCensus libaries. You can control whether to exclude some of
+	// them using the option below.
+	// Specify them using comma separated strings in envvar.
+	ExcludedMetricPrefixes []string `env:"STACKDRIVER_EXCLUDED_METRIC_PREFIXES"`
 }

--- a/pkg/observability/noop.go
+++ b/pkg/observability/noop.go
@@ -27,7 +27,7 @@ func NewNoop(_ context.Context) (Exporter, error) {
 	return &noopExporter{}, nil
 }
 
-func (g *noopExporter) StartExporter() error {
+func (g *noopExporter) StartExporter(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -80,7 +80,7 @@ func AllViews() []*view.View {
 // used by this application.
 type Exporter interface {
 	io.Closer
-	StartExporter() error
+	StartExporter(ctx context.Context) error
 }
 
 // NewFromEnv returns the observability exporter given the provided configuration, or an error

--- a/pkg/observability/opencensus.go
+++ b/pkg/observability/opencensus.go
@@ -48,7 +48,7 @@ func NewOpenCensus(ctx context.Context, config *OpenCensusConfig) (Exporter, err
 }
 
 // StartExporter starts the exporter.
-func (e *opencensusExporter) StartExporter() error {
+func (e *opencensusExporter) StartExporter(_ context.Context) error {
 	trace.ApplyConfig(trace.Config{
 		DefaultSampler: trace.ProbabilitySampler(e.config.SampleRate),
 	})


### PR DESCRIPTION
Stackdriver.

Fixes
https://github.com/google/exposure-notifications-verification-server/issues/1060