### PR TITLE
Switch to Postgres 13, add optional regional replicas

### DIFF
--- a/terraform-e2e-ci/main.tf
+++ b/terraform-e2e-ci/main.tf
@@ -28,7 +28,6 @@ module "en" {
 
   project                           = var.project
   cloudsql_disk_size_gb             = 500
-  db_name                           = "en-server-${random_string.suffix.result}"
   kms_export_signing_key_ring_name  = "export-signing-${random_string.suffix.result}"
   kms_revision_tokens_key_ring_name = "revision-tokens-${random_string.suffix.result}"
 

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -35,17 +35,18 @@ variable "db_location" {
   default = "us-central1"
 }
 
-# The name of the database.
-variable "db_name" {
-  type    = string
-  default = "en-server"
-}
-
 variable "db_version" {
   type    = string
-  default = "POSTGRES_11"
+  default = "POSTGRES_13"
 
   description = "Version of the database to use. Must be at least 11 or higher."
+}
+
+variable "db_failover_replica_regions" {
+  type    = list(string)
+  default = []
+
+  description = "List of regions in which to create failover replicas. The default configuration is resistant to zonal outages. This will increase costs."
 }
 
 # The region for the networking components.


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Switch to Postgres 13 by default, support optional regional replica configuration in Terraform
```