### PR TITLE
move all serializable transactions to automatically retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kv v0.7.0
 	github.com/hashicorp/vault/api v1.0.5-0.20201001211907-38d91b749c77
 	github.com/hashicorp/vault/sdk v0.1.14-0.20201214222404-d8fffe05d2f4
+	github.com/jackc/pgconn v1.8.0
 	github.com/jackc/pgx/v4 v4.10.0
 	github.com/kelseyhightower/run v0.0.17
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/internal/authorizedapp/database/authorized_app.go
+++ b/internal/authorizedapp/database/authorized_app.go
@@ -46,7 +46,7 @@ func (aa *AuthorizedAppDB) InsertAuthorizedApp(ctx context.Context, m *model.Aut
 		return fmt.Errorf("AuthorizedApp invalid: %v", strings.Join(errors, ", "))
 	}
 
-	return aa.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return aa.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO
 				AuthorizedApp
@@ -67,7 +67,7 @@ func (aa *AuthorizedAppDB) InsertAuthorizedApp(ctx context.Context, m *model.Aut
 
 // UpdateAuthorizedApp updates the properties of an authorized app, including possibly renaming it.
 func (aa *AuthorizedAppDB) UpdateAuthorizedApp(ctx context.Context, priorKey string, m *model.AuthorizedApp) error {
-	return aa.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return aa.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE AuthorizedApp
 			SET
@@ -92,7 +92,7 @@ func (aa *AuthorizedAppDB) UpdateAuthorizedApp(ctx context.Context, priorKey str
 // DeleteAuthorizedApp removes an authorized app from the database.
 func (aa *AuthorizedAppDB) DeleteAuthorizedApp(ctx context.Context, name string) error {
 	var count int64
-	err := aa.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	err := aa.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			DELETE FROM
 				AuthorizedApp

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgconn"
 	pgx "github.com/jackc/pgx/v4"
+	"github.com/sethvargo/go-retry"
 )
 
 var (
@@ -29,13 +31,55 @@ var (
 
 	// ErrKeyConflict indicates that there was a key conflict inserting a row.
 	ErrKeyConflict = errors.New("key conflict")
+
+	// FastRetry will attempt a transation 3 times using exponential backoff starting at 10
+	FastRetry retry.Backoff
 )
+
+func init() {
+	FastRetry, _ = retry.NewExponential(10 * time.Millisecond)
+	FastRetry = retry.WithMaxRetries(3, FastRetry)
+}
 
 func (db *DB) NullableTime(t time.Time) *time.Time {
 	if t.IsZero() {
 		return nil
 	}
 	return &t
+}
+
+// IsSerializationError returns true if the error is a transaction serialization error
+// from PG. This should only occur with isolation level of serializable and is
+// a retryable condition.
+func IsSerializationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// See https://www.postgresql.org/docs/current/errcodes-appendix.html
+	if pgErr, ok := err.(*pgconn.PgError); !ok || pgErr.Code == "40001" {
+		return true
+	}
+	return false
+}
+
+// SerializableTx will run f in a transaction with an isolation level of serializable.
+// The transaction will be retried according the default FastRetry strategy
+// a serialization error occurs.
+func (db *DB) SerializableTx(ctx context.Context, f func(tx pgx.Tx) error) error {
+	return db.SerializableTxWithBackoff(ctx, FastRetry, f)
+}
+
+// SerializableTxWithBackoff will run f in a transaction with an isolation level of serializable.
+// The transaction will be retried according to the provided backoff strategy if
+// a serialization error occurs.
+func (db *DB) SerializableTxWithBackoff(ctx context.Context, b retry.Backoff, f func(tx pgx.Tx) error) error {
+	return retry.Do(ctx, b, func(ctx context.Context) error {
+		err := db.InTx(ctx, pgx.Serializable, f)
+		if IsSerializationError(err) {
+			return retry.RetryableError(err)
+		}
+		return err
+	})
 }
 
 // InTx runs the given function f within a transaction with isolation level isoLevel.

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -32,7 +32,7 @@ var (
 	// ErrKeyConflict indicates that there was a key conflict inserting a row.
 	ErrKeyConflict = errors.New("key conflict")
 
-	// FastRetry will attempt a transation 3 times using exponential backoff starting at 10
+	// FastRetry will attempt a transaction 3 times using exponential backoff starting at 10
 	FastRetry retry.Backoff
 )
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -226,7 +226,7 @@ func TestPublishEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	if err := db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 		UPDATE
 			ExportBatch

--- a/internal/export/database/export.go
+++ b/internal/export/database/export.go
@@ -48,7 +48,7 @@ func (db *ExportDB) AddExportConfig(ctx context.Context, ec *model.ExportConfig)
 	}
 
 	thru := db.db.NullableTime(ec.Thru)
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO
 				ExportConfig
@@ -77,7 +77,7 @@ func (db *ExportDB) UpdateExportConfig(ctx context.Context, ec *model.ExportConf
 	}
 
 	thru := db.db.NullableTime(ec.Thru)
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE
 				ExportConfig
@@ -242,7 +242,7 @@ func (db *ExportDB) AddSignatureInfo(ctx context.Context, si *model.SignatureInf
 	if !si.EndTimestamp.IsZero() {
 		thru = &si.EndTimestamp
 	}
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO
  				SignatureInfo
@@ -264,7 +264,7 @@ func (db *ExportDB) UpdateSignatureInfo(ctx context.Context, si *model.Signature
 	if !si.EndTimestamp.IsZero() {
 		thru = &si.EndTimestamp
 	}
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE SignatureInfo
 			SET
@@ -405,7 +405,7 @@ func scanOneSignatureInfo(row pgx.Row) (*model.SignatureInfo, error) {
 func (db *ExportDB) LatestExportBatchEnd(ctx context.Context, ec *model.ExportConfig) (time.Time, error) {
 	var t time.Time
 
-	if err := db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	if err := db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			SELECT
 				MAX(end_timestamp)
@@ -442,7 +442,7 @@ func (db *ExportDB) LatestExportBatchEnd(ctx context.Context, ec *model.ExportCo
 func (db *ExportDB) ListLatestExportBatchEnds(ctx context.Context) (map[int64]*time.Time, error) {
 	ts := make(map[int64]*time.Time, 8)
 
-	if err := db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	if err := db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
 			SELECT
 				config_id, MAX(end_timestamp)
@@ -478,7 +478,7 @@ func (db *ExportDB) ListLatestExportBatchEnds(ctx context.Context) (map[int64]*t
 
 // AddExportBatches inserts new export batches.
 func (db *ExportDB) AddExportBatches(ctx context.Context, batches []*model.ExportBatch) error {
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		const stmtName = "insert export batches"
 		_, err := tx.Prepare(ctx, stmtName, `
 			INSERT INTO
@@ -559,7 +559,7 @@ func (db *ExportDB) LeaseBatch(ctx context.Context, ttl time.Duration, batchMaxC
 	for _, bid := range openBatchIDs {
 		// In a serialized transaction, fetch the existing batch and make sure it can be leased, then lease it.
 		leased := false
-		err := db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+		err := db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 			row := tx.QueryRow(ctx, `
 				SELECT
 					status, lease_expires
@@ -652,7 +652,7 @@ func lookupExportBatch(ctx context.Context, batchID int64, queryRow queryRowFn) 
 
 // FinalizeBatch writes the ExportFile records and marks the ExportBatch as complete.
 func (db *ExportDB) FinalizeBatch(ctx context.Context, eb *model.ExportBatch, files []string, batchSize int) error {
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		// Update ExportFile for the files created.
 		for i, file := range files {
 			ef := model.ExportFile{
@@ -868,7 +868,7 @@ func (db *ExportDB) DeleteFilesBefore(ctx context.Context, before time.Time, blo
 			return 0, fmt.Errorf("delete object: %w", err)
 		}
 
-		err := db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+		err := db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 			// Update Status in ExportFile.
 			if err := updateExportFileStatus(ctx, tx, f.filename, model.ExportBatchDeleted); err != nil {
 				return fmt.Errorf("updating ExportFile: %w", err)

--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -356,7 +356,7 @@ func TestBatches(t *testing.T) {
 			batchID := leaseBatches()
 
 			// Complete a batch.
-			err = testDB.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error { return completeBatch(ctx, tx, batchID) })
+			err = testDB.SerializableTx(ctx, func(tx pgx.Tx) error { return completeBatch(ctx, tx, batchID) })
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -842,7 +842,7 @@ func TestAddExportFileSkipsDuplicates(t *testing.T) {
 	}
 
 	// Add a record.
-	err = testDB.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	err = testDB.SerializableTx(ctx, func(tx pgx.Tx) error {
 		if err := addExportFile(ctx, tx, ef); err != nil {
 			return err
 		}
@@ -863,7 +863,7 @@ func TestAddExportFileSkipsDuplicates(t *testing.T) {
 
 	// Add a second record with same filename, must return ErrKeyConflict, and not overwrite.
 	ef.BucketName = "bucket-2"
-	err = testDB.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	err = testDB.SerializableTx(ctx, func(tx pgx.Tx) error {
 		if err := addExportFile(ctx, tx, ef); err != nil {
 			if err == database.ErrKeyConflict {
 				return nil // Expected result.

--- a/internal/exportimport/database/exportimport.go
+++ b/internal/exportimport/database/exportimport.go
@@ -162,7 +162,7 @@ func (db *ExportImportDB) AddConfig(ctx context.Context, ei *model.ExportImport)
 		return err
 	}
 
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO
 			ExportImport
@@ -186,7 +186,7 @@ func (db *ExportImportDB) UpdateConfig(ctx context.Context, c *model.ExportImpor
 	}
 
 	from := db.db.NullableTime(c.From)
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE
 				ExportImport

--- a/internal/federationin/database/federationin.go
+++ b/internal/federationin/database/federationin.go
@@ -104,7 +104,7 @@ func getFederationInQuery(ctx context.Context, queryID string, queryRow queryRow
 
 // AddFederationInQuery adds a FederationInQuery entity. It will overwrite a query with matching q.queryID if it exists.
 func (db *FederationInDB) AddFederationInQuery(ctx context.Context, q *model.FederationInQuery) error {
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		query := `
 			INSERT INTO
 				FederationInQuery
@@ -209,7 +209,7 @@ func (db *FederationInDB) StartFederationInSync(ctx context.Context, q *model.Fe
 	finalize := func(state *federation.FetchState, q *model.FederationInQuery, totalInserted int) error {
 		completed := started.Add(time.Since(startedTimer))
 
-		return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+		return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 			// Special case: when no keys are pulled, the maxTimestamp will be 0, so we don't update the
 			// FederationQuery in this case to prevent it from going back and fetching old keys from the past.
 			if totalInserted > 0 {

--- a/internal/federationout/database/federationout.go
+++ b/internal/federationout/database/federationout.go
@@ -37,7 +37,7 @@ func New(db *database.DB) *FederationOutDB {
 
 // AddFederationOutAuthorization adds or updates a FederationOutAuthorization record.
 func (db *FederationOutDB) AddFederationOutAuthorization(ctx context.Context, auth *model.FederationOutAuthorization) error {
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		q := `
 			INSERT INTO
 				FederationOutAuthorization

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -367,7 +367,7 @@ func TestIntegration(t *testing.T) {
 			}
 
 			// Mark the export in the past to force a cleanup
-			if err := db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+			if err := db.SerializableTx(ctx, func(tx pgx.Tx) error {
 				result, err := tx.Exec(ctx, `
 				UPDATE
 					ExportBatch

--- a/internal/mirror/database/mirror.go
+++ b/internal/mirror/database/mirror.go
@@ -35,7 +35,7 @@ func New(db *database.DB) *MirrorDB {
 }
 
 func (db *MirrorDB) AddMirror(ctx context.Context, m *model.Mirror) error {
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO
 				Mirror (index_file, export_root, cloud_storage_bucket, filename_root, filename_rewrite)
@@ -54,7 +54,7 @@ func (db *MirrorDB) AddMirror(ctx context.Context, m *model.Mirror) error {
 // UpdateMirror updates the given mirror struct in the database. It must already
 // exist in the database, keyed off of ID.
 func (db *MirrorDB) UpdateMirror(ctx context.Context, m *model.Mirror) error {
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE
 				Mirror
@@ -82,7 +82,7 @@ func (db *MirrorDB) UpdateMirror(ctx context.Context, m *model.Mirror) error {
 }
 
 func (db *MirrorDB) DeleteMirror(ctx context.Context, m *model.Mirror) error {
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			DELETE FROM
 				MirrorFile

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -109,7 +109,7 @@ func TestExport(t *testing.T) {
 	if err := client.ExportBatches(); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	if err := db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 					UPDATE
 						ExportBatch
@@ -225,7 +225,7 @@ func TestExport(t *testing.T) {
 	// Next, measure cleanup performance
 
 	// Mark the export in the past to force a cleanup
-	if err := db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	if err := db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE
 				ExportBatch

--- a/internal/revision/database/revision.go
+++ b/internal/revision/database/revision.go
@@ -88,7 +88,7 @@ func (rdb *RevisionDB) DestroyKey(ctx context.Context, keyID int64) error {
 	logger := logging.FromContext(ctx)
 	logger.Warnf("destroying key material for revision key ID %v", keyID)
 
-	if err := rdb.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	if err := rdb.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE
 				RevisionKeys

--- a/internal/verification/database/health_authority_db.go
+++ b/internal/verification/database/health_authority_db.go
@@ -54,7 +54,7 @@ func (db *HealthAuthorityDB) AddHealthAuthority(ctx context.Context, ha *model.H
 		return err
 	}
 
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO
 				HealthAuthority
@@ -79,7 +79,7 @@ func (db *HealthAuthorityDB) UpdateHealthAuthority(ctx context.Context, ha *mode
 		return err
 	}
 
-	return db.db.InTx(ctx, pgx.Serializable, func(tx pgx.Tx) error {
+	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE HealthAuthority
 			SET


### PR DESCRIPTION
Fixes #1316

## Proposed Changes

* Add default retries to serializable transactions
* includes all uses of lock - where we've seen these errors

From the docs: https://www.postgresql.org/docs/9.5/transaction-iso.html

The Serializable isolation level provides the strictest transaction isolation. This level emulates serial transaction execution for all committed transactions; as if transactions had been executed one after another, serially, rather than concurrently. However, like the Repeatable Read level, applications using this level must be prepared to retry transactions due to serialization failures.

**Release Note**

```release-note
**Behavior Change** All transactions with an isolation level of serializable will automatically retry 3 times with a quick exponential backoff period. This impacts background groups that may periodically fail due to lock contention. 
```