### PR TITLE
remove batchnum/batchsize construct

### DIFF
--- a/internal/export/exportfile_test.go
+++ b/internal/export/exportfile_test.go
@@ -95,7 +95,7 @@ func TestMarshalUnmarshalExportFile(t *testing.T) {
 
 	signer := &customTestSigner{}
 
-	blob, err := MarshalExportFile(batch, exposures, revisedExposures, 1, 1, []*Signer{
+	blob, err := MarshalExportFile(batch, exposures, revisedExposures, int32(1), false /* single file batch */, []*Signer{
 		{SignatureInfo: signatureInfo, Signer: signer},
 	})
 	if err != nil {

--- a/internal/export/worker_test.go
+++ b/internal/export/worker_test.go
@@ -451,7 +451,7 @@ func TestExportFilename(t *testing.T) {
 	cases := []struct {
 		name       string
 		m          *model.ExportBatch
-		num        int
+		num        int32
 		regenCount int64
 		exp        string
 	}{

--- a/internal/pb/export/export.proto
+++ b/internal/pb/export/export.proto
@@ -26,7 +26,11 @@ option go_package = "github.com/google/exposure-notifications-server/internal/pb
 // file verifying the contents.
 message TemporaryExposureKeyExport {
   // Time window of keys in this file based on arrival to server, in UTC
-  // seconds
+  // seconds. start_timestamp, end_timestamp, and batch_num must be unique
+  // at any given snapshot of the index for a server. If multiple
+  // files are used for a specific time period, and batch_num/batch_size
+  // are both 1 (See below), then offsetting the end_timestamp is the
+  // suggested method for forcing uniqueness.
   optional fixed64 start_timestamp = 1;
   optional fixed64 end_timestamp = 2;
 
@@ -119,6 +123,8 @@ message TEKSignature {
   // Info about the signing key, version, algorithm, etc.
   optional SignatureInfo signature_info = 1;
   // E.g., Batch 2 of 10
+  // Must match fields from TemporaryExposureKeyExport, see
+  // documentation on that message.
   optional int32 batch_num = 2;
   optional int32 batch_size = 3;
   // Signature in X9.62 format (ASN.1 SEQUENCE of two INTEGER fields)

--- a/tools/export-generate/main.go
+++ b/tools/export-generate/main.go
@@ -154,7 +154,7 @@ func main() {
 	}
 	numBatches := int(math.Ceil(float64(actualNumKeys) / float64(*batchSize)))
 	log.Printf("number of batches: %d", numBatches)
-	b := 0
+	var b int32
 	currentBatch := []*publishmodel.Exposure{}
 	for i := 0; i < actualNumKeys; i++ {
 		currentBatch = append(currentBatch, &exposureKeys[i])
@@ -190,7 +190,7 @@ type exportFileWriter struct {
 	exportBatch *model.ExportBatch
 	exposures   []*publishmodel.Exposure
 	revisions   []*publishmodel.Exposure
-	curBatch    int
+	curBatch    int32
 	numBatches  int
 	totalKeys   int
 	privateKey  *ecdsa.PrivateKey
@@ -205,7 +205,7 @@ func (e *exportFileWriter) writeFile() {
 		SignatureInfo: signatureInfo,
 		Signer:        e.privateKey,
 	}
-	data, err := export.MarshalExportFile(e.exportBatch, e.exposures, e.revisions, e.curBatch, e.numBatches, []*export.Signer{signer})
+	data, err := export.MarshalExportFile(e.exportBatch, e.exposures, e.revisions, e.curBatch, e.numBatches > 1, []*export.Signer{signer})
 	if err != nil {
 		log.Fatalf("error marshaling export file: %v", err)
 	}


### PR DESCRIPTION
Fixes #1184 

## Proposed Changes

* remove usage of batchNum/batchSize in our code - device side issues prevent us from leveraging these fields.

**Release Note**

```release-note
Removed usage of export batch num / batch size in the export code to prevent accidental usage of this in the future.
```