### PR TITLE
parametrize DB name and User name to avoid replacement

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -102,7 +102,7 @@ resource "google_sql_database_instance" "replicas" {
 resource "google_sql_database" "db" {
   project  = data.google_project.project.project_id
   instance = google_sql_database_instance.db-inst.name
-  name     = "key"
+  name     = var.db_name
 }
 
 resource "google_sql_ssl_cert" "db-cert" {
@@ -118,7 +118,7 @@ resource "random_password" "db-password" {
 
 resource "google_sql_user" "user" {
   instance = google_sql_database_instance.db-inst.name
-  name     = "key"
+  name     = var.db_user
   password = random_password.db-password.result
 }
 

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -35,6 +35,17 @@ variable "db_location" {
   default = "us-central1"
 }
 
+# database name, not instance name
+variable "db_name" {	
+  type    = string	
+  default = "key"	
+}
+
+variable "db_user" {	
+  type    = string	
+  default = "key"	
+}
+
 variable "db_version" {
   type    = string
   default = "POSTGRES_13"


### PR DESCRIPTION
As per https://github.com/google/exposure-notifications-server/issues/1194

I don't need to change the instance name but the DB name and user name. 