### PR TITLE
increase test coverage, refactor duplicate code.

### DIFF
--- a/internal/exportimport/database/exportimport.go
+++ b/internal/exportimport/database/exportimport.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
+// ExportImportDB contains databse methods for managing with export-import configs.
 type ExportImportDB struct {
 	db *database.DB
 }
@@ -62,6 +63,8 @@ func (db *ExportImportDB) GetConfig(ctx context.Context, id int64) (*model.Expor
 	return config, nil
 }
 
+// ListConfigs lists all configs (active and inactive). This is a utility method for the
+// admin console.
 func (db *ExportImportDB) ListConfigs(ctx context.Context) ([]*model.ExportImport, error) {
 	var configs []*model.ExportImport
 
@@ -71,7 +74,7 @@ func (db *ExportImportDB) ListConfigs(ctx context.Context) ([]*model.ExportImpor
 				id, index_file, export_root, region, from_timestamp, thru_timestamp
 			FROM
 				exportimport
-			ORDER BY id DESC
+			ORDER BY id ASC
 		`)
 		if err != nil {
 			return fmt.Errorf("failed to list: %w", err)
@@ -97,6 +100,7 @@ func (db *ExportImportDB) ListConfigs(ctx context.Context) ([]*model.ExportImpor
 	return configs, nil
 }
 
+// ActiveConfigs returns the active export import configurations.
 func (db *ExportImportDB) ActiveConfigs(ctx context.Context) ([]*model.ExportImport, error) {
 	var configs []*model.ExportImport
 
@@ -110,7 +114,7 @@ func (db *ExportImportDB) ActiveConfigs(ctx context.Context) ([]*model.ExportImp
 				from_timestamp <= $1
 			AND
 				(thru_timestamp IS NULL OR thru_timestamp >= $1)
-			ORDER BY id DESC
+			ORDER BY id ASC
 		`, time.Now().UTC())
 		if err != nil {
 			return fmt.Errorf("failed to list: %w", err)
@@ -152,6 +156,7 @@ func scanOneConfig(row pgx.Row) (*model.ExportImport, error) {
 	return &m, nil
 }
 
+// AddConfig saves a new ExportImport configuration.
 func (db *ExportImportDB) AddConfig(ctx context.Context, ei *model.ExportImport) error {
 	if err := ei.Validate(); err != nil {
 		return err

--- a/internal/exportimport/database/exportimport.go
+++ b/internal/exportimport/database/exportimport.go
@@ -26,7 +26,7 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
-// ExportImportDB contains databse methods for managing with export-import configs.
+// ExportImportDB contains database methods for managing with export-import configs.
 type ExportImportDB struct {
 	db *database.DB
 }

--- a/internal/exportimport/model/exportimport.go
+++ b/internal/exportimport/model/exportimport.go
@@ -20,6 +20,9 @@ import (
 	"time"
 )
 
+// ExportImport reqpresnts the configuration of a set of export files
+// to be imported into this server, by pointing at the index file
+// and remote root directory.
 type ExportImport struct {
 	ID         int64
 	IndexFile  string
@@ -29,6 +32,8 @@ type ExportImport struct {
 	Thru       *time.Time
 }
 
+// Validate checks the contents of an ExportImport file. This is a utility
+// function for the admin console.
 func (ei *ExportImport) Validate() error {
 	if l := len(ei.Region); l == 0 {
 		return fmt.Errorf("region cannot be blank")
@@ -46,6 +51,8 @@ func (ei *ExportImport) Validate() error {
 	return nil
 }
 
+// Active returns if the ExportImport configuration is currently
+// active based on From and Thru times.
 func (ei *ExportImport) Active() bool {
 	now := time.Now().UTC()
 	return ei.From.Before(now) && (ei.Thru == nil || now.Before(*ei.Thru))

--- a/internal/exportimport/model/exportimport.go
+++ b/internal/exportimport/model/exportimport.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-// ExportImport reqpresnts the configuration of a set of export files
+// ExportImport represents the configuration of a set of export files
 // to be imported into this server, by pointing at the index file
 // and remote root directory.
 type ExportImport struct {
@@ -51,7 +51,7 @@ func (ei *ExportImport) Validate() error {
 	return nil
 }
 
-// Active returns if the ExportImport configuration is currently
+// Active returns true if the ExportImport configuration is currently
 // active based on From and Thru times.
 func (ei *ExportImport) Active() bool {
 	now := time.Now().UTC()

--- a/internal/exportimport/model/exportimport_test.go
+++ b/internal/exportimport/model/exportimport_test.go
@@ -1,0 +1,138 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ei   *ExportImport
+		want string
+	}{
+		{
+			name: "no_region",
+			ei:   &ExportImport{},
+			want: "region cannot be blank",
+		},
+		{
+			name: "too_big_region",
+			ei: &ExportImport{
+				Region: "ABCDEF",
+			},
+			want: "region cannot be longer than 5 characters",
+		},
+		{
+			name: "no_index_file",
+			ei: &ExportImport{
+				Region: "US",
+			},
+			want: "IndexFile cannot be blank",
+		},
+		{
+			name: "no_export_root",
+			ei: &ExportImport{
+				Region:    "US",
+				IndexFile: "a/index.txt",
+			},
+			want: "ExportRoot cannot be blank",
+		},
+		{
+			name: "valid",
+			ei: &ExportImport{
+				Region:     "US",
+				IndexFile:  "a/index.txt",
+				ExportRoot: "a",
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ""
+			err := tc.ei.Validate()
+			if err != nil {
+				got = err.Error()
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unmarshal mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestActive(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+
+	cases := []struct {
+		name string
+		ei   *ExportImport
+		want bool
+	}{
+		{
+			name: "valid_time",
+			ei: &ExportImport{
+				From: now.Add(-1 * time.Second),
+			},
+			want: true,
+		},
+		{
+			name: "valid_time_with_exp",
+			ei: &ExportImport{
+				From: now.Add(-1 * time.Second),
+				Thru: timePtr(now.Add(time.Hour)),
+			},
+			want: true,
+		},
+		{
+			name: "expired",
+			ei: &ExportImport{
+				From: now.Add(-2 * time.Hour),
+				Thru: timePtr(now.Add(-1 * time.Hour)),
+			},
+			want: false,
+		},
+		{
+			name: "future",
+			ei: &ExportImport{
+				From: now.Add(2 * time.Hour),
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.ei.Active()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unmarshal mismatch (-want +got):\n%v", diff)
+			}
+		})
+	}
+}

--- a/internal/exportimport/model/exportimport_test.go
+++ b/internal/exportimport/model/exportimport_test.go
@@ -73,6 +73,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := ""
 			err := tc.ei.Validate()
 			if err != nil {
@@ -129,6 +130,7 @@ func TestActive(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := tc.ei.Active()
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unmarshal mismatch (-want +got):\n%v", diff)

--- a/internal/exportimport/model/file.go
+++ b/internal/exportimport/model/file.go
@@ -25,6 +25,8 @@ const (
 	ImportFileFailed   = "FAILED"
 )
 
+// ImportFile represents an individual export file that is scheduled for,
+// or has been attempted or imported into the system.
 type ImportFile struct {
 	ID             int64
 	ExportImportID int64

--- a/internal/exportimport/model/importkeys.go
+++ b/internal/exportimport/model/importkeys.go
@@ -23,8 +23,8 @@ import (
 
 // ImportFilePublicKey represents a possible signing key
 // for export files being imported into this system.
-// A given ExportImportID can have more than one, and more than
-// one that is currently valid.
+// A given ExportImportID can have more than one associated key,
+// and more than one that is currently valid.
 type ImportFilePublicKey struct {
 	ExportImportID int64
 	KeyID          string

--- a/internal/exportimport/model/importkeys.go
+++ b/internal/exportimport/model/importkeys.go
@@ -16,13 +16,15 @@ package model
 
 import (
 	"crypto/ecdsa"
-	"crypto/x509"
-	"encoding/pem"
-	"errors"
-	"fmt"
 	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/keys"
 )
 
+// ImportFilePublicKey represents a possible signing key
+// for export files being imported into this system.
+// A given ExportImportID can have more than one, and more than
+// one that is currently valid.
 type ImportFilePublicKey struct {
 	ExportImportID int64
 	KeyID          string
@@ -33,19 +35,5 @@ type ImportFilePublicKey struct {
 }
 
 func (pk *ImportFilePublicKey) PublicKey() (*ecdsa.PublicKey, error) {
-	block, _ := pem.Decode([]byte(pk.PublicKeyPEM))
-	if block == nil {
-		return nil, errors.New("unable to decode PEM block containing PUBLIC KEY")
-	}
-	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("x509.ParsePKIXPublicKey: %w", err)
-	}
-
-	switch typ := pub.(type) {
-	case *ecdsa.PublicKey:
-		return typ, nil
-	default:
-		return nil, fmt.Errorf("unsupported public key type: %T", typ)
-	}
+	return keys.ParseECDSAPublicKey(pk.PublicKeyPEM)
 }

--- a/internal/flag/flag_test.go
+++ b/internal/flag/flag_test.go
@@ -47,9 +47,7 @@ func TestString(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var l RegionListVar
-			l = tc.value
-
+			var l RegionListVar = tc.value
 			if r := l.String(); r != tc.want {
 				t.Errorf("wrong value, want: %q got: %q", tc.want, r)
 			}

--- a/internal/flag/flag_test.go
+++ b/internal/flag/flag_test.go
@@ -1,0 +1,77 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flag
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		value []string
+		want  string
+	}{
+		{
+			name:  "empty",
+			value: []string{},
+			want:  "[]",
+		},
+		{
+			name:  "single",
+			value: []string{"A"},
+			want:  "[A]",
+		},
+		{
+			name:  "multi",
+			value: []string{"A", "B", "C"},
+			want:  "[A B C]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var l RegionListVar
+			l = tc.value
+
+			if r := l.String(); r != tc.want {
+				t.Errorf("wrong value, want: %q got: %q", tc.want, r)
+			}
+		})
+	}
+}
+
+func TestSetError(t *testing.T) {
+	var l RegionListVar = []string{"A"}
+	if err := l.Set("A"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestSet(t *testing.T) {
+	var l RegionListVar
+	if err := l.Set("A, B, C,D, A"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var want RegionListVar = []string{"A", "B", "C", "D"}
+	if diff := cmp.Diff(want, l); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}

--- a/internal/jsonutil/marshal.go
+++ b/internal/jsonutil/marshal.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 )
 
+// MarshalResponse is a helper function to write an object to the http.ResponseWriter
+// with fallback error template.
 func MarshalResponse(w http.ResponseWriter, status int, response interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 

--- a/internal/jsonutil/marshal_test.go
+++ b/internal/jsonutil/marshal_test.go
@@ -43,7 +43,7 @@ func TestMarshalResponse(t *testing.T) {
 		t.Errorf("wrong response code, want: %v got: %v", http.StatusOK, w.Code)
 	}
 
-	got := string(w.Body.Bytes())
+	got := w.Body.String()
 	want := `{"name":"Steve"}`
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unmarshal mismatch (-want +got):\n%v", diff)
@@ -68,7 +68,7 @@ func TestMarshalResponseError(t *testing.T) {
 		t.Errorf("wrong response code, want: %v got: %v", http.StatusOK, w.Code)
 	}
 
-	got := string(w.Body.Bytes())
+	got := w.Body.String()
 	want := `{"error":"json: unsupported value: encountered a cycle via *jsonutil.Circular"}`
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unmarshal mismatch (-want +got):\n%v", diff)

--- a/internal/jsonutil/marshal_test.go
+++ b/internal/jsonutil/marshal_test.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEscapeJSON(t *testing.T) {
+	want := `{\"a\": \"b\"}`
+	got := escapeJSON(`{"a": "b"}`)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unmarshal mismatch (-want +got):\n%v", diff)
+	}
+}
+
+func TestMarshalResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	toSave := map[string]string{
+		"name": "Steve",
+	}
+
+	MarshalResponse(w, http.StatusOK, toSave)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("wrong response code, want: %v got: %v", http.StatusOK, w.Code)
+	}
+
+	got := string(w.Body.Bytes())
+	want := `{"name":"Steve"}`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unmarshal mismatch (-want +got):\n%v", diff)
+	}
+}
+
+func TestMarshalResponseError(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	type Circular struct {
+		Name string    `json:"name"`
+		Next *Circular `json:"next"`
+	}
+
+	badInput := &Circular{
+		Name: "Bob",
+	}
+	badInput.Next = badInput
+
+	MarshalResponse(w, http.StatusInternalServerError, badInput)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("wrong response code, want: %v got: %v", http.StatusOK, w.Code)
+	}
+
+	got := string(w.Body.Bytes())
+	want := `{"error":"json: unsupported value: encountered a cycle via *jsonutil.Circular"}`
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unmarshal mismatch (-want +got):\n%v", diff)
+	}
+}

--- a/internal/jsonutil/unmarshal_test.go
+++ b/internal/jsonutil/unmarshal_test.go
@@ -16,10 +16,12 @@ package jsonutil
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +29,21 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestBodyTooLarge(t *testing.T) {
+	input := make(map[string]string, 1)
+	input["padding"] = strings.Repeat("0", maxBodyBytes+10)
+
+	largeJSON, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errors := []string{
+		`http: request body too large`,
+	}
+	unmarshalTestHelper(t, []string{string(largeJSON)}, errors, http.StatusRequestEntityTooLarge)
+}
 
 func TestInvalidHeader(t *testing.T) {
 	body := ioutil.NopCloser(bytes.NewReader([]byte("")))

--- a/internal/jsonutil/unmarshal_test.go
+++ b/internal/jsonutil/unmarshal_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestBodyTooLarge(t *testing.T) {
+	t.Parallel()
 	input := make(map[string]string, 1)
 	input["padding"] = strings.Repeat("0", maxBodyBytes+10)
 
@@ -46,6 +47,7 @@ func TestBodyTooLarge(t *testing.T) {
 }
 
 func TestInvalidHeader(t *testing.T) {
+	t.Parallel()
 	body := ioutil.NopCloser(bytes.NewReader([]byte("")))
 	r := httptest.NewRequest("POST", "/", body)
 	r.Header.Set("content-type", "application/text")
@@ -66,6 +68,7 @@ func TestInvalidHeader(t *testing.T) {
 }
 
 func TestEmptyBody(t *testing.T) {
+	t.Parallel()
 	invalidJSON := []string{
 		``,
 	}
@@ -75,6 +78,7 @@ func TestEmptyBody(t *testing.T) {
 	unmarshalTestHelper(t, invalidJSON, errors, http.StatusBadRequest)
 }
 func TestMultipleJson(t *testing.T) {
+	t.Parallel()
 	invalidJSON := []string{
 		`{"temporaryExposureKeys":
 			[{"key": "ABC"},
@@ -96,6 +100,7 @@ func TestMultipleJson(t *testing.T) {
 }
 
 func TestInvalidJSON(t *testing.T) {
+	t.Parallel()
 	invalidJSON := []string{
 		`totally not json`,
 		`{"key": "value", badKey: 6`,
@@ -110,6 +115,7 @@ func TestInvalidJSON(t *testing.T) {
 }
 
 func TestInvalidStructure(t *testing.T) {
+	t.Parallel()
 	invalidJSON := []string{
 		`{"temporaryExposureKeys": 42}`,
 		`{"temporaryExposureKeys": ["41", 42]}`,
@@ -128,6 +134,7 @@ func TestInvalidStructure(t *testing.T) {
 }
 
 func TestValidPublishMessage(t *testing.T) {
+	t.Parallel()
 	intervalNumber := int32(time.Date(2020, 04, 17, 20, 04, 01, 1, time.UTC).Unix() / 600)
 	json := `{"temporaryExposureKeys": [
 		  {"key": "ABC", "rollingStartNumber": %v, "rollingPeriod": 144, "TransmissionRisk": 2},

--- a/internal/verification/model/health_authority.go
+++ b/internal/verification/model/health_authority.go
@@ -17,12 +17,12 @@ package model
 
 import (
 	"crypto/ecdsa"
-	"crypto/x509"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/keys"
 )
 
 // HealthAuthority represents a public health authority that is authorized to
@@ -104,19 +104,5 @@ func (k HealthAuthorityKey) Revoke() {
 // PublicKey decodes the PublicKeyPEM text and returns the `*ecdsa.PublicKey`
 // This system only supports verifying ECDSA JWTs, `alg: ES256`.
 func (k *HealthAuthorityKey) PublicKey() (*ecdsa.PublicKey, error) {
-	block, _ := pem.Decode([]byte(k.PublicKeyPEM))
-	if block == nil || block.Type != "PUBLIC KEY" {
-		return nil, errors.New("unable to decode PEM block containing PUBLIC KEY")
-	}
-	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("x509.ParsePKIXPublicKey: %w", err)
-	}
-
-	switch typ := pub.(type) {
-	case *ecdsa.PublicKey:
-		return typ, nil
-	default:
-		return nil, fmt.Errorf("unsupported public key type: %T", typ)
-	}
+	return keys.ParseECDSAPublicKey(k.PublicKeyPEM)
 }

--- a/pkg/keys/ecdsa_pem.go
+++ b/pkg/keys/ecdsa_pem.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 )
 
-// ParseECDSAPublicKey is a conveinence function for decoding an
+// ParseECDSAPublicKey is a convenience function for decoding an
 // ECDSA public key in PEM format.
 func ParseECDSAPublicKey(pemBlock string) (*ecdsa.PublicKey, error) {
 	block, _ := pem.Decode([]byte(pemBlock))

--- a/pkg/keys/ecdsa_pem.go
+++ b/pkg/keys/ecdsa_pem.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keys
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+// ParseECDSAPublicKey is a conveinence function for decoding an
+// ECDSA public key in PEM format.
+func ParseECDSAPublicKey(pemBlock string) (*ecdsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(pemBlock))
+	if block == nil {
+		return nil, errors.New("unable to decode PEM block containing PUBLIC KEY")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("x509.ParsePKIXPublicKey: %w", err)
+	}
+
+	switch typ := pub.(type) {
+	case *ecdsa.PublicKey:
+		return typ, nil
+	default:
+		return nil, fmt.Errorf("unsupported public key type: %T", typ)
+	}
+}

--- a/pkg/keys/ecdsa_pem_test.go
+++ b/pkg/keys/ecdsa_pem_test.go
@@ -41,6 +41,9 @@ func TestParseECDSAPublicKey_WrongKeyType(t *testing.T) {
 	}
 
 	x509EncodedPub, err := x509.MarshalPKIXPublicKey(pk.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 	pemEncodedPub := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: x509EncodedPub})
 	pemPublicKey := string(pemEncodedPub)
 

--- a/pkg/keys/ecdsa_pem_test.go
+++ b/pkg/keys/ecdsa_pem_test.go
@@ -1,0 +1,54 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keys
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+)
+
+func TestParseECDSAPublicKey_DecodeError(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseECDSAPublicKey("foo")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestParseECDSAPublicKey_WrongKeyType(t *testing.T) {
+	t.Parallel()
+
+	pk, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	x509EncodedPub, err := x509.MarshalPKIXPublicKey(pk.PublicKey)
+	pemEncodedPub := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: x509EncodedPub})
+	pemPublicKey := string(pemEncodedPub)
+
+	_, err = ParseECDSAPublicKey(pemPublicKey)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if want := "x509.ParsePKIXPublicKey"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("wrong error, want: %q got: %q", want, err.Error())
+	}
+}

--- a/pkg/keys/ecdsa_pem_test.go
+++ b/pkg/keys/ecdsa_pem_test.go
@@ -40,10 +40,7 @@ func TestParseECDSAPublicKey_WrongKeyType(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	x509EncodedPub, err := x509.MarshalPKIXPublicKey(pk.PublicKey)
-	if err != nil {
-		t.Fatal(err)
-	}
+	x509EncodedPub := x509.MarshalPKCS1PublicKey(&pk.PublicKey)
 	pemEncodedPub := pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: x509EncodedPub})
 	pemPublicKey := string(pemEncodedPub)
 

--- a/pkg/keys/hashicorp_vault.go
+++ b/pkg/keys/hashicorp_vault.go
@@ -17,7 +17,6 @@ package keys
 import (
 	"context"
 	"crypto"
-	"crypto/ecdsa"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -411,15 +410,5 @@ func (s *HashiCorpVaultSigner) getPublicKey() (crypto.PublicKey, error) {
 		return nil, fmt.Errorf("invalid public_key type %T", publicKeyPEMRaw)
 	}
 
-	publicKey, err := parsePublicKeyPEM(publicKeyPEM)
-	if err != nil {
-		return nil, err
-	}
-
-	typed, ok := publicKey.(*ecdsa.PublicKey)
-	if !ok {
-		return nil, fmt.Errorf("invalid public key type: %T", publicKey)
-	}
-
-	return typed, nil
+	return ParseECDSAPublicKey(publicKeyPEM)
 }


### PR DESCRIPTION
Towards #1279 

## Proposed Changes

* increase coverage on exportimpoert model + database
* increase coverage on json parsing
* collapse multiple copies of Public Key parsing function

Overall coverage increased by .7 percent w/ this change.

**Release Note**

```release-note
Increase test coverage on exportimport model and database packages.
```