### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/design/verification_protocol.md
+++ b/docs/design/verification_protocol.md
@@ -87,7 +87,7 @@ Standard JWT headers must be provided.
 
 * `alg` : _REQUIRED_ and must be set to `ES256`
 * `kid` : _REQUIRED_ and indicate a specific key ID to use for verification
-* `twp` : _REQUIRED_ and must be set to `JWT`
+* `typ` : _REQUIRED_ and must be set to `JWT`
 
 ### HMAC Calculation
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Fixes typo in the documentation.

* JWT header field name: `twp` -> `typ`
  * https://tools.ietf.org/html/rfc7519#section-5.1

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```