### PR TITLE
Use gorilla mux.

### DIFF
--- a/cmd/cleanup-export/main.go
+++ b/cmd/cleanup-export/main.go
@@ -18,7 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/cleanup"
@@ -26,6 +25,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 	"github.com/sethvargo/go-signalcontext"
 )
 
@@ -60,9 +60,9 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("cleanup.NewExportHandler: %w", err)
 	}
 
-	mux := http.NewServeMux()
-	mux.Handle("/", handler)
-	mux.Handle("/health", server.HandleHealthz(ctx))
+	r := mux.NewRouter()
+	r.Handle("/", handler)
+	r.Handle("/health", server.HandleHealthz(ctx))
 
 	srv, err := server.New(config.Port)
 	if err != nil {
@@ -70,5 +70,5 @@ func realMain(ctx context.Context) error {
 	}
 	logger.Infof("listening on :%s", config.Port)
 
-	return srv.ServeHTTPHandler(ctx, mux)
+	return srv.ServeHTTPHandler(ctx, r)
 }

--- a/cmd/cleanup-exposure/main.go
+++ b/cmd/cleanup-exposure/main.go
@@ -18,7 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/cleanup"
@@ -26,6 +25,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 	"github.com/sethvargo/go-signalcontext"
 )
 
@@ -60,9 +60,9 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("cleanup.NewExposureHandler: %w", err)
 	}
 
-	mux := http.NewServeMux()
-	mux.Handle("/", handler)
-	mux.Handle("/health", server.HandleHealthz(ctx))
+	r := mux.NewRouter()
+	r.Handle("/", handler)
+	r.Handle("/health", server.HandleHealthz(ctx))
 
 	srv, err := server.New(config.Port)
 	if err != nil {
@@ -70,5 +70,5 @@ func realMain(ctx context.Context) error {
 	}
 	logger.Infof("listening on :%s", config.Port)
 
-	return srv.ServeHTTPHandler(ctx, mux)
+	return srv.ServeHTTPHandler(ctx, r)
 }

--- a/cmd/federationin/main.go
+++ b/cmd/federationin/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/federationin"
@@ -27,6 +26,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 	"github.com/sethvargo/go-signalcontext"
 )
 
@@ -57,9 +57,9 @@ func realMain(ctx context.Context) error {
 
 	handler := federationin.NewHandler(env, &config)
 
-	mux := http.NewServeMux()
-	mux.Handle("/", handler)
-	mux.Handle("/health", server.HandleHealthz(ctx))
+	r := mux.NewRouter()
+	r.Handle("/", handler)
+	r.Handle("/health", server.HandleHealthz(ctx))
 
 	srv, err := server.New(config.Port)
 	if err != nil {
@@ -67,5 +67,5 @@ func realMain(ctx context.Context) error {
 	}
 	logger.Infof("listening on :%s", config.Port)
 
-	return srv.ServeHTTPHandler(ctx, mux)
+	return srv.ServeHTTPHandler(ctx, r)
 }

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/generate"
@@ -27,6 +26,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 	"github.com/sethvargo/go-signalcontext"
 )
 
@@ -61,9 +61,9 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("generate.NewHandler: %w", err)
 	}
 
-	mux := http.NewServeMux()
-	mux.Handle("/", handler)
-	mux.Handle("/health", server.HandleHealthz(ctx))
+	r := mux.NewRouter()
+	r.Handle("/", handler)
+	r.Handle("/health", server.HandleHealthz(ctx))
 
 	srv, err := server.New(config.Port)
 	if err != nil {
@@ -71,5 +71,5 @@ func realMain(ctx context.Context) error {
 	}
 	logger.Infof("listening on :%s", config.Port)
 
-	return srv.ServeHTTPHandler(ctx, mux)
+	return srv.ServeHTTPHandler(ctx, r)
 }

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/google/mako v0.2.0
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/handlers v1.5.1
+	github.com/gorilla/mux v1.7.4
 	github.com/gostaticanalysis/analysisutil v0.6.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/google/mako v0.2.0
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/handlers v1.5.1
-	github.com/gorilla/mux v1.7.4
+	github.com/gorilla/mux v1.8.0
 	github.com/gostaticanalysis/analysisutil v0.6.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -610,6 +610,8 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=

--- a/internal/debugger/server.go
+++ b/internal/debugger/server.go
@@ -17,10 +17,10 @@ package debugger
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 )
 
 // Server is the debugger server.
@@ -53,10 +53,10 @@ func NewServer(config *Config, env *serverenv.ServerEnv) (*Server, error) {
 	}, nil
 }
 
-func (s *Server) Routes(ctx context.Context) *http.ServeMux {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", s.handleDebug(ctx))
-	mux.Handle("/health", server.HandleHealthz(ctx))
+func (s *Server) Routes(ctx context.Context) *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc("/", s.handleDebug(ctx))
+	r.Handle("/health", server.HandleHealthz(ctx))
 
-	return mux
+	return r
 }

