### PR TITLE
allow export filename rewriting in mirror job

### DIFF
--- a/cmd/mirror/main.go
+++ b/cmd/mirror/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This binary provides a server that can import export files from a trusted partner.
+// This binary provides a server that can mirror export files.
 package main
 
 import (
@@ -57,7 +57,7 @@ func realMain(ctx context.Context) error {
 	}
 	defer env.Close(ctx)
 
-	rotationServer, err := mirror.NewServer(&config, env)
+	mirrorServer, err := mirror.NewServer(&config, env)
 	if err != nil {
 		return fmt.Errorf("mirror.NewServer: %w", err)
 	}
@@ -68,5 +68,5 @@ func realMain(ctx context.Context) error {
 	}
 	logger.Info("listening on: ", config.Port)
 
-	return srv.ServeHTTPHandler(ctx, rotationServer.Routes(ctx))
+	return srv.ServeHTTPHandler(ctx, mirrorServer.Routes(ctx))
 }

--- a/internal/mirror/model/mirror_test.go
+++ b/internal/mirror/model/mirror_test.go
@@ -1,0 +1,69 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewriteFilenameNoOp(t *testing.T) {
+	m := Mirror{}
+
+	want := "afile.zip"
+	if got, err := m.RewriteFilename(want); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if want != got {
+		t.Fatalf("filename should not have been rewritten: want: %q got: %q", want, got)
+	}
+}
+
+func TestRewriteFilenameTimestamps(t *testing.T) {
+	pattern := "[timestamp]-[timestamp]-00001.zip"
+	m := Mirror{
+		FilenameRewrite: &pattern,
+	}
+
+	got, err := m.RewriteFilename("random...")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	parts := strings.Split(got, "-")
+	if len(parts) != 3 {
+		t.Fatalf("filename doesn't have 3 parts: got: %v", parts)
+	}
+
+	if parts[0] == parts[1] {
+		t.Fatalf("got 2 identical timestamps...")
+	}
+}
+
+func TestRewriteUUID(t *testing.T) {
+	pattern := "[uuid]-00001.zip"
+	m := Mirror{
+		FilenameRewrite: &pattern,
+	}
+
+	got, err := m.RewriteFilename("random...")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	parts := strings.Split(got, "-")
+	if len(parts) != 6 {
+		t.Fatalf("didn't get a uuid: %q", got)
+	}
+}

--- a/migrations/000048_AddMirrorRewrite.down.sql
+++ b/migrations/000048_AddMirrorRewrite.down.sql
@@ -1,0 +1,23 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE mirror
+    DROP COLUMN filename_rewrite;
+
+ALTER TABLE mirrorfile
+    DROP COLUMN local_filename;
+
+END;

--- a/migrations/000048_AddMirrorRewrite.up.sql
+++ b/migrations/000048_AddMirrorRewrite.up.sql
@@ -1,0 +1,23 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE mirror
+    ADD COLUMN filename_rewrite varchar(200);
+
+ALTER TABLE mirrorfile
+    ADD COLUMN local_filename varchar(200);
+
+END;


### PR DESCRIPTION
Fixes #1164 

## Proposed Changes

* Allow rewriting of filenames during mirror
* process mirrors in remote index order

**Release Note**

```release-note
cmd/mirror only : allow for mirrors to generate different filenames than what is upstream. Two patterns are accepted [timestamp] and [uuid] - uses of timestamp will always have increasing values within an individual mirror config.
```