### PR TITLE
Do not ignore annotation changes

### DIFF
--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -104,6 +104,7 @@ resource "google_cloud_run_service" "cleanup-export" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -117,7 +118,9 @@ resource "google_cloud_run_service" "cleanup-export" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -98,6 +98,7 @@ resource "google_cloud_run_service" "cleanup-exposure" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -111,7 +112,9 @@ resource "google_cloud_run_service" "cleanup-exposure" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_debugger.tf
+++ b/terraform/service_debugger.tf
@@ -106,6 +106,7 @@ resource "google_cloud_run_service" "debugger" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "10",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -119,7 +120,9 @@ resource "google_cloud_run_service" "debugger" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -114,6 +114,7 @@ resource "google_cloud_run_service" "export" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "10",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -127,7 +128,9 @@ resource "google_cloud_run_service" "export" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_export_importer.tf
+++ b/terraform/service_export_importer.tf
@@ -102,6 +102,7 @@ resource "google_cloud_run_service" "export-importer" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "10",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -115,7 +116,9 @@ resource "google_cloud_run_service" "export-importer" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -114,6 +114,7 @@ resource "google_cloud_run_service" "exposure" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "500",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -127,7 +128,9 @@ resource "google_cloud_run_service" "exposure" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -98,6 +98,7 @@ resource "google_cloud_run_service" "federationin" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "3",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -111,7 +112,9 @@ resource "google_cloud_run_service" "federationin" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -98,6 +98,7 @@ resource "google_cloud_run_service" "federationout" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "5",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -111,7 +112,9 @@ resource "google_cloud_run_service" "federationout" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -98,6 +98,7 @@ resource "google_cloud_run_service" "generate" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -111,7 +112,9 @@ resource "google_cloud_run_service" "generate" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_jwks.tf
+++ b/terraform/service_jwks.tf
@@ -98,6 +98,7 @@ resource "google_cloud_run_service" "jwks" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -111,7 +112,9 @@ resource "google_cloud_run_service" "jwks" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_keyrotation.tf
+++ b/terraform/service_keyrotation.tf
@@ -114,6 +114,7 @@ resource "google_cloud_run_service" "key-rotation" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -127,7 +128,9 @@ resource "google_cloud_run_service" "key-rotation" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }

--- a/terraform/service_mirror.tf
+++ b/terraform/service_mirror.tf
@@ -102,6 +102,7 @@ resource "google_cloud_run_service" "mirror" {
       annotations = {
         "autoscaling.knative.dev/maxScale" : "10",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
       }
     }
   }
@@ -115,7 +116,9 @@ resource "google_cloud_run_service" "mirror" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations,
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
     ]
   }


### PR DESCRIPTION
The annotation will be used to do the ingress control (currently EAP).

Part of https://github.com/google/exposure-notifications-verification-server/issues/895