### PR TITLE
Terraform: VPC connector depends on service networking connection

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -87,6 +87,7 @@ resource "google_vpc_access_connector" "connector" {
   max_throughput = var.vpc_access_connector_max_throughput
 
   depends_on = [
+    google_service_networking_connection.private_vpc_connection,
     google_project_service.services["compute.googleapis.com"],
     google_project_service.services["vpcaccess.googleapis.com"],
   ]


### PR DESCRIPTION
Adapted from verification server terrafrom config, terraform could be flaky without this

