### PR TITLE
Switch 30d to hours

### DIFF
--- a/internal/jwks/config.go
+++ b/internal/jwks/config.go
@@ -31,7 +31,7 @@ type Config struct {
 
 	Port string `env:"PORT, default=8080"`
 
-	KeyCleanupTTL time.Duration `env:"HEALTH_AUTHORITY_KEY_CLEANUP_TTL, default=30d"`
+	KeyCleanupTTL time.Duration `env:"HEALTH_AUTHORITY_KEY_CLEANUP_TTL, default=720h"` // 30 days
 }
 
 func (c *Config) DatabaseConfig() *database.Config {


### PR DESCRIPTION
d is not a valid Go duration suffix

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Switch 30d to 720h
```