### PR TITLE
chown admin console template files

### DIFF
--- a/builders/admin-console.dockerfile
+++ b/builders/admin-console.dockerfile
@@ -23,7 +23,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 USER nobody
 COPY ./bin/admin-console /admin-console
-COPY ./cmd/admin-console/templates /templates
+COPY --chown=65534:65534 ./cmd/admin-console/templates /templates
 COPY --from=builder /var/run /var/run
 COPY --from=builder /var/run/secrets /var/run/secrets
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* When building from linux I've had troubling with permissions on reading assets files. Adding the chown property to the copy ensures they have permissions to read them
    * Note: the internet notes that `RUN chown` and works similarly and was common practice, but results in an unnecessary intermediate layer.  The `COPY --chown` was added to avoid the former which tended to blow up container sizes having created two versions of files.
