### PR TITLE
allow stats API to be disabled on a per HA basis. Improve test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,7 @@ test-acc:
 .PHONY: test-acc
 
 test-coverage:
-	@go tool cover \
-		-func coverage.out \
-		| grep total \
-		| awk '{print $NF}'
+	@go tool cover -func ./coverage.out | grep total
 .PHONY: test-coverage		
 
 performance-test:

--- a/internal/admin/healthauthority/form.go
+++ b/internal/admin/healthauthority/form.go
@@ -24,16 +24,18 @@ import (
 )
 
 type formData struct {
-	Issuer   string `form:"issuer"`
-	Audience string `form:"audience"`
-	Name     string `form:"name"`
-	JwksURI  string `form:"jwks-uri"`
+	Issuer         string `form:"issuer"`
+	Audience       string `form:"audience"`
+	Name           string `form:"name"`
+	EnableStatsAPI bool   `form:"enable-stats-api"`
+	JwksURI        string `form:"jwks-uri"`
 }
 
 func (f *formData) PopulateHealthAuthority(ha *model.HealthAuthority) {
 	ha.Issuer = f.Issuer
 	ha.Audience = f.Audience
 	ha.Name = f.Name
+	ha.EnableStatsAPI = f.EnableStatsAPI
 	ha.SetJWKS(f.JwksURI)
 }
 

--- a/internal/admin/healthauthority/save.go
+++ b/internal/admin/healthauthority/save.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/exposure-notifications-server/internal/admin"
@@ -74,5 +75,6 @@ func (h *saveController) Execute(c *gin.Context) {
 
 	m.AddSuccess(fmt.Sprintf("Updated Health Authority '%v'", healthAuthority.Issuer))
 	m["ha"] = healthAuthority
+	m["hak"] = &model.HealthAuthorityKey{From: time.Now()} // For create form.
 	c.HTML(http.StatusOK, "healthauthority", m)
 }

