### PR TITLE
Remove the reference to the metrics middleware.

### DIFF
--- a/internal/federationin/federationin.go
+++ b/internal/federationin/federationin.go
@@ -30,8 +30,7 @@ import (
 	coredb "github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/federationin/database"
 	"github.com/google/exposure-notifications-server/internal/federationin/model"
-	"github.com/google/exposure-notifications-server/internal/metrics"
-	"github.com/google/exposure-notifications-server/internal/metrics/metricsware"
+	"github.com/google/exposure-notifications-server/internal/metrics/federationin"
 	"github.com/google/exposure-notifications-server/internal/pb/federation"
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
@@ -45,6 +44,7 @@ import (
 	"google.golang.org/grpc/credentials/oauth"
 
 	"go.opencensus.io/plugin/ocgrpc"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 )
 
@@ -93,23 +93,21 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	logger := logging.FromContext(ctx)
-	metrics := h.env.MetricsExporter(ctx)
-	metricsMiddleWare := metricsware.NewMiddleWare(&metrics)
 
 	queryIDs, ok := r.URL.Query()[queryParam]
 	if !ok {
-		metricsMiddleWare.RecordPullInvalidRequest(ctx)
+		stats.Record(ctx, federationin.PullInvalidRequest.M(1))
 		badRequestf(ctx, w, "%s is required", queryParam)
 		return
 	}
 	if len(queryIDs) > 1 {
-		metricsMiddleWare.RecordPullInvalidRequest(ctx)
+		stats.Record(ctx, federationin.PullInvalidRequest.M(1))
 		badRequestf(ctx, w, "only one %s allowed", queryParam)
 		return
 	}
 	queryID := queryIDs[0]
 	if queryID == "" {
-		metricsMiddleWare.RecordPullInvalidRequest(ctx)
+		stats.Record(ctx, federationin.PullInvalidRequest.M(1))
 		badRequestf(ctx, w, "%s is required", queryParam)
 		return
 	}
@@ -119,7 +117,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	unlockFn, err := h.db.Lock(ctx, lock, h.config.Timeout)
 	if err != nil {
 		if errors.Is(err, coredb.ErrAlreadyLocked) {
-			metricsMiddleWare.RecordPullLockContention(ctx)
+			stats.Record(ctx, federationin.PullLockContention.M(1))
 			msg := fmt.Sprintf("Lock %s already in use. No work will be performed.", lock)
 			logger.Infof(msg)
 			fmt.Fprint(w, msg) // We return status 200 here so that Cloud Scheduler does not retry.
@@ -206,7 +204,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		maxMagnitudeSymptomOnsetDays: h.config.MaxMagnitudeSymptomOnsetDays,
 		debugReleaseSameDay:          h.config.ReleaseSameDayKeys,
 	}
-	if err := pull(timeoutContext, metrics, &opts); err != nil {
+	if err := pull(timeoutContext, &opts); err != nil {
 		internalErrorf(ctx, w, "Federation query %q failed: %v", queryID, err)
 		return
 	}
@@ -300,9 +298,7 @@ func buildExposure(e *federation.ExposureKey, config *Config) (*publishmodel.Exp
 	return &exposure, nil
 }
 
-func pull(ctx context.Context, metrics metrics.Exporter, opts *pullOptions) (err error) {
-	metricsMiddleWare := metricsware.NewMiddleWare(&metrics)
-
+func pull(ctx context.Context, opts *pullOptions) (err error) {
 	ctx, span := trace.StartSpan(ctx, "federationin.pull")
 	defer func() {
 		if err != nil {
@@ -393,8 +389,8 @@ func pull(ctx context.Context, metrics metrics.Exporter, opts *pullOptions) (err
 				return fmt.Errorf("inserting %d exposures: %w", len(newExposures), err)
 			}
 			// Success, update metrics
-			metricsMiddleWare.RecordPullInsertions(ctx, int(resp.Inserted))
-			metricsMiddleWare.RecordPullDropped(ctx, int(resp.Dropped))
+			stats.Record(ctx, federationin.PullInserts.M(int64(resp.Inserted)))
+			stats.Record(ctx, federationin.PullDropped.M(int64(resp.Dropped)))
 
 			total += int(resp.Inserted)
 		} else {
@@ -431,8 +427,8 @@ func pull(ctx context.Context, metrics metrics.Exporter, opts *pullOptions) (err
 				return fmt.Errorf("revising %d exposures: %w", len(revisedExposures), err)
 			}
 			// Success, update metrics
-			metricsMiddleWare.RecordPullRevisions(ctx, int(resp.Revised))
-			metricsMiddleWare.RecordPullDropped(ctx, int(resp.Dropped))
+			stats.Record(ctx, federationin.PullRevisions.M(int64(resp.Revised)))
+			stats.Record(ctx, federationin.PullDropped.M(int64(resp.Dropped)))
 
 			total += int(resp.Revised)
 		} else {

--- a/internal/federationin/federationin_test.go
+++ b/internal/federationin/federationin_test.go
@@ -25,7 +25,6 @@ import (
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 
-	"github.com/google/exposure-notifications-server/internal/metrics"
 	"github.com/google/exposure-notifications-server/internal/pb/federation"
 
 	"github.com/google/go-cmp/cmp"
@@ -437,7 +436,7 @@ func TestFederationPull(t *testing.T) {
 				maxMagnitudeSymptomOnsetDays: 14,
 			}
 
-			err := pull(ctx, metrics.NewLogsBasedFromContext(ctx), &opts)
+			err := pull(ctx, &opts)
 			if err != nil {
 				t.Fatalf("pull returned err=%v, want err=nil", err)
 			}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -25,10 +25,11 @@ import (
 	"net/http"
 	"time"
 
+	"go.opencensus.io/stats"
 	"go.opencensus.io/trace"
 
 	"github.com/google/exposure-notifications-server/internal/authorizedapp"
-	"github.com/google/exposure-notifications-server/internal/metrics/metricsware"
+	"github.com/google/exposure-notifications-server/internal/metrics/publish"
 	"github.com/google/exposure-notifications-server/internal/pb"
 	"github.com/google/exposure-notifications-server/internal/publish/database"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
@@ -189,8 +190,6 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 	defer span.End()
 
 	logger := logging.FromContext(ctx).With("health_authority_id", data.HealthAuthorityID)
-	metrics := h.serverenv.MetricsExporter(ctx)
-	metricsMiddleWare := metricsware.NewMiddleWare(&metrics)
 
 	logger.Info("publish API request")
 
@@ -209,7 +208,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 					Code:         verifyapi.ErrorUnknownHealthAuthorityID,
 				},
 				metrics: func() {
-					metricsMiddleWare.RecordHealthAuthorityNotAuthorized(ctx)
+					stats.Record(ctx, publish.HealthAuthorityNotAuthorized.M(1))
 				},
 			}
 		}
@@ -228,7 +227,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 				Code:         verifyapi.ErrorUnableToLoadHealthAuthority,
 			},
 			metrics: func() {
-				metricsMiddleWare.RecordErrorLoadingAuthorizedApp(ctx)
+				stats.Record(ctx, publish.ErrorLoadingAuthorizedApp.M(1))
 			},
 		}
 	}
@@ -250,7 +249,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 						ErrorMessage: message, // Error code omitted, since this isn't in the v1 path.
 					},
 					metrics: func() {
-						metricsMiddleWare.RecordRegionNotAuthorized(ctx)
+						stats.Record(ctx, publish.RegionNotAuthorized.M(1))
 					},
 				}
 			}
