### PR TITLE
allow for max records to be overridden on a per-export-config basis

### DIFF
--- a/internal/admin/exports/form.go
+++ b/internal/admin/exports/form.go
@@ -29,19 +29,20 @@ import (
 var ErrCannotSetBothTravelers = errors.New("cannot have both 'include travelers', and 'only non-travelers' set")
 
 type formData struct {
-	OutputRegion     string        `form:"OutputRegion"`
-	InputRegions     string        `form:"InputRegions"`
-	IncludeTravelers bool          `form:"IncludeTravelers"`
-	OnlyNonTravelers bool          `form:"OnlyNonTravelers"`
-	ExcludeRegions   string        `form:"ExcludeRegions"`
-	BucketName       string        `form:"BucketName"`
-	FilenameRoot     string        `form:"FilenameRoot"`
-	Period           time.Duration `form:"Period"`
-	FromDate         string        `form:"fromdate"`
-	FromTime         string        `form:"fromtime"`
-	ThruDate         string        `form:"thrudate"`
-	ThruTime         string        `form:"thrutime"`
-	SigInfoIDs       []int64       `form:"siginfo"`
+	OutputRegion       string        `form:"OutputRegion"`
+	InputRegions       string        `form:"InputRegions"`
+	IncludeTravelers   bool          `form:"IncludeTravelers"`
+	OnlyNonTravelers   bool          `form:"OnlyNonTravelers"`
+	ExcludeRegions     string        `form:"ExcludeRegions"`
+	BucketName         string        `form:"BucketName"`
+	FilenameRoot       string        `form:"FilenameRoot"`
+	Period             time.Duration `form:"Period"`
+	FromDate           string        `form:"fromdate"`
+	FromTime           string        `form:"fromtime"`
+	ThruDate           string        `form:"thrudate"`
+	ThruTime           string        `form:"thrutime"`
+	SigInfoIDs         []int64       `form:"siginfo"`
+	MaxRecordsOverride int           `form:"MaxRecordsOverride"`
 }
 
 // splitRegions turns a string of regions (generally separated by newlines), and
@@ -82,6 +83,12 @@ func (f *formData) PopulateExportConfig(ec *model.ExportConfig) error {
 	ec.From = from
 	ec.Thru = thru
 	ec.SignatureInfoIDs = f.SigInfoIDs
+	if f.MaxRecordsOverride > 0 {
+		ec.MaxRecordsOverride = &f.MaxRecordsOverride
+	} else {
+		ec.MaxRecordsOverride = nil
+	}
+
 	if len(ec.SignatureInfoIDs) > 10 {
 		return fmt.Errorf("too many signing keys selected, there is a limit of 10")
 	}

--- a/internal/export/batcher.go
+++ b/internal/export/batcher.go
@@ -124,18 +124,19 @@ func (s *Server) maybeCreateBatches(ctx context.Context, ec *model.ExportConfig,
 		infoIds := make([]int64, len(ec.SignatureInfoIDs))
 		copy(infoIds, ec.SignatureInfoIDs)
 		batches = append(batches, &model.ExportBatch{
-			ConfigID:         ec.ConfigID,
-			BucketName:       ec.BucketName,
-			FilenameRoot:     ec.FilenameRoot,
-			StartTimestamp:   br.start,
-			EndTimestamp:     br.end,
-			OutputRegion:     ec.OutputRegion,
-			InputRegions:     ec.InputRegions,
-			IncludeTravelers: ec.IncludeTravelers,
-			OnlyNonTravelers: ec.OnlyNonTravelers,
-			ExcludeRegions:   ec.ExcludeRegions,
-			Status:           model.ExportBatchOpen,
-			SignatureInfoIDs: infoIds,
+			ConfigID:           ec.ConfigID,
+			BucketName:         ec.BucketName,
+			FilenameRoot:       ec.FilenameRoot,
+			StartTimestamp:     br.start,
+			EndTimestamp:       br.end,
+			OutputRegion:       ec.OutputRegion,
+			InputRegions:       ec.InputRegions,
+			IncludeTravelers:   ec.IncludeTravelers,
+			OnlyNonTravelers:   ec.OnlyNonTravelers,
+			ExcludeRegions:     ec.ExcludeRegions,
+			Status:             model.ExportBatchOpen,
+			SignatureInfoIDs:   infoIds,
+			MaxRecordsOverride: ec.MaxRecordsOverride,
 		})
 	}
 

--- a/internal/export/model/export_model.go
+++ b/internal/export/model/export_model.go
@@ -36,18 +36,19 @@ const (
 // ExportConfig describes what goes into an export, and how frequently.
 // These are used to periodically generate an ExportBatch.
 type ExportConfig struct {
-	ConfigID         int64
-	BucketName       string
-	FilenameRoot     string
-	Period           time.Duration
-	OutputRegion     string
-	InputRegions     []string
-	ExcludeRegions   []string
-	IncludeTravelers bool
-	OnlyNonTravelers bool
-	From             time.Time
-	Thru             time.Time
-	SignatureInfoIDs []int64
+	ConfigID           int64
+	BucketName         string
+	FilenameRoot       string
+	Period             time.Duration
+	OutputRegion       string
+	InputRegions       []string
+	ExcludeRegions     []string
+	IncludeTravelers   bool
+	OnlyNonTravelers   bool
+	From               time.Time
+	Thru               time.Time
+	SignatureInfoIDs   []int64
+	MaxRecordsOverride *int
 }
 
 // EffectiveInputRegions either returns `InputRegions` or if that array is
@@ -79,20 +80,32 @@ func (ec *ExportConfig) Validate() error {
 
 // ExportBatch holds what was used to generate an export.
 type ExportBatch struct {
-	BatchID          int64
-	ConfigID         int64
-	BucketName       string
-	FilenameRoot     string
-	StartTimestamp   time.Time
-	EndTimestamp     time.Time
-	OutputRegion     string
-	InputRegions     []string
-	IncludeTravelers bool
-	OnlyNonTravelers bool
-	ExcludeRegions   []string
-	Status           string
-	LeaseExpires     time.Time
-	SignatureInfoIDs []int64
+	BatchID            int64
+	ConfigID           int64
+	BucketName         string
+	FilenameRoot       string
+	StartTimestamp     time.Time
+	EndTimestamp       time.Time
+	OutputRegion       string
+	InputRegions       []string
+	IncludeTravelers   bool
+	OnlyNonTravelers   bool
+	ExcludeRegions     []string
+	Status             string
+	LeaseExpires       time.Time
+	SignatureInfoIDs   []int64
+	MaxRecordsOverride *int
+}
+
+// EffectiveMaxRecords returns either the provided value or the override
+// present in this config.
+func (eb *ExportBatch) EffectiveMaxRecords(systemDefault int) int {
+	// If the value is null in the database or > 0. Prevent accidental setting to 0 to
+	// think it indicates default.
+	if eb.MaxRecordsOverride != nil && *eb.MaxRecordsOverride > 0 {
+		return *eb.MaxRecordsOverride
+	}
+	return systemDefault
 }
 
 // EffectiveInputRegions either returns `InputRegions` or if that array is

--- a/internal/export/model/export_model_test.go
+++ b/internal/export/model/export_model_test.go
@@ -54,3 +54,19 @@ func TestExportRegions(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveMaxRecords(t *testing.T) {
+	eb := &ExportBatch{
+		MaxRecordsOverride: nil,
+	}
+
+	want := 57
+	if got := eb.EffectiveMaxRecords(want); want != got {
+		t.Fatalf("mismatch want: %v got: %v", want, got)
+	}
+
+	eb.MaxRecordsOverride = &want
+	if got := eb.EffectiveMaxRecords(450293); want != got {
+		t.Fatalf("mismatch want: %v got: %v", want, got)
+	}
+}

--- a/internal/export/worker_test.go
+++ b/internal/export/worker_test.go
@@ -265,7 +265,7 @@ func TestBatchExposures(t *testing.T) {
 					OnlyLocalProvenance: true,
 				}
 
-				groups, err := server.batchExposures(ctx, criteria, "US")
+				groups, err := server.batchExposures(ctx, criteria, config.MaxRecords, "US")
 				if err != nil {
 					t.Fatalf("failed to read exposures: %v", err)
 				}
@@ -296,7 +296,7 @@ func TestBatchExposures(t *testing.T) {
 					OnlyLocalProvenance: false,
 				}
 
-				groups, err := server.batchExposures(ctx, criteria, "REMOTE")
+				groups, err := server.batchExposures(ctx, criteria, config.MaxRecords, "REMOTE")
 				if err != nil {
 					t.Fatalf("failed to read exposures: %v", err)
 				}
@@ -324,7 +324,7 @@ func TestBatchExposures(t *testing.T) {
 					IncludeTravelers:    true,
 					OnlyLocalProvenance: true,
 				}
-				groups, err := server.batchExposures(ctx, criteria, "US")
+				groups, err := server.batchExposures(ctx, criteria, config.MaxRecords, "US")
 				if err != nil {
 					t.Fatalf("failed to read exposures: %v", err)
 				}
@@ -357,7 +357,7 @@ func TestBatchExposures(t *testing.T) {
 					OnlyNonTravelers:    true,
 					OnlyLocalProvenance: false,
 				}
-				groups, err := server.batchExposures(ctx, criteria, "REMOTE")
+				groups, err := server.batchExposures(ctx, criteria, config.MaxRecords, "REMOTE")
 				if err != nil {
 					t.Fatalf("failed to read exposures: %v", err)
 				}
@@ -439,7 +439,7 @@ func TestVariableBatchMaxSize(t *testing.T) {
 			OnlyLocalProvenance: true,
 		}
 
-		groups, err := server.batchExposures(ctx, criteria, "REMOTE")
+		groups, err := server.batchExposures(ctx, criteria, batchSize, "REMOTE")
 		if err != nil {
 			t.Fatalf("failed to read exposures: %v", err)
 		}

--- a/migrations/000053_AddMaxRecordsOverride.down.sql
+++ b/migrations/000053_AddMaxRecordsOverride.down.sql
@@ -1,0 +1,26 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Some systems don't support pgaudit, gracefully degrade in that case
+
+BEGIN;
+
+ALTER TABLE exportconfig
+  DROP column max_records_override;
+
+ALTER TABLE exportbatch
+  DROP column max_records_override;
+
+END;
+

--- a/migrations/000053_AddMaxRecordsOverride.up.sql
+++ b/migrations/000053_AddMaxRecordsOverride.up.sql
@@ -1,0 +1,26 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Some systems don't support pgaudit, gracefully degrade in that case
+
+BEGIN;
+
+-- default null of intentional
+ALTER TABLE exportconfig
+  ADD COLUMN max_records_override INT;
+
+ALTER TABLE exportbatch
+  ADD COLUMN max_records_override INT;
+
+END;

--- a/tools/admin-console/templates/export.html
+++ b/tools/admin-console/templates/export.html
@@ -101,6 +101,15 @@
       </div>
 
       <div class="form-label-group">
+        <input type="text" name="MaxRecordsOverride" id="max-records-override" value="{{.export.MaxRecordsOverride | deref}}"
+          placeholder="" class="form-control">
+        <label for="max-records-override">Max records per export file (override)</label>
+        <small class="form-text text-muted">
+          If set to a value > 0, override the system settings for this export only.
+        </small>
+      </div>
+
+      <div class="form-label-group">
         <input type="text" name="Period" id="period" value="{{.export.Period}}"
           placeholder="Export period" class="form-control">
         <label for="period">Export period</label>


### PR DESCRIPTION
Fixes #1214 

## Proposed Changes

* Allow exportconfig entries to override max records

**Release Note**


```release-note
Allow for individual exportconfigs to have variable sizes for the max records setting.
```