### PR TITLE
restore the original timeline

### DIFF
--- a/docs/regen_exports.md
+++ b/docs/regen_exports.md
@@ -1,0 +1,10 @@
+# Regenerating exports
+
+Should you need to regenerate exports.
+
+1) Pause the scheduler for the `/do-work` invoker of the export job.
+2) Delete the exportfiles for the files you want to regnerate.
+3) Mark the batches as `'OPEN'` for the batches you want to regenerate.
+4) Increment the value of the `REPROCESS_COUNT` environment variable on the export service.
+5) Restart all instances of the export service.
+6) Unpause the `/do-work` invoker.

--- a/internal/export/config.go
+++ b/internal/export/config.go
@@ -52,7 +52,7 @@ type Config struct {
 	TruncateWindow     time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 	MinWindowAge       time.Duration `env:"MIN_WINDOW_AGE, default=2h"`
 	TTL                time.Duration `env:"CLEANUP_TTL, default=336h"`
-	// ReprocessCount needs to be incremented by one ever time you go back and
+	// ReprocessCount needs to be incremented by one every time you go back and
 	// regenerate previously exported files.
 	ReprocessCount uint `env:"REPROCESS_COUNT, default=0"`
 }

--- a/internal/export/config.go
+++ b/internal/export/config.go
@@ -52,6 +52,13 @@ type Config struct {
 	TruncateWindow     time.Duration `env:"TRUNCATE_WINDOW, default=1h"`
 	MinWindowAge       time.Duration `env:"MIN_WINDOW_AGE, default=2h"`
 	TTL                time.Duration `env:"CLEANUP_TTL, default=336h"`
+	// ReprocessCount needs to be incremented by one ever time you go back and
+	// regenerate previously exported files.
+	ReprocessCount uint `env:"REPROCESS_COUNT, default=0"`
+}
+
+func (c *Config) RepressGeneration() int64 {
+	return int64(c.ReprocessCount)
 }
 
 func (c *Config) BlobstoreConfig() *storage.Config {

--- a/internal/export/exportfile_test.go
+++ b/internal/export/exportfile_test.go
@@ -95,7 +95,7 @@ func TestMarshalUnmarshalExportFile(t *testing.T) {
 
 	signer := &customTestSigner{}
 
-	blob, pbHexSHA, err := MarshalExportFile(batch, exposures, revisedExposures, 1, 1, []*Signer{
+	blob, err := MarshalExportFile(batch, exposures, revisedExposures, 1, 1, []*Signer{
 		{SignatureInfo: signatureInfo, Signer: signer},
 	})
 	if err != nil {
@@ -110,11 +110,6 @@ func TestMarshalUnmarshalExportFile(t *testing.T) {
 	wantDigest := "jN+W9DnqfXx5hp+6LaI8JuilsFWoiyF8DE/73OGZMJM="
 	if b64digest := base64.StdEncoding.EncodeToString(digest); b64digest != wantDigest {
 		t.Errorf("wrong message digest want: %v, got: %v", wantDigest, b64digest)
-	}
-
-	wantHexSHA := "8cdf96f439ea7d7c79869fba2da23c26e8a5b055a88b217c0c4ffbdce1993093"
-	if wantHexSHA != pbHexSHA {
-		t.Errorf("want PB hex sha to be: %v, got: %v", wantHexSHA, pbHexSHA)
 	}
 
 	infos := []*export.SignatureInfo{

--- a/internal/export/worker_test.go
+++ b/internal/export/worker_test.go
@@ -444,75 +444,54 @@ func TestExportFilename(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		m   *model.ExportBatch
-		num int
-		sha string
-		exp string
+		name       string
+		m          *model.ExportBatch
+		num        int
+		regenCount int64
+		exp        string
 	}{
 		{
+			name: "no_regn",
 			m: &model.ExportBatch{
 				FilenameRoot:   "v1",
 				StartTimestamp: time.Unix(0, 0),
 				EndTimestamp:   time.Unix(0, 0),
 			},
-			num: 1,
-			sha: "abc123",
-			exp: "v1/0-0-00001999999999097098099049050051.zip",
+			num:        1,
+			regenCount: 0,
+			exp:        "v1/0-0-00001.zip",
 		},
 		{
+			name: "regen_2",
 			m: &model.ExportBatch{
 				FilenameRoot:   "v1",
 				StartTimestamp: time.Unix(0, 0),
 				EndTimestamp:   time.Unix(0, 0),
 			},
-			num: 2,
-			sha: "",
-			exp: "v1/0-0-00002999999999.zip",
+			num:        2,
+			regenCount: 2,
+			exp:        "v1/2-2-00002.zip",
 		},
 		{
+			name: "regen_3",
 			m: &model.ExportBatch{
 				FilenameRoot:   "v2",
 				StartTimestamp: time.Unix(100, 0),
 				EndTimestamp:   time.Unix(300, 0),
 			},
-			num: 1,
-			sha: "",
-			exp: "v2/100-300-00001999999999.zip",
+			num:        1,
+			regenCount: 3,
+			exp:        "v2/103-303-00001.zip",
 		},
 	}
 
 	for _, tc := range cases {
 		tc := tc
 
-		t.Run(tc.sha, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got, want := exportFilename(tc.m, tc.num, tc.sha), tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
-			}
-		})
-	}
-}
-
-func TestToASCIISortable(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		in  string
-		out string
-	}{
-		{"foo", "102111111"},
-		{"bar", "098097114"},
-		{"ad3e93", "097100051101057051"},
-	}
-
-	for _, tc := range cases {
-		tc := tc
-
-		t.Run(tc.in, func(t *testing.T) {
-			t.Parallel()
-
-			if got, want := toASCIISortable(tc.in), tc.out; got != want {
+			if got, want := exportFilename(tc.m, tc.num, tc.regenCount), tc.exp; got != want {
 				t.Errorf("expected %q to be %q", got, want)
 			}
 		})

--- a/tools/export-generate/main.go
+++ b/tools/export-generate/main.go
@@ -205,11 +205,11 @@ func (e *exportFileWriter) writeFile() {
 		SignatureInfo: signatureInfo,
 		Signer:        e.privateKey,
 	}
-	data, hexSHA, err := export.MarshalExportFile(e.exportBatch, e.exposures, e.revisions, e.curBatch, e.numBatches, []*export.Signer{signer})
+	data, err := export.MarshalExportFile(e.exportBatch, e.exposures, e.revisions, e.curBatch, e.numBatches, []*export.Signer{signer})
 	if err != nil {
 		log.Fatalf("error marshaling export file: %v", err)
 	}
-	fileName := fmt.Sprintf(e.exportBatch.FilenameRoot+"%d-records-%d-of-%d-%s"+filenameSuffix, e.totalKeys, e.curBatch, e.numBatches, hexSHA[0:6])
+	fileName := fmt.Sprintf(e.exportBatch.FilenameRoot+"%d-records-%d-of-%d"+filenameSuffix, e.totalKeys, e.curBatch, e.numBatches)
 	log.Printf("Creating %v", fileName)
 	err = ioutil.WriteFile(fileName, data, 0666)
 	if err != nil {


### PR DESCRIPTION
## Proposed Changes

* Restore default export filenames to be what they were last week. Too many deployed haps have taken dependencies on them.
* Introduce `REPROCESS_COUNT` to compensate - will allow an operator to cause filenames to be different (off by 1)

**Release Note**

```release-note
Restores filename patterns to their original format and provides instructions for regenerating export batches.
App developers should not depend on the filename pattern.
```