@@ -280,7 +279,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 				Code:         verifyapi.ErrorHealthAuthorityMissingRegionConfiguration,
 			},
 			metrics: func() {
-				metricsMiddleWare.RecordRegionNotSpecified(ctx)
+				stats.Record(ctx, publish.RegionNotSpecified.M(1))
 			},
 		}
 	}
@@ -290,7 +289,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 	if err != nil {
 		if appConfig.BypassHealthAuthorityVerification {
 			logger.Warnf("bypassing health authority certificate verification health authority: %v", appConfig.AppPackageName)
-			metricsMiddleWare.RecordVerificationBypassed(ctx)
+			stats.Record(ctx, publish.VerificationBypassed.M(1))
 		} else {
 			message := fmt.Sprintf("unable to validate diagnosis verification: %v", err)
 			if h.config.DebugLogBadCertificates {
@@ -306,7 +305,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 					Code:         verifyapi.ErrorVerificationCertificateInvalid,
 				},
 				metrics: func() {
-					metricsMiddleWare.RecordBadVerification(ctx)
+					stats.Record(ctx, publish.BadVerification.M(1))
 				},
 			}
 		}
@@ -346,7 +345,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 				Warnings:     transformWarnings,
 			},
 			metrics: func() {
-				metricsMiddleWare.RecordTransformFail(ctx)
+				stats.Record(ctx, publish.TransformFail.M(1))
 			},
 		}
 	}
@@ -396,7 +395,7 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 				Warnings:     transformWarnings,
 			},
 			metrics: func() {
-				metricsMiddleWare.RecordRevisionTokenIssue(ctx, metric)
+				stats.Record(ctx, publish.RevisionTokenIssue.M(1))
 			},
 		}
 	}
@@ -443,9 +442,9 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 		status:      http.StatusOK,
 		pubResponse: &publishResponse,
 		metrics: func() {
-			metricsMiddleWare.RecordInsertions(ctx, int(resp.Inserted))
-			metricsMiddleWare.RecordRevisions(ctx, int(resp.Revised))
-			metricsMiddleWare.RecordDrops(ctx, int(resp.Dropped))
+			stats.Record(ctx, publish.ExposuresInserted.M(int64(resp.Inserted)))
+			stats.Record(ctx, publish.ExposuresInserted.M(int64(resp.Revised)))
+			stats.Record(ctx, publish.ExposuresInserted.M(int64(resp.Dropped)))
 		},
 	}
 }

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -395,6 +395,9 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, b
 				Warnings:     transformWarnings,
 			},
 			metrics: func() {
+				// TODO(yegle): we want to use this string later when we
+				// refactor the metrics.
+				_ = metric
 				stats.Record(ctx, publish.RevisionTokenIssue.M(1))
 			},
 		}


### PR DESCRIPTION
Per the internal discussion, we don't actually use the log based metric
exporter. It would be simpler to just call stats.Record directly without
an extra layer of indirection.