### PR TITLE
ensure imported keys are future dated

### DIFF
--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -354,7 +354,8 @@ func (e *Exposure) AdjustAndValidate(settings *KeyTransform) error {
 	if e.IntervalNumber+e.IntervalCount > settings.MaxStartInterval {
 		// key is still valid. The created At for this key needs to be adjusted unless debugging is enabled.
 		if !settings.ReleaseStillValidKeys {
-			e.CreatedAt = TimeForIntervalNumber(e.IntervalNumber + e.IntervalCount).Truncate(settings.BatchWindow)
+			// The add of the batch window is to ensure that the created at time is after the expiry.
+			e.CreatedAt = TimeForIntervalNumber(e.IntervalNumber + e.IntervalCount).Add(settings.BatchWindow).Truncate(settings.BatchWindow)
 		}
 	}
 

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -412,7 +412,7 @@ func TestStillValidKey(t *testing.T) {
 					},
 				},
 			},
-			createdAt:          TruncateWindow(TimeForIntervalNumber(intervalNumber+verifyapi.MaxIntervalCount), time.Minute),
+			createdAt:          TruncateWindow(TimeForIntervalNumber(intervalNumber+verifyapi.MaxIntervalCount).Add(time.Minute), time.Minute),
 			releaseSameDayKeys: false,
 		},
 	}


### PR DESCRIPTION

## Proposed Changes

* for imported keys - future date them if not expired. Works around potential bugs in upstream systems
* put created at date for published future dated keys into the NEXT interval. 

**Release Note**

```release-note
Imported keys will be future dated if they haven't expired yet.
Published keys will be moved forward one extra interval when they are adjusted. **There is no actual issue here with the default configuration because of the additional 2 hour embargo, but this is more technically correct.**
```