### PR TITLE
Add CloudSchedulerJobFailed alert based on log metrics.

### DIFF
--- a/docs/playbooks/alerts/CloudSchedulerJobFailed.md
+++ b/docs/playbooks/alerts/CloudSchedulerJobFailed.md
@@ -1,0 +1,16 @@
+# CloudSchedulerJobFailed
+
+Cloud Scheduler produced some ERROR level logs, indicating the job is
+failing for some reason.
+
+## Triage Steps
+
+Go to Logs Explorer, use the following filter:
+
+```
+resource.type="cloud_scheduler_job"
+severity=ERROR
+```
+
+See what the error message is. Depending on the error, you may also need
+to check the corresponding Cloud Run service's log.


### PR DESCRIPTION
```release-note
Monitoring: Add CloudSchedulerJobFailed alert.
```