### PR TITLE
Improve control over logging package

### DIFF
--- a/cmd/cleanup-export/main.go
+++ b/cmd/cleanup-export/main.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/cleanup"
@@ -34,11 +32,9 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
-
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
 	err := realMain(ctx)

--- a/cmd/cleanup-exposure/main.go
+++ b/cmd/cleanup-exposure/main.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/cleanup"
@@ -34,10 +32,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -18,8 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/debugger"
@@ -32,10 +30,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/export-importer/main.go
+++ b/cmd/export-importer/main.go
@@ -18,8 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/exportimport"
@@ -32,10 +30,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -18,8 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/export"
@@ -33,10 +31,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/publish"
@@ -35,10 +34,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/federationin/main.go
+++ b/cmd/federationin/main.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/federationin"
@@ -35,10 +33,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/federationout/main.go
+++ b/cmd/federationout/main.go
@@ -18,8 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -39,10 +37,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/generate"
@@ -35,10 +33,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/jwks-updater/main.go
+++ b/cmd/jwks-updater/main.go
@@ -19,8 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/setup"
@@ -33,10 +31,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/key-rotation/main.go
+++ b/cmd/key-rotation/main.go
@@ -18,8 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/keyrotation"
@@ -33,10 +31,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/golang-migrate/migrate/v4"
+	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/logging"
@@ -37,6 +38,11 @@ func main() {
 	flag.Parse()
 
 	ctx, done := signalcontext.OnInterrupt()
+
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	err := realMain(ctx)
 	done()

--- a/cmd/mirror/main.go
+++ b/cmd/mirror/main.go
@@ -18,8 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/mirror"
@@ -32,10 +30,10 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
-	logger = logger.With("build_id", buildinfo.BuildID)
-	logger = logger.With("build_tag", buildinfo.BuildTag)
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
 
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/docs/getting-started/development.md
+++ b/docs/getting-started/development.md
@@ -45,6 +45,10 @@ represent best practices.
     # Disable observability locally.
     export OBSERVABILITY_EXPORTER="NOOP"
 
+    # Configure local logging.
+    export LOG_LEVEL="debug"
+    export LOG_MODE="development"
+
     # Configure key management for revision tokens. Create your own revision
     # token AAD with:
     #

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -42,7 +42,6 @@ import (
 	vermodel "github.com/google/exposure-notifications-server/internal/verification/model"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-server/pkg/keys"
-	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/exposure-notifications-server/pkg/util"
 	"github.com/jackc/pgx/v4"
@@ -485,10 +484,6 @@ func TestPublishWithBypass(t *testing.T) {
 			}
 
 			t.Run(addVer+tc.Name, func(t *testing.T) {
-				ctx = context.Background()
-				logger := logging.NewLogger(true)
-				ctx = logging.WithLogger(ctx, logger)
-
 				// And set up publish handler up front.
 				config := Config{}
 				config.AuthorizedApp.CacheDuration = time.Nanosecond

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -24,7 +24,7 @@ import (
 func TestNewLogger(t *testing.T) {
 	t.Parallel()
 
-	logger := logging.NewLogger(true)
+	logger := logging.NewLogger("", true)
 	if logger == nil {
 		t.Fatal("expected logger to never be nil")
 	}

--- a/terraform-e2e-ci/main.tf
+++ b/terraform-e2e-ci/main.tf
@@ -43,17 +43,18 @@ module "en" {
       TRUNCATE_WINDOW = "1s"
       MIN_WINDOW_AGE  = "1s"
 
-      LOG_DEBUG = "true"
+      LOG_LEVEL = "debug"
     }
 
     exposure = {
       TRUNCATE_WINDOW             = "1s"
       DEBUG_RELEASE_SAME_DAY_KEYS = true
-      LOG_DEBUG                   = "true"
+
+      LOG_LEVEL = "debug"
     }
 
     generate = {
-      LOG_DEBUG = "true"
+      LOG_LEVEL = "debug"
     }
   }
 }

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -22,14 +22,13 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"time"
 
 	authorizedappdatabase "github.com/google/exposure-notifications-server/internal/authorizedapp/database"
 	authorizedappmodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
+	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	verificationdatabase "github.com/google/exposure-notifications-server/internal/verification/database"
@@ -43,8 +42,9 @@ import (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug)
+	logger := logging.NewLoggerFromEnv().Named("tools.seed")
+	logger = logger.With("build_id", buildinfo.BuildID)
+	logger = logger.With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
 	err := realMain(ctx)

--- a/tools/sign/main.go
+++ b/tools/sign/main.go
@@ -24,8 +24,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
@@ -43,11 +41,9 @@ var (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug).Named("tools.sign")
+	logger := logging.NewLoggerFromEnv().Named("tools.sign")
 	logger = logger.With("build_id", buildinfo.BuildID)
 	logger = logger.With("build_tag", buildinfo.BuildTag)
-
 	ctx = logging.WithLogger(ctx, logger)
 
 	err := realMain(ctx)

--- a/tools/verify/main.go
+++ b/tools/verify/main.go
@@ -26,8 +26,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"os"
-	"strconv"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
@@ -45,11 +43,9 @@ var (
 func main() {
 	ctx, done := signalcontext.OnInterrupt()
 
-	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
-	logger := logging.NewLogger(debug).Named("tools.verify")
+	logger := logging.NewLoggerFromEnv().Named("tools.verify")
 	logger = logger.With("build_id", buildinfo.BuildID)
 	logger = logger.With("build_tag", buildinfo.BuildTag)
-
 	ctx = logging.WithLogger(ctx, logger)
 
 	err := realMain(ctx)


### PR DESCRIPTION
The previous implementation conflated "development" mode with logging levels. Development mode is a special zap construct that changes the behavior of the logger whereas the log level is independent of the mode. This commit separates the mode from the level, allowing more control over the log levels.

It also codifies the environment variables used to find the level and mode in the logging package, which reduces some of the complexity of creating a logger.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Improve control over logging package
```