### PR TITLE
Refactor Terraform to allow easy override of Cloud Run service annotations

### DIFF
--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -101,11 +101,14 @@ resource "google_cloud_run_service" "cleanup-export" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -101,13 +101,10 @@ resource "google_cloud_run_service" "cleanup-export" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "1",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "cleanup_export", {}),
       )
     }
   }

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -95,13 +95,10 @@ resource "google_cloud_run_service" "cleanup-exposure" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "1",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "cleanup_exposure", {}),
       )
     }
   }

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -95,11 +95,14 @@ resource "google_cloud_run_service" "cleanup-exposure" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 

--- a/terraform/service_debugger.tf
+++ b/terraform/service_debugger.tf
@@ -103,11 +103,14 @@ resource "google_cloud_run_service" "debugger" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "10",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 
@@ -169,7 +172,7 @@ resource "google_compute_backend_service" "debugger" {
   }
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
-    enable = var.enable_lb_logging
+    enable = local.enable_lb_logging
   }
 }
 

--- a/terraform/service_debugger.tf
+++ b/terraform/service_debugger.tf
@@ -103,13 +103,10 @@ resource "google_cloud_run_service" "debugger" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "10",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "debugger", {}),
       )
     }
   }

--- a/terraform/service_debugger.tf
+++ b/terraform/service_debugger.tf
@@ -172,7 +172,7 @@ resource "google_compute_backend_service" "debugger" {
   }
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
-    enable = local.enable_lb_logging
+    enable = var.enable_lb_logging
   }
 }
 

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -111,13 +111,10 @@ resource "google_cloud_run_service" "export" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "10",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "export", {}),
       )
     }
   }

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -111,11 +111,14 @@ resource "google_cloud_run_service" "export" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "10",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 

--- a/terraform/service_export_importer.tf
+++ b/terraform/service_export_importer.tf
@@ -99,11 +99,14 @@ resource "google_cloud_run_service" "export-importer" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "10",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 

--- a/terraform/service_export_importer.tf
+++ b/terraform/service_export_importer.tf
@@ -99,13 +99,10 @@ resource "google_cloud_run_service" "export-importer" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "10",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "export-importer", {}),
       )
     }
   }

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -111,11 +111,14 @@ resource "google_cloud_run_service" "exposure" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "500",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 
@@ -175,7 +178,7 @@ resource "google_compute_backend_service" "exposure" {
   }
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
-    enable = var.enable_lb_logging
+    enable = local.enable_lb_logging
   }
 }
 

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -111,13 +111,10 @@ resource "google_cloud_run_service" "exposure" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "500",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "exposure", {}),
       )
     }
   }

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -178,7 +178,7 @@ resource "google_compute_backend_service" "exposure" {
   }
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
-    enable = local.enable_lb_logging
+    enable = var.enable_lb_logging
   }
 }
 

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -95,13 +95,10 @@ resource "google_cloud_run_service" "federationin" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "3",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "federationin", {}),
       )
     }
   }

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -95,11 +95,14 @@ resource "google_cloud_run_service" "federationin" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "3",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -95,11 +95,14 @@ resource "google_cloud_run_service" "federationout" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "5",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 
@@ -159,7 +162,7 @@ resource "google_compute_backend_service" "federationout" {
   }
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
-    enable = var.enable_lb_logging
+    enable = local.enable_lb_logging
   }
 }
 

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -95,13 +95,10 @@ resource "google_cloud_run_service" "federationout" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "5",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "federationout", {}),
       )
     }
   }

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -162,7 +162,7 @@ resource "google_compute_backend_service" "federationout" {
   }
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
-    enable = local.enable_lb_logging
+    enable = var.enable_lb_logging
   }
 }
 

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -95,13 +95,10 @@ resource "google_cloud_run_service" "generate" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "1",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "generate", {}),
       )
     }
   }

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -95,11 +95,14 @@ resource "google_cloud_run_service" "generate" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 

--- a/terraform/service_jwks.tf
+++ b/terraform/service_jwks.tf
@@ -95,13 +95,10 @@ resource "google_cloud_run_service" "jwks" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "1",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "jwks", {}),
       )
     }
   }

--- a/terraform/service_jwks.tf
+++ b/terraform/service_jwks.tf
@@ -95,11 +95,14 @@ resource "google_cloud_run_service" "jwks" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 

--- a/terraform/service_keyrotation.tf
+++ b/terraform/service_keyrotation.tf
@@ -111,11 +111,14 @@ resource "google_cloud_run_service" "key-rotation" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "1",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 

--- a/terraform/service_keyrotation.tf
+++ b/terraform/service_keyrotation.tf
@@ -111,13 +111,10 @@ resource "google_cloud_run_service" "key-rotation" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "1",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "key_rotation", {}),
       )
     }
   }

--- a/terraform/service_mirror.tf
+++ b/terraform/service_mirror.tf
@@ -99,13 +99,10 @@ resource "google_cloud_run_service" "mirror" {
     }
 
     metadata {
-      annotations = merge({
-        "autoscaling.knative.dev/maxScale" : "10",
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-        }, local.enable_lb ? {
-        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
-        } : {}
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "mirror", {}),
       )
     }
   }

--- a/terraform/service_mirror.tf
+++ b/terraform/service_mirror.tf
@@ -99,11 +99,14 @@ resource "google_cloud_run_service" "mirror" {
     }
 
     metadata {
-      annotations = {
+      annotations = merge({
         "autoscaling.knative.dev/maxScale" : "10",
         "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
         "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+        }, local.enable_lb ? {
+        "run.googleapis.com/ingress" : "internal-and-cloud-load-balancing"
+        } : {}
+      )
     }
   }
 

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -258,6 +258,31 @@ variable "enable_lb_logging" {
   EOT
 }
 
+variable "service_annotations" {
+  type    = map(map(string))
+  default = {}
+
+  description = "Per-service additional annotations."
+}
+
+locals {
+  default_annotations = {
+    "autoscaling.knative.dev/maxScale" : "1",
+    "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
+    "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+  }
+}
+
+variable "default_annotations_overrides" {
+  type    = map(string)
+  default = {}
+
+  description = <<-EOT
+  Annotations that applies to all services. Can be used to override
+  default_annotations.
+  EOT
+}
+
 terraform {
   required_version = ">= 0.14.2"
 


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/895

```release-note
Breaking: To continue using the Terraform module, the following input variable is needed to avoid introducing a diff:

service_annotations = {
    debugger        = { "autoscaling.knative.dev/maxScale" : "10" }
    export          = { "autoscaling.knative.dev/maxScale" : "10" }
    export-importer = { "autoscaling.knative.dev/maxScale" : "10" }
    exposure        = { "autoscaling.knative.dev/maxScale" : "500" }
    federationin    = { "autoscaling.knative.dev/maxScale" : "3" }
    federationout   = { "autoscaling.knative.dev/maxScale" : "5" }
    mirror          = { "autoscaling.knative.dev/maxScale" : "10" }
}
```