### PR TITLE
Remove bogus provider configs.

### DIFF
--- a/terraform/alerting/main.tf
+++ b/terraform/alerting/main.tf
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-provider "google" {
-  project = var.project
-}
-
-provider "google-beta" {
-  project = var.project
-}
-
 resource "google_project_service" "services" {
   for_each = toset([
     "monitoring.googleapis.com",


### PR DESCRIPTION
Having these lines makes Terraform complain if the module is used with
`depends_on`:

> Module "en-alerting" cannot be used with depends_on because it contains a
nested provider configuration for "google".