### PR TITLE
fix carriage returns in public keys

### DIFF
--- a/internal/admin/handle_health_authority.go
+++ b/internal/admin/handle_health_authority.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -226,7 +227,7 @@ func (f *keyhealthAuthorityFormData) PopulateHealthAuthorityKey(hak *model.Healt
 	hak.Version = project.TrimSpaceAndNonPrintable(f.Version)
 	hak.From = fTime
 	hak.Thru = tTime
-	hak.PublicKeyPEM = project.TrimSpaceAndNonPrintable(f.PEMBlock)
+	hak.PublicKeyPEM = strings.ReplaceAll(project.TrimSpaceAndNonPrintable(f.PEMBlock), "\r", "")
 
 	_, err = hak.PublicKey()
 	return err

--- a/internal/jwks/jwks.go
+++ b/internal/jwks/jwks.go
@@ -134,6 +134,7 @@ func stripKey(k string) string {
 	k = strings.ReplaceAll(k, "-----BEGIN PUBLIC KEY-----", "")
 	k = strings.ReplaceAll(k, "-----END PUBLIC KEY-----", "")
 	k = strings.ReplaceAll(k, "\n", "")
+	k = strings.ReplaceAll(k, "\r", "")
 	return k
 }
 


### PR DESCRIPTION
## Proposed Changes

* don't save carriage returns  `\r` in public key PEM format
* strip `\r` on comparison in JWKS service

**Release Note**


```release-note
JWKS Service - fix issue where manually added keys containing `\r` characters could prevent upgrading a health authority to use JWKS discovery.
```