### PR TITLE
Fix the Cloud Run annotations

### DIFF
--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -70,6 +70,13 @@ resource "google_cloud_run_service" "cleanup-export" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "cleanup_export", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.cleanup-export.email
@@ -102,9 +109,9 @@ resource "google_cloud_run_service" "cleanup-export" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "cleanup_export", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "cleanup_export", {}),
       )
     }
   }
@@ -122,6 +129,8 @@ resource "google_cloud_run_service" "cleanup-export" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -64,6 +64,13 @@ resource "google_cloud_run_service" "cleanup-exposure" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "cleanup_exposure", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.cleanup-exposure.email
@@ -96,9 +103,9 @@ resource "google_cloud_run_service" "cleanup-exposure" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "cleanup_exposure", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "cleanup_exposure", {}),
       )
     }
   }
@@ -116,6 +123,8 @@ resource "google_cloud_run_service" "cleanup-exposure" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_debugger.tf
+++ b/terraform/service_debugger.tf
@@ -70,6 +70,13 @@ resource "google_cloud_run_service" "debugger" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "debugger", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.debugger.email
@@ -104,9 +111,9 @@ resource "google_cloud_run_service" "debugger" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "debugger", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "debugger", {}),
       )
     }
   }
@@ -124,6 +131,8 @@ resource "google_cloud_run_service" "debugger" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -76,6 +76,13 @@ resource "google_cloud_run_service" "export" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "export", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.export.email
@@ -112,9 +119,9 @@ resource "google_cloud_run_service" "export" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "export", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "export", {}),
       )
     }
   }
@@ -132,6 +139,8 @@ resource "google_cloud_run_service" "export" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_export_importer.tf
+++ b/terraform/service_export_importer.tf
@@ -64,6 +64,13 @@ resource "google_cloud_run_service" "export-importer" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "export-importer", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.export-importer.email
@@ -100,9 +107,9 @@ resource "google_cloud_run_service" "export-importer" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "export-importer", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "export-importer", {}),
       )
     }
   }
@@ -120,6 +127,8 @@ resource "google_cloud_run_service" "export-importer" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -76,6 +76,13 @@ resource "google_cloud_run_service" "exposure" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "exposure", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.exposure.email
@@ -112,9 +119,9 @@ resource "google_cloud_run_service" "exposure" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "exposure", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "exposure", {}),
       )
     }
   }
@@ -132,6 +139,8 @@ resource "google_cloud_run_service" "exposure" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -64,6 +64,13 @@ resource "google_cloud_run_service" "federationin" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "federationin", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.federationin.email
@@ -96,9 +103,9 @@ resource "google_cloud_run_service" "federationin" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "federationin", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "federationin", {}),
       )
     }
   }
@@ -116,6 +123,8 @@ resource "google_cloud_run_service" "federationin" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -64,6 +64,13 @@ resource "google_cloud_run_service" "federationout" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "federationout", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.federationout.email
@@ -96,9 +103,9 @@ resource "google_cloud_run_service" "federationout" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "federationout", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "federationout", {}),
       )
     }
   }
@@ -116,6 +123,8 @@ resource "google_cloud_run_service" "federationout" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -64,6 +64,13 @@ resource "google_cloud_run_service" "generate" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "generate", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.generate.email
@@ -96,9 +103,9 @@ resource "google_cloud_run_service" "generate" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "generate", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "generate", {}),
       )
     }
   }
@@ -116,6 +123,8 @@ resource "google_cloud_run_service" "generate" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_jwks.tf
+++ b/terraform/service_jwks.tf
@@ -64,6 +64,13 @@ resource "google_cloud_run_service" "jwks" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "jwks", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.jwks.email
@@ -96,9 +103,9 @@ resource "google_cloud_run_service" "jwks" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "jwks", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "jwks", {}),
       )
     }
   }
@@ -116,6 +123,8 @@ resource "google_cloud_run_service" "jwks" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_keyrotation.tf
+++ b/terraform/service_keyrotation.tf
@@ -76,6 +76,13 @@ resource "google_cloud_run_service" "key-rotation" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "key_rotation", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.key-rotation.email
@@ -112,9 +119,9 @@ resource "google_cloud_run_service" "key-rotation" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "key_rotation", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "key_rotation", {}),
       )
     }
   }
@@ -132,6 +139,8 @@ resource "google_cloud_run_service" "key-rotation" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_mirror.tf
+++ b/terraform/service_mirror.tf
@@ -64,6 +64,13 @@ resource "google_cloud_run_service" "mirror" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "mirror", {}),
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.mirror.email
@@ -100,9 +107,9 @@ resource "google_cloud_run_service" "mirror" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "mirror", {}),
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "mirror", {}),
       )
     }
   }
@@ -120,6 +127,8 @@ resource "google_cloud_run_service" "mirror" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -258,31 +258,64 @@ variable "enable_lb_logging" {
   EOT
 }
 
-variable "service_annotations" {
-  type    = map(map(string))
-  default = {}
-
-  description = "Per-service additional annotations."
-}
+// Note: in Cloud Run/Knative, there are two kinds of annotations.
+// - Service level annotations: applies to all revisions in the service. E.g.
+//   the ingress restriction
+//   https://cloud.google.com/run/docs/securing/ingress#yaml
+// - Revision level annotations: only applies to a new revision you want to
+//   create. E.g. the VPC connector setting
+//   https://cloud.google.com/run/docs/configuring/connecting-vpc#yaml
+//
+// Unfortunately they are just too similar and you'll have to read the doc
+// carefully to know what kind of annotation is needed to enable a feature.
+//
+// The variables below are named service_annotations and revision_annotations
+// accordingly.
 
 locals {
-  default_annotations = {
+  default_revision_annotations = {
     "autoscaling.knative.dev/maxScale" : "1",
     "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
     "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
   }
+  default_service_annotations = {
+    "run.googleapis.com/ingress" : "all"
+  }
 }
 
-variable "default_annotations_overrides" {
+variable "service_annotations" {
+  type    = map(map(string))
+  default = {}
+
+  description = "Per-service service level annotations."
+}
+
+variable "default_service_annotations_overrides" {
   type    = map(string)
   default = {}
 
   description = <<-EOT
   Annotations that applies to all services. Can be used to override
-  default_annotations.
+  default_service_annotations.
   EOT
 }
 
+variable "revision_annotations" {
+  type    = map(map(string))
+  default = {}
+
+  description = "Per-service revision level annotations."
+}
+
+variable "default_revision_annotations_overrides" {
+  type    = map(string)
+  default = {}
+
+  description = <<-EOT
+  Annotations that applies to all services. Can be used to override
+  default_revision_annotations.
+  EOT
+}
 terraform {
   required_version = ">= 0.14.2"
 


### PR DESCRIPTION
There are two types of annotations per Knative spec. See the inline
comment on the difference.

Part of https://github.com/google/exposure-notifications-verification-server/issues/895

```release-note
Breaking: To continue using the Terraform module, the following input variable is needed to avoid introducing a diff:

revision_annotations = {
    debugger        = { "autoscaling.knative.dev/maxScale" : "10" }
    export          = { "autoscaling.knative.dev/maxScale" : "10" }
    export-importer = { "autoscaling.knative.dev/maxScale" : "10" }
    exposure        = { "autoscaling.knative.dev/maxScale" : "500" }
    federationin    = { "autoscaling.knative.dev/maxScale" : "3" }
    federationout   = { "autoscaling.knative.dev/maxScale" : "5" }
    mirror          = { "autoscaling.knative.dev/maxScale" : "10" }
}
```