### PR TITLE
check for serialization error on lock and unlock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kv v0.7.0
 	github.com/hashicorp/vault/api v1.0.5-0.20201001211907-38d91b749c77
 	github.com/hashicorp/vault/sdk v0.1.14-0.20201214222404-d8fffe05d2f4
+	github.com/jackc/pgconn v1.8.0
 	github.com/jackc/pgx/v4 v4.10.0
 	github.com/kelseyhightower/run v0.0.17
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/internal/database/config.go
+++ b/internal/database/config.go
@@ -40,6 +40,10 @@ type Config struct {
 	PoolMaxConnLife    time.Duration `env:"DB_POOL_MAX_CONN_LIFETIME, default=5m" json:",omitempty"`
 	PoolMaxConnIdle    time.Duration `env:"DB_POOL_MAX_CONN_IDLE_TIME, default=1m" json:",omitempty"`
 	PoolHealthCheck    time.Duration `env:"DB_POOL_HEALTH_CHECK_PERIOD, default=1m" json:",omitempty"`
+
+	// LockRetryTime is a suggested default for retry on lock acquisition.
+	// Consider a different value for things in user facing paths.
+	LockRetryTime time.Duration `env:"LOCK_RETRY_TIME, default=1s"`
 }
 
 func (c *Config) DatabaseConfig() *Config {

--- a/internal/database/lock.go
+++ b/internal/database/lock.go
@@ -92,6 +92,7 @@ func makeMultiUnlockFn(ctx context.Context, db *DB, lockIDs []string, expires ti
 }
 
 func serializationError(err error) bool {
+	// See https://www.postgresql.org/docs/current/errcodes-appendix.html
 	if pgErr, ok := err.(*pgconn.PgError); !ok || pgErr.Code == "40001" {
 		return true
 	}

--- a/internal/database/lock_test.go
+++ b/internal/database/lock_test.go
@@ -102,7 +102,7 @@ func TestLockRetry(t *testing.T) {
 				ch <- struct{}{}
 			}()
 			ctx := context.Background()
-			unlock, err := testDB.LockRetry(ctx, lockName, ttl, 2*time.Second)
+			unlock, err := testDB.LockRetry(ctx, lockName, ttl, 10*time.Second)
 			if err != nil {
 				log.Printf("worker %v unable to acquire lock: %v", worker, err)
 				t.Errorf("unable to acquire lock: worker: %v err: %v", worker, err)

--- a/internal/export/batcher.go
+++ b/internal/export/batcher.go
@@ -42,7 +42,7 @@ func (s *Server) handleCreateBatches(ctx context.Context) http.HandlerFunc {
 
 		// Obtain lock to make sure there are no other processes working to create batches.
 		lock := "create_batches"
-		unlockFn, err := db.Lock(ctx, lock, s.config.CreateTimeout)
+		unlockFn, err := db.LockRetry(ctx, lock, s.config.CreateTimeout, s.config.Database.LockRetryTime)
 		if err != nil {
 			if errors.Is(err, coredb.ErrAlreadyLocked) {
 				stats.Record(ctx, mBatcherLockContention.M(1))

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -395,7 +395,7 @@ func (s *Server) retryingCreateIndex(ctx context.Context, eb *model.ExportBatch,
 			return nil
 		}
 
-		unlock, err := db.Lock(ctx, lockID, time.Minute)
+		unlock, err := db.LockRetry(ctx, lockID, time.Minute, s.config.Database.LockRetryTime)
 		if err != nil {
 			if errors.Is(err, coredb.ErrAlreadyLocked) {
 				logger.Debugf("Lock %s is locked; sleeping %v and will try again", lockID, sleep)

--- a/internal/exportimport/importer.go
+++ b/internal/exportimport/importer.go
@@ -70,7 +70,7 @@ func (s *Server) runImport(ctx context.Context, config *model.ExportImport) erro
 	logger := logging.FromContext(ctx)
 
 	// Obtain a lock to work on this import config.
-	unlock, err := s.db.Lock(ctx, fmt.Sprintf("%s%d", lockPrefix, config.ID), s.config.MaxRuntime)
+	unlock, err := s.db.LockRetry(ctx, fmt.Sprintf("%s%d", lockPrefix, config.ID), s.config.MaxRuntime, s.config.Database.LockRetryTime)
 	if err != nil {
 		if errors.Is(err, database.ErrAlreadyLocked) {
 			logger.Warnw("import already locked", "config", config)

--- a/internal/exportimport/scheduler.go
+++ b/internal/exportimport/scheduler.go
@@ -42,7 +42,7 @@ func (s *Server) handleSchedule(ctx context.Context) http.HandlerFunc {
 		_, span := trace.StartSpan(r.Context(), "(*exportimport.handleSchedule).ServeHTTP")
 		defer span.End()
 
-		unlock, err := s.db.Lock(ctx, schedulerLockID, s.config.MaxRuntime)
+		unlock, err := s.db.LockRetry(ctx, schedulerLockID, s.config.MaxRuntime, s.config.Database.LockRetryTime)
 		if err != nil {
 			if errors.Is(err, database.ErrAlreadyLocked) {
 				w.WriteHeader(http.StatusOK)

--- a/internal/mirror/mirror.go
+++ b/internal/mirror/mirror.go
@@ -147,7 +147,7 @@ func (s *Server) processMirror(ctx context.Context, deadline time.Time, mirror *
 	blobstore := s.env.Blobstore()
 
 	lockID := fmt.Sprintf("%s-%d", mirrorLockPrefix, mirror.ID)
-	unlock, err := s.db.Lock(ctx, lockID, s.config.MaxRuntime)
+	unlock, err := s.db.LockRetry(ctx, lockID, s.config.MaxRuntime, s.config.Database.LockRetryTime)
 	if err != nil {
 		if errors.Is(err, database.ErrAlreadyLocked) {
 			logger.Infow("mirror already locked, skipping")


### PR DESCRIPTION
Towards #1316

## Proposed Changes

Provide primitives to fixed observed occurrences of postgres serialization contention.

* Add `LockRetry` that checks for pg serialization error and uses exponential backoff to retry lock acquire
* Unlock function uses 3 constant reties on a tight schedule, only reties on serialization errors

If this looks good - I will asses each db.Lock call site to determine if we should retry lock acquisition.

From the docs: https://www.postgresql.org/docs/9.5/transaction-iso.html

The Serializable isolation level provides the strictest transaction isolation. This level emulates serial transaction execution for all committed transactions; as if transactions had been executed one after another, serially, rather than concurrently. However, like the Repeatable Read level, **applications using this level must be prepared to retry transactions due to serialization failures**.

**Release Note**

```release-note
DB backed locks will retry unlock 3 times in quick succession if unable to serialize the transaction.
```