--- a/internal/export/server.go
+++ b/internal/export/server.go
@@ -17,10 +17,10 @@ package export
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 )
 
 // NewServer makes a Server.
@@ -52,12 +52,12 @@ type Server struct {
 }
 
 // Routes defines and returns the routes for this server.
-func (s *Server) Routes(ctx context.Context) *http.ServeMux {
-	mux := http.NewServeMux()
+func (s *Server) Routes(ctx context.Context) *mux.Router {
+	r := mux.NewRouter()
 
-	mux.HandleFunc("/create-batches", s.handleCreateBatches(ctx))
-	mux.HandleFunc("/do-work", s.handleDoWork(ctx))
-	mux.Handle("/health", server.HandleHealthz(ctx))
+	r.HandleFunc("/create-batches", s.handleCreateBatches(ctx))
+	r.HandleFunc("/do-work", s.handleDoWork(ctx))
+	r.Handle("/health", server.HandleHealthz(ctx))
 
-	return mux
+	return r
 }

--- a/internal/exportimport/server.go
+++ b/internal/exportimport/server.go
@@ -18,7 +18,6 @@ package exportimport
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/database"
 	eidb "github.com/google/exposure-notifications-server/internal/exportimport/database"
@@ -26,6 +25,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 )
 
 // Server hosts end points to manage key rotation
@@ -62,12 +62,12 @@ func NewServer(config *Config, env *serverenv.ServerEnv) (*Server, error) {
 }
 
 // Routes defines and returns the routes for this server.
-func (s *Server) Routes(ctx context.Context) *http.ServeMux {
-	mux := http.NewServeMux()
+func (s *Server) Routes(ctx context.Context) *mux.Router {
+	r := mux.NewRouter()
 
-	mux.HandleFunc("/schedule", s.handleSchedule(ctx))
-	mux.HandleFunc("/import", s.handleImport(ctx))
-	mux.Handle("/health", server.HandleHealthz(ctx))
+	r.HandleFunc("/schedule", s.handleSchedule(ctx))
+	r.HandleFunc("/import", s.handleImport(ctx))
+	r.Handle("/health", server.HandleHealthz(ctx))
 
-	return mux
+	return r
 }

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -40,6 +40,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 	"github.com/sethvargo/go-envconfig"
 	"github.com/sethvargo/go-retry"
 
@@ -136,7 +137,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	)
 	// Note: don't call env.Cleanup() because the database helper closes the
 	// connection for us.
