### PR TITLE
make data padding more better

### DIFF
--- a/internal/export/worker_test.go
+++ b/internal/export/worker_test.go
@@ -58,7 +58,7 @@ func TestDoNotPadZeroLength(t *testing.T) {
 	t.Parallel()
 
 	exposures := make([]*publishmodel.Exposure, 0)
-	exposures, generated, err := ensureMinNumExposures(exposures, "US", 1000, 100, time.Now())
+	exposures, generated, err := ensureMinNumExposures(exposures, "US", 1000, 100, 2000, time.Now())
 	if err != nil {
 		t.Fatalf("unepected error: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestEnsureMinExposures(t *testing.T) {
 
 	// pad the download.
 	inputSize := len(exposures)
-	exposures, generated, err := ensureMinNumExposures(exposures, "US", numKeys, variance, time.Now())
+	exposures, generated, err := ensureMinNumExposures(exposures, "US", numKeys, variance, numKeys*10, time.Now())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestEnsureMinExposures(t *testing.T) {
 	}
 	for k, v := range m {
 		if v < 20 {
-			t.Errorf("distribution not random, expected >= 30 keys with start interval %v, got %v", k, v)
+			t.Errorf("distribution not random, expected >= 20 keys with start interval %v, got %v", k, v)
 		}
 	}
 }


### PR DESCRIPTION

## Proposed Changes

* Take randomness out of export padding and just clone every key at least once
* Makes some paths less complicated, but makes many paths more complicated (see before and after)

Using the same source data:

Before:
![before](https://user-images.githubusercontent.com/92319/101428111-f45df880-38b4-11eb-9f02-617628dd38b6.png)

After
![after](https://user-images.githubusercontent.com/92319/101428120-f922ac80-38b4-11eb-84f5-709f9cb2fd51.png)

**Release Note**

```release-note
Export padding will clone every key at least once to better obscure TEK links.
```