### PR TITLE
additional data defaults when importing keys from export files

### DIFF
--- a/internal/exportimport/config.go
+++ b/internal/exportimport/config.go
@@ -37,6 +37,11 @@ type Config struct {
 	IndexFileDownloadTimeout  time.Duration `env:"INDEX_FILE_DOWNLOAD_TIMEOUT, default=30s"`
 	ExportFileDownloadTimeout time.Duration `env:"EXPORT_FILE_DOWNLOAD_TIMEOUT, default=2m"`
 
+	// For importing files that may have missed setting v1.5+ fields.
+	BackfillReportType          string `env:"BACKFILL_REPORT_TYPE, default=confirmed"`
+	BackfillDaysSinceOnset      bool   `env:"BACKFILL_DAYS_SINCE_ONSET, default=true"`
+	BackfillDaysSinceOnsetValue int    `env:"BACKFILL_DAYS_SINCE_ONSET_VALUE, default=10"`
+
 	MaxInsertBatchSize           int           `env:"MAX_INSERT_BATCH_SIZE, default=100"`
 	MaxIntervalAge               time.Duration `env:"MAX_INTERVAL_AGE_ON_PUBLISH, default=360h"`
 	MaxMagnitudeSymptomOnsetDays uint          `env:"MAX_SYMPTOM_ONSET_DAYS, default=14"`

--- a/internal/exportimport/server.go
+++ b/internal/exportimport/server.go
@@ -24,6 +24,7 @@ import (
 	eidb "github.com/google/exposure-notifications-server/internal/exportimport/database"
 	pubdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/server"
 )
 
@@ -41,6 +42,10 @@ type Server struct {
 func NewServer(config *Config, env *serverenv.ServerEnv) (*Server, error) {
 	if env.Database() == nil {
 		return nil, fmt.Errorf("missing database in server environment")
+	}
+
+	if rt := config.BackfillReportType; !(rt == "" || rt == verifyapi.ReportTypeConfirmed || rt == verifyapi.ReportTypeClinical) {
+		return nil, fmt.Errorf("BACKFILL_REPORT_TYPE value is invalid, must be %q, %q, or %q", "", verifyapi.ReportTypeConfirmed, verifyapi.ReportTypeClinical)
 	}
 
 	db := env.Database()


### PR DESCRIPTION
Fixes #1229

## Proposed Changes

For export-importer
* backfill report type
* backfill transmission risk
* backfill days since onset

**Release Note**

```release-note
Export-importer changes to backfill missing data on export files during processing.
```

/hold