-	mux := http.NewServeMux()
+	r := mux.NewRouter()
 
 	// Cleanup export
 	cleanupExportConfig := &cleanup.Config{
@@ -148,7 +149,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	if err != nil {
 		tb.Fatal(err)
 	}
-	mux.Handle("/cleanup-export", cleanupExportHandler)
+	r.Handle("/cleanup-export", cleanupExportHandler)
 
 	// Cleanup exposure
 	cleanupExposureConfig := &cleanup.Config{
@@ -160,7 +161,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	if err != nil {
 		tb.Fatal(err)
 	}
-	mux.Handle("/cleanup-exposure", cleanupExposureHandler)
+	r.Handle("/cleanup-exposure", cleanupExposureHandler)
 
 	// Export
 	exportConfig := &export.Config{
@@ -179,7 +180,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 		tb.Fatal(err)
 	}
 	exportHandler := http.StripPrefix("/export", exportServer.Routes(ctx))
-	mux.Handle("/export/", exportHandler)
+	r.Handle("/export/", exportHandler)
 
 	// Federation
 	federationInConfig := &federationin.Config{
@@ -188,7 +189,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	}
 
 	federationinHandler := federationin.NewHandler(env, federationInConfig)
-	mux.Handle("/federation-in", federationinHandler)
+	r.Handle("/federation-in", federationinHandler)
 
 	// Federation out
 	// TODO: this is a grpc listener and requires a lot of setup.
@@ -212,7 +213,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	if err != nil {
 		tb.Fatal(err)
 	}
-	mux.Handle("/key-rotation/", http.StripPrefix("/key-rotation", rotationServer.Routes(ctx)))
+	r.Handle("/key-rotation/", http.StripPrefix("/key-rotation", rotationServer.Routes(ctx)))
 
 	// Parse the config to load default values.
 	publishConfig := publish.Config{}
@@ -230,7 +231,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	if err != nil {
 		tb.Fatal(err)
 	}
-	mux.Handle("/publish", publishHandler.Handle())
+	r.Handle("/publish", publishHandler.Handle())
 
 	srv, err := server.New("")
 	if err != nil {
@@ -243,7 +244,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 
 	// Start the server
 	go func() {
-		if err := srv.ServeHTTPHandler(stopCtx, mux); err != nil {
+		if err := srv.ServeHTTPHandler(stopCtx, r); err != nil {
 			tb.Error(err)
 		}
 	}()

--- a/internal/integration/helpers.go
+++ b/internal/integration/helpers.go
@@ -180,7 +180,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 		tb.Fatal(err)
 	}
 	exportHandler := http.StripPrefix("/export", exportServer.Routes(ctx))
-	r.Handle("/export/", exportHandler)
+	r.PathPrefix("/export/").Handler(exportHandler)
 
 	// Federation
 	federationInConfig := &federationin.Config{
@@ -213,7 +213,7 @@ func NewTestServer(tb testing.TB) (*serverenv.ServerEnv, *Client) {
 	if err != nil {
 		tb.Fatal(err)
 	}
-	r.Handle("/key-rotation/", http.StripPrefix("/key-rotation", rotationServer.Routes(ctx)))
+	r.PathPrefix("/key-rotation/").Handler(http.StripPrefix("/key-rotation", rotationServer.Routes(ctx)))
 
 	// Parse the config to load default values.
 	publishConfig := publish.Config{}

--- a/internal/keyrotation/server.go
+++ b/internal/keyrotation/server.go
@@ -18,12 +18,12 @@ package keyrotation
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/database"
 	revisiondb "github.com/google/exposure-notifications-server/internal/revision/database"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 )
 
 // Server hosts end points to manage key rotation
@@ -63,11 +63,11 @@ func NewServer(config *Config, env *serverenv.ServerEnv) (*Server, error) {
 }
 
 // Routes defines and returns the routes for this server.
-func (s *Server) Routes(ctx context.Context) *http.ServeMux {
-	mux := http.NewServeMux()
+func (s *Server) Routes(ctx context.Context) *mux.Router {
+	r := mux.NewRouter()
 
-	mux.HandleFunc("/rotate-keys", s.handleRotateKeys(ctx))
-	mux.Handle("/health", server.HandleHealthz(ctx))
+	r.HandleFunc("/rotate-keys", s.handleRotateKeys(ctx))
+	r.Handle("/health", server.HandleHealthz(ctx))
 
-	return mux
+	return r
 }

--- a/internal/mirror/server.go
+++ b/internal/mirror/server.go
@@ -18,12 +18,12 @@ package mirror
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/exposure-notifications-server/internal/database"
 	mirrordb "github.com/google/exposure-notifications-server/internal/mirror/database"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 )
 
 // Server hosts end points to manage key rotation
@@ -56,11 +56,11 @@ func NewServer(config *Config, env *serverenv.ServerEnv) (*Server, error) {
 }
 
 // Routes defines and returns the routes for this server.
-func (s *Server) Routes(ctx context.Context) *http.ServeMux {
-	mux := http.NewServeMux()
+func (s *Server) Routes(ctx context.Context) *mux.Router {
+	r := mux.NewRouter()
 
-	mux.HandleFunc("/", s.handleMirror(ctx))
-	mux.Handle("/health", server.HandleHealthz(ctx))
+	r.HandleFunc("/", s.handleMirror(ctx))
+	r.Handle("/health", server.HandleHealthz(ctx))
 
-	return mux
+	return r
 }

--- a/pkg/jwks/server.go
+++ b/pkg/jwks/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/server"
+	"github.com/gorilla/mux"
 )
 
 // Server is the debugger server.
@@ -50,12 +51,12 @@ func NewServer(config *Config, env *serverenv.ServerEnv) (*Server, error) {
 	}, nil
 }
 
-func (s *Server) Routes(ctx context.Context) *http.ServeMux {
-	mux := http.NewServeMux()
-	mux.Handle("/health", server.HandleHealthz(ctx))
-	mux.Handle("/", s.handleUpdateAll(ctx))
+func (s *Server) Routes(ctx context.Context) *mux.Router {
+	r := mux.NewRouter()
+	r.Handle("/health", server.HandleHealthz(ctx))
+	r.Handle("/", s.handleUpdateAll(ctx))
 
-	return mux
+	return r
 }
 
 func (s *Server) handleUpdateAll(ctx context.Context) http.Handler {

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -24,6 +24,7 @@ import (
 
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/gorilla/mux"
 )
 
 // ServeMetricsIfPrometheus serves the opencensus metrics at /metrics when OBSERVABILITY_EXPORTER set to "prometheus"
@@ -43,11 +44,11 @@ func ServeMetricsIfPrometheus(ctx context.Context) error {
 		}
 
 		go func() {
-			mux := http.NewServeMux()
-			mux.Handle("/metrics", exporter)
+			r := mux.NewRouter()
+			r.Handle("/metrics", exporter)
 
 			logger.Debugf("Metrics endpoint listening on :%s", metricsPort)
-			if err := http.ListenAndServe(":"+metricsPort, mux); err != nil {
+			if err := http.ListenAndServe(":"+metricsPort, r); err != nil {
 				logger.Debugf("error while serving metrics endpoint: %w", err)
 			}
 		}()


### PR DESCRIPTION
The intention is to be able to share middlewares between key server and
verification server.

NOTE: some of the changed lines are not strictly required (e.g. the
Prometheus /metrics handler can use the Go http mux perfectly fine), but
are changed to be consistent.