### PR TITLE
Add a mark/sweep to ExportFile deletion.

### DIFF
--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -439,6 +439,15 @@ func TestFinalizeBatch(t *testing.T) {
 			t.Errorf("mismatch for %q (-want, +got):\n%s", filename, diff)
 		}
 	}
+
+	// Check marking files for deletion.
+	sleepTime := time.Second
+	time.Sleep(sleepTime)
+	if num, err := New(testDB).MarkExpiredFiles(ctx, eb.ConfigID, sleepTime); err != nil {
+		t.Errorf("error marking files for deletion: %v", err)
+	} else if num != len(gotFiles) {
+		t.Errorf("expected to mark %d files expired, got %d", len(gotFiles), num)
+	}
 }
 
 // TestTravelerKeys ensures traveler keys are pulled in when necessary.

--- a/internal/export/model/export_model.go
+++ b/internal/export/model/export_model.go
@@ -22,16 +22,19 @@ import (
 )
 
 var (
-	ExportBatchOpen     = "OPEN"
-	ExportBatchPending  = "PENDING"
-	ExportBatchComplete = "COMPLETE"
-	ExportBatchDeleted  = "DELETED"
+	ExportBatchOpen          = "OPEN"
+	ExportBatchPending       = "PENDING"
+	ExportBatchComplete      = "COMPLETE"
+	ExportBatchDeletePending = "DEL_PEND"
+	ExportBatchDeleted       = "DELETED"
 )
 
 const (
 	oneDay = 24 * time.Hour
 )
 
+// ExportConfig describes what goes into an export, and how frequently.
+// These are used to periodically generate an ExportBatch.
 type ExportConfig struct {
 	ConfigID         int64
 	BucketName       string
@@ -74,6 +77,7 @@ func (ec *ExportConfig) Validate() error {
 	return nil
 }
 
+// ExportBatch holds what was used to generate an export.
 type ExportBatch struct {
 	BatchID          int64
 	ConfigID         int64

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -359,6 +359,11 @@ func TestIntegration(t *testing.T) {
 			}); err != nil {
 				t.Fatal(err)
 			}
+			if numFiles, err := exportdb.New(db).MarkExpiredFiles(ctx, 1, 0); err != nil {
+				t.Fatalf("error marking expired %v", err)
+			} else if numFiles != len(batchFiles) {
+				t.Errorf("expected %d files, got %d", len(batchFiles), numFiles)
+			}
 
 			// Ensure the export was deleted
 			Eventually(t, 30, time.Second, func() error {

--- a/migrations/000051_AddPendingDelete.down.sql
+++ b/migrations/000051_AddPendingDelete.down.sql
@@ -1,0 +1,13 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.

--- a/migrations/000051_AddPendingDelete.up.sql
+++ b/migrations/000051_AddPendingDelete.up.sql
@@ -1,0 +1,19 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TYPE ExportBatchStatus ADD VALUE 'DEL_PEND';
+
+END;


### PR DESCRIPTION
Fixes #1148

This PR replaces PR #1162


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
ExportFiles won't be deleted until they're removed from the index.html
```