### PR TITLE
Update google provider to 3.51

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -255,11 +255,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.36"
+      version = "~> 3.51"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.36"
+      version = "~> 3.51"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
This release fixed https://github.com/hashicorp/terraform-provider-google/pull/8006