### PR TITLE
Allow generate service to take up to 2min to complete

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -16,7 +16,7 @@ locals {
   p50_latency_thresholds = {
     export         = "10min"
     cleanup-export = "1min"
-    generate       = "30s"
+    generate       = "2min"
   }
   p50_latency_thresholds_default = "10s"
 


### PR DESCRIPTION
We're generating a lot more data, plus cold starts. Plus this isn't in the path of downtime, so we really only want to be alerted when it's very, very broken.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow generate service to take up to 2min to complete
```