### PR TITLE
write publish stats in the background

### DIFF
--- a/internal/publish/database/exposure.go
+++ b/internal/publish/database/exposure.go
@@ -668,9 +668,11 @@ func (db *PublishDB) InsertAndReviseExposures(ctx context.Context, req *InsertAn
 			// For all practical purposes - this can be no more than a couple hundred TEKs in a single transaction.
 			stats.NumTEKs = int32(resp.Inserted) + int32(resp.Revised)
 			stats.Revision = resp.Revised > 0
-			if err := db.UpdateStatsInTx(ctx, tx, stats.CreatedAt, *healthAuthorityID, stats); err != nil {
-				return fmt.Errorf("failed to update statistics: %w", err)
-			}
+			go func() {
+				if err := db.UpdateStats(context.Background(), stats.CreatedAt, *healthAuthorityID, stats); err != nil {
+					logger.Errorw("failed to update statistics", "error", err)
+				}
+			}()
 		}
 
 		return nil

--- a/internal/publish/database/stats.go
+++ b/internal/publish/database/stats.go
@@ -98,7 +98,7 @@ func scanOneHealthAuthorityStats(rows pgx.Rows, stats *model.HealthAuthorityStat
 
 // UpdateStats performance a read-modify-write to update the requested stats.
 func (db *PublishDB) UpdateStats(ctx context.Context, hour time.Time, healthAuthorityID int64, info *model.PublishInfo) error {
-	return db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
+	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
 		return db.UpdateStatsInTx(ctx, tx, hour, healthAuthorityID, info)
 	})
 }

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -736,6 +736,8 @@ func TestPublishWithBypass(t *testing.T) {
 						}
 
 						if tc.HealthAuthority != nil {
+							// statistics are written in the background.
+							time.Sleep(2 * time.Second)
 							// There was a valid certificate present. there should be statistics.
 							stats, err := pubDB.ReadStats(ctx, tc.HealthAuthority.ID)
 							if err != nil {

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -737,7 +737,7 @@ func TestPublishWithBypass(t *testing.T) {
 
 						if tc.HealthAuthority != nil {
 							// statistics are written in the background.
-							time.Sleep(2 * time.Second)
+							time.Sleep(5 * time.Second)
 							// There was a valid certificate present. there should be statistics.
 							stats, err := pubDB.ReadStats(ctx, tc.HealthAuthority.ID)
 							if err != nil {


### PR DESCRIPTION
## Proposed Changes

* be consistent with verification server stats - i.e. best effort.

**Release Note**

```release-note
Publish statistics are written in the background instead of inline with the publish request.
```