--- a/internal/admin/healthauthority/view.go
+++ b/internal/admin/healthauthority/view.go
@@ -40,7 +40,9 @@ func (v *viewController) Execute(c *gin.Context) {
 	ctx := c.Request.Context()
 	m := admin.TemplateMap{}
 
-	healthAuthority := &model.HealthAuthority{}
+	healthAuthority := &model.HealthAuthority{
+		EnableStatsAPI: true, // default enabled.
+	}
 	if IDParam := c.Param("id"); IDParam == "0" {
 		m["new"] = true
 	} else {
@@ -57,7 +59,6 @@ func (v *viewController) Execute(c *gin.Context) {
 			return
 		}
 	}
-
 	m["ha"] = healthAuthority
 	m["hak"] = &model.HealthAuthorityKey{From: time.Now()} // For create form.
 	c.HTML(http.StatusOK, "healthauthority", m)

--- a/internal/publish/stats_test.go
+++ b/internal/publish/stats_test.go
@@ -74,9 +74,10 @@ func TestRetrieveMetrics(t *testing.T) {
 
 	// Create a health authority with a public key.
 	healthAuthority := &vermodel.HealthAuthority{
-		Issuer:   "health-authority",
-		Audience: "n/a",
-		Name:     "health-authority",
+		Issuer:         "health-authority",
+		Audience:       "n/a",
+		Name:           "health-authority",
+		EnableStatsAPI: true,
 	}
 	healthAuthorityKey := &vermodel.HealthAuthorityKey{
 		Version: "v1",

--- a/internal/verification/authenticate_stats.go
+++ b/internal/verification/authenticate_stats.go
@@ -77,6 +77,11 @@ func (v *Verifier) AuthenticateStatsToken(ctx context.Context, rawToken string) 
 		if !ok {
 			return nil, fmt.Errorf("incorrect type in cache: %w", err)
 		}
+		// check that the API is enabled for this HA.
+		if !healthAuthority.EnableStatsAPI {
+			return nil, fmt.Errorf("API access forbidden")
+		}
+
 		// Look for the matching 'kid'
 		for _, key := range healthAuthority.Keys {
 			if key.Version == kid && key.IsValid() {

--- a/internal/verification/authenticate_stats_test.go
+++ b/internal/verification/authenticate_stats_test.go
@@ -60,6 +60,7 @@ func TestAuthenticateStatsToken(t *testing.T) {
 		ModifyClaims ClaimChanger
 		ModifyHeader HeaderChanger
 		ModifyJWT    JWTChanger
+		DisableAPI   bool
 		Error        string
 	}{
 		{
@@ -140,6 +141,14 @@ func TestAuthenticateStatsToken(t *testing.T) {
 			},
 			Error: "token contains an invalid number of segments",
 		},
+		{
+			Name:         "forbidden",
+			ModifyClaims: claimsIdentity,
+			ModifyHeader: headerIdentity,
+			ModifyJWT:    jwtIdentity,
+			DisableAPI:   true,
+			Error:        "API access forbidden",
+		},
 	}
 
 	for _, tc := range cases {
@@ -170,9 +179,13 @@ func TestAuthenticateStatsToken(t *testing.T) {
 			issuer := fmt.Sprintf("issuer-%s", t.Name())
 			audience := fmt.Sprintf("aud-%s", t.Name())
 			healthAuthority := model.HealthAuthority{
-				Issuer:   issuer,
-				Audience: audience,
-				Name:     "Very Real Health Authority",
+				Issuer:         issuer,
+				Audience:       audience,
+				Name:           "Very Real Health Authority",
+				EnableStatsAPI: true,
+			}
+			if tc.DisableAPI {
+				healthAuthority.EnableStatsAPI = false
 			}
 			if err := haDB.AddHealthAuthority(ctx, &healthAuthority); err != nil {
 				t.Fatal(err)

--- a/internal/verification/model/health_authority.go
+++ b/internal/verification/model/health_authority.go
@@ -21,21 +21,25 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
 // HealthAuthority represents a public health authority that is authorized to
 // issue diagnosis verification certificates accepted by this server.
 type HealthAuthority struct {
-	ID       int64
-	Issuer   string
-	Audience string
-	Name     string
-	Keys     []*HealthAuthorityKey
-	JwksURI  *string
+	ID             int64
+	Issuer         string
+	Audience       string
+	Name           string
+	Keys           []*HealthAuthorityKey
+	JwksURI        *string
+	EnableStatsAPI bool
 }
 
+// SetJWKS sets the optional JwksURI property of the HealthAuthority.
 func (ha *HealthAuthority) SetJWKS(uri string) {
+	uri = strings.TrimSpace(uri)
 	if uri == "" {
 		ha.JwksURI = nil
 		return

--- a/internal/verification/model/health_authority_test.go
+++ b/internal/verification/model/health_authority_test.go
@@ -18,7 +18,46 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
 )
+
+func TestSetJWKS(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  *string
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "trim_empty",
+			input: "  ",
+			want:  nil,
+		},
+		{
+			name:  "valid",
+			input: "https://jwks.example.com/",
+			want:  proto.String("https://jwks.example.com/"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ha := &HealthAuthority{}
+			ha.SetJWKS(tc.input)
+			if diff := cmp.Diff(tc.want, ha.JwksURI); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestIsValid(t *testing.T) {
 	now := time.Now().UTC()

--- a/migrations/000055_AddDisableHAStats.down.sql
+++ b/migrations/000055_AddDisableHAStats.down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE healthauthority
+    DROP COLUMN enable_stats;
+
+END;

--- a/migrations/000055_AddDisableHAStats.down.sql
+++ b/migrations/000055_AddDisableHAStats.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/migrations/000055_AddDisableHAStats.up.sql
+++ b/migrations/000055_AddDisableHAStats.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/migrations/000055_AddDisableHAStats.up.sql
+++ b/migrations/000055_AddDisableHAStats.up.sql
@@ -1,0 +1,23 @@
+-- Copyright 2020 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE healthauthority
+    ADD COLUMN enable_stats BOOL DEFAULT true;
+
+ALTER TABLE healthauthority
+    ALTER COLUMN enable_stats SET NOT NULL;
+
+END;

--- a/scripts/create_db_migration.sh
+++ b/scripts/create_db_migration.sh
@@ -30,7 +30,7 @@ command -v migrate >/dev/null 2>&1 || {
 migrate create -ext sql -dir migrations -seq $1
 
 # Template for the newly created migration file
-TEMPLATE='-- Copyright 2020 Google LLC
+TEMPLATE='-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/tools/admin-console/templates/healthauthority.html
+++ b/tools/admin-console/templates/healthauthority.html
@@ -55,6 +55,17 @@
         </small>
       </div>
 
+      <div class="form-group">
+        <label for="enable-stats-api">Enable Stats API Access</label>
+        <select name="enable-stats-api" id="enable-stats-api" class="form-control custom-select">
+          <option value="true" {{if .ha.EnableStatsAPI}}selected{{end}}>true</option>
+          <option value="false" {{if not .ha.EnableStatsAPI}}selected{{end}}>false</option>
+        </select>
+        <small class="form-text text-muted">
+          If false, this health authority will always get "unauthorized" on the stats API.
+        </small>
+      </div>
+
       <div class="form-label-group">
         <input type="text" name="jwks-uri" id="jwks-uri" value="{{deref .ha.JwksURI}}"
           placeholder="JWKS URI" class="form-control">


### PR DESCRIPTION
Fixes #1267

## Proposed Changes

* Allow stats API to be disabled for a specific HA (enabled by default)
* Improve test coverage
* Fix make file, prow doesn't have awk apparently

**Release Note**

```release-note
Allow stats API to be enabled/disabled on a per HA basis.
```