### PR TITLE
Remove feature flags for audience checking

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -89,9 +89,6 @@ type Config struct {
 	// Should only be set if a server is being operated in a single region.
 	DefaultRegion string `env:"DEFAULT_REGION"`
 
-	// Feature flags - eventually these are removed as features become default behavior
-	FailOnCertificateAudienceMismatch bool `env:"FEATURE_FAIL_ON_CERTIFICATE_AUDIENCE_MISMATCH, default=true"`
-
 	// Flags for local development and testing. This will cause still valid keys
 	// to not be embargoed.
 	// Normally "still valid" keys can be accepted, but are embargoed.

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -286,7 +286,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 	}
 
 	// Perform health authority certificate verification.
-	verifiedClaims, err := h.verifier.VerifyDiagnosisCertificate(ctx, appConfig, data, h.config.FailOnCertificateAudienceMismatch)
+	verifiedClaims, err := h.verifier.VerifyDiagnosisCertificate(ctx, appConfig, data)
 	if err != nil {
 		if appConfig.BypassHealthAuthorityVerification {
 			logger.Warnf("bypassing health authority certificate verification health authority: %v", appConfig.AppPackageName)

--- a/internal/verification/phaverify.go
+++ b/internal/verification/phaverify.go
@@ -61,7 +61,7 @@ type VerifiedClaims struct {
 // VerifyDiagnosisCertificate accepts a publish request (from which is extracts the JWT),
 // fully verifies the JWT and signture against what the passed in authorrized app is allowed
 // to use. Returns any transmission risk overrides if they are present.
-func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamodel.AuthorizedApp, publish *verifyapi.Publish, enforceAudienceMatch bool) (*VerifiedClaims, error) {
+func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamodel.AuthorizedApp, publish *verifyapi.Publish) (*VerifiedClaims, error) {
 	logger := logging.FromContext(ctx)
 	// These get assigned during the ParseWithClaims closure.
 	var healthAuthorityID int64
@@ -110,12 +110,7 @@ func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamo
 
 		// Advisory check the aud.
 		if claims.Audience != ha.Audience {
-			// TODO(mikehelmick) - clean up feature flag casing.
-			logger.Errorw("certifice audience mismatch - will be a failure in the next release", "claims.Aud", claims.Audience, "allowed", ha.Audience, "iss", ha.Issuer)
-			if enforceAudienceMatch {
-				// This flag guarding will be removed in a future release.
-				return nil, fmt.Errorf("audience mismatch for issuer: %v", ha.Issuer)
-			}
+			return nil, fmt.Errorf("audience mismatch for issuer: %v (+%s, -%s)", ha.Issuer, claims.Audience, ha.Audience)
 		}
 
 		// Find a key version.

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -53,7 +53,6 @@ func TestVerifyCertificate(t *testing.T) {
 		MacKeyAdjustment string
 		ChangeIssuer     string
 		ChangeAudience   string
-		EnforceAudience  bool // TODO(mikehelmick) Remove when removing feature flag
 		Error            string
 	}{
 		{
@@ -65,15 +64,9 @@ func TestVerifyCertificate(t *testing.T) {
 			Error:        "issuer not found",
 		},
 		{
-			Name:            "bad_audience_off",
-			ChangeAudience:  "bar",
-			EnforceAudience: false,
-		},
-		{
-			Name:            "bad_audience",
-			ChangeAudience:  "bar",
-			Error:           "audience mismatch for issuer",
-			EnforceAudience: true,
+			Name:           "bad_audience",
+			ChangeAudience: "bar",
+			Error:          "audience mismatch for issuer",
 		},
 		{
 			Name:  "past",
@@ -255,7 +248,7 @@ func TestVerifyCertificate(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish, tc.EnforceAudience)
+					verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish)
 					if err != nil {
 						if tc.Error == "" {
 							t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Fixes #1127

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
**Potentially breaking** - Remove feature flags for audience checking - audience checking is always enforced for all HAs.
```