### PR TITLE
Use proper unit and avoid converting between units.

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -13,20 +13,20 @@
 # limitations under the License.
 
 locals {
-  p50_latency_thresholds_in_seconds = {
+  p50_latency_thresholds= {
     export         = 600
     cleanup-export = 60
     generate       = 30
   }
-  p50_latency_thresholds_in_seconds_default = 10
+  p50_latency_thresholds_default = 10
 
   p50_latency_condition = join("\n|| ", concat(
     [
-      for k, v in local.p50_latency_thresholds_in_seconds :
-      "(resource.service_name == '${k}' && val > ${v * 1000} 'ms')"
+      for k, v in local.p50_latency_thresholds:
+      "(resource.service_name == '${k}' && val > ${v} 's')"
     ],
     [
-      "(val > ${local.p50_latency_thresholds_in_seconds_default * 1000} 'ms')"
+      "(val > ${local.p50_latency_thresholds_default} 's')"
     ]
   ))
 }

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 locals {
-  p50_latency_thresholds= {
+  p50_latency_thresholds = {
     export         = 600
     cleanup-export = 60
     generate       = 30


### PR DESCRIPTION
It looks like the 'm' in 'ms' is a PREFIX_SYMBOL of 's' and we can use
's' as unit directly.

Reference: https://cloud.google.com/monitoring/mql/reference#units-of-measure