### PR TITLE
Exclude a rule in Cloud Armor.

### DIFF
--- a/terraform/dos.tf
+++ b/terraform/dos.tf
@@ -29,7 +29,17 @@ resource "google_compute_security_policy" "cloud-armor" {
     action      = "deny(403)"
     description = "SQL Injection protection"
     match {
-      expr { expression = "evaluatePreconfiguredExpr('sqli-stable')" }
+      expr {
+        expression = <<-EOT
+        evaluatePreconfiguredExpr(
+          'sqli-stable',
+          [
+            // Causes Content-Type:application/json request to fail.
+            'owasp-crs-v030001-id942432-sqli'
+          ]
+        )
+        EOT
+      }
     }
     preview  = true
     priority = 20


### PR DESCRIPTION
This rule seems to cause Content-Type:applicatition/json requests to
fail.