### PR TITLE
don't stop retrying azure credential refresh on single failure

### DIFF
--- a/internal/storage/azure_blobstore.go
+++ b/internal/storage/azure_blobstore.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/google/exposure-notifications-server/pkg/signal"
 	"github.com/prometheus/common/log"
 )
 
@@ -60,7 +61,18 @@ func newMSITokenCredential(blobstoreURL string) (azblob.Credential, error) {
 		err := spt.Refresh()
 		if err != nil {
 			log.Errorf("failed to refresh access token: %v", err)
-			return 0
+
+			token := spt.Token()
+			if token.Expires().After(time.Now().UTC()) {
+				log.Errorf("access token expired - shutting down server")
+				if err := signal.SendInterrupt(); err != nil {
+					// extreme measures.
+					log.Fatalf("unable to shot down server safely: %v", err)
+				}
+			}
+
+			// Retry again in 1 minute.
+			return time.Minute
 		}
 
 		token := spt.Token()

--- a/internal/storage/azure_blobstore.go
+++ b/internal/storage/azure_blobstore.go
@@ -71,8 +71,10 @@ func newMSITokenCredential(blobstoreURL string) (azblob.Credential, error) {
 				}
 			}
 
-			// Retry again in 1 minute.
-			return time.Minute
+			// Retry again in 15 seconds.
+			// Max of ~8 retries since refresh is normally scheduled for 2 minutes
+			// prior to expiration.
+			return 15 * time.Second
 		}
 
 		token := spt.Token()

--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package signal provides convenance methods for sending interrupt signals to the self process.
+package signal
+
+import (
+	"fmt"
+	"os"
+)
+
+// SendInterrupt sends an interrupt to the current process.
+func SendInterrupt() error {
+	pid := os.Getpid()
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("unable to find own pid: %w", err)
+	}
+
+	err = proc.Signal(os.Interrupt)
+	if err != nil {
+		return fmt.Errorf("signal: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #1213

## Proposed Changes

* Keep retrying azure blobstore credential refresh 
* If the token expires, cause the server to gracefully shutdown

**Release Note**

```release-note
Retry Azure credential refresh in the event of a refresh failure. Shutdown if token expires.
```

/assign @nmiodice 