### PR TITLE
Adjust the alerting threshold to 10min.

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -44,7 +44,7 @@ resource "google_monitoring_alert_policy" "LatencyTooHigh" {
       | group_by [resource.service_name, type],
       [val: percentile(value.request_latencies, 50)]
       | condition
-        (type == 'SLOWEST' && val > 60000 'ms')
+        (type == 'SLOWEST' && val > 600000 'ms')
         || (type == 'SLOWER' && val > 20000 'ms')
         || (type == 'NORMAL' && val > 10000 'ms')
       EOT


### PR DESCRIPTION
The export service sometimes takes more than 8min to finish. We can use
10min for now and see if it will lower the noise. If it's still noisy we
can just exclude the service from latency alert and add a request
error rate alert for it.