### PR TITLE
Delete serverless vpc connector ahead of time

### DIFF
--- a/scripts/ci-terraform.sh
+++ b/scripts/ci-terraform.sh
@@ -127,7 +127,7 @@ function destroy() {
   local db_inst_name
   # Fetching databases from previous terraform deployment output is not always reliable,
   # especially when previous terraform deployment failed. So grepping from terraform state instead.
-  db_inst_name="$(terraform state show module.en.google_sql_database_instance.db-inst | grep -Eo 'en-server-[a-zA-Z0-9]+' | uniq)"
+  db_inst_name="$(terraform state show module.en.google_sql_database_instance.db-inst | grep -Eo 'en-server-[a-zA-Z0-9]+' | uniq)" || best_effort
   if [[ -n "${db_inst_name}" ]]; then
     echo "Deleting db ${db_inst_name}"
     gcloud sql instances delete ${db_inst_name} -q --project=${PROJECT_ID}
@@ -137,6 +137,11 @@ function destroy() {
   # Clean up states after manual DB delete
   terraform state rm module.en.google_sql_user.user || best_effort
   terraform state rm module.en.google_sql_ssl_cert.db-cert || best_effort
+
+  # Serverless VPC connector can be very easily get to a bad state from previous terraform destroy,
+  # Manually destroy it again.
+  local vpc_connector_name="serverless-vpc-connector"
+  gcloud compute networks vpc-access connectors delete ${vpc_connector_name} -q --region us-central1 --project=$PROJECT_ID || best_effort
 
   terraform destroy -auto-approve
   popd > /dev/null


### PR DESCRIPTION
serverless-vpc-connector had been into bad state quite a few times after deleted by terraform, terraform remove it from state with the existence of a broken vpc connector, which prevents future terraform apply due to `serverless vpc connector already exist`. Forcing delete to avoid manual intervention