### PR TITLE
Bump export service to 2G RAM

### DIFF
--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -86,7 +86,7 @@ resource "google_cloud_run_service" "export" {
         resources {
           limits = {
             cpu    = "2000m"
-            memory = "1G"
+            memory = "2G"
           }
         }
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-server/issues/1219

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Bump export service to 2G RAM
```