### PR TITLE
Update locking procedure to be strongly consistent

### DIFF
--- a/internal/database/lock.go
+++ b/internal/database/lock.go
@@ -89,7 +89,9 @@ func makeMultiUnlockFn(ctx context.Context, db *DB, lockIDs []string, expires ti
 	}
 }
 
-// Lock acquires lock with given name that times out after ttl. Returns an UnlockFn that can be used to unlock the lock. ErrAlreadyLocked will be returned if there is already a lock in use.
+// Lock acquires lock with given name that times out after ttl. Returns an
+// UnlockFn that can be used to unlock the lock. ErrAlreadyLocked will be
+// returned if there is already a lock in use.
 func (db *DB) Lock(ctx context.Context, lockID string, ttl time.Duration) (UnlockFn, error) {
 	var expires time.Time
 	err := db.SerializableTx(ctx, func(tx pgx.Tx) error {

--- a/internal/database/lock_test.go
+++ b/internal/database/lock_test.go
@@ -75,12 +75,13 @@ func TestLock(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer conn.Release()
-	var count int
-	if err := conn.QueryRow(ctx, `SELECT count(*) FROM Lock`).Scan(&count); err != nil {
+
+	var expires time.Time
+	if err := conn.QueryRow(ctx, `SELECT expires FROM Lock WHERE lock_id = $1`, id1).Scan(&expires); err != nil {
 		t.Fatal(err)
 	}
-	if count != 0 {
-		t.Fatalf("got %d rows from Lock table, wanted zero", count)
+	if got, want := expires.UTC(), time.Unix(0, 0).UTC(); got != want {
+		t.Fatalf("expected lock to be expired (%v), got %v", want, got)
 	}
 }
 

--- a/migrations/000056_UpdateLocks.down.sql
+++ b/migrations/000056_UpdateLocks.down.sql
@@ -1,0 +1,52 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+DROP INDEX IF EXISTS lock_lock_id_expires;
+
+CREATE OR REPLACE FUNCTION AcquireLock(VARCHAR(100), INT) RETURNS TIMESTAMP AS $$
+  DECLARE
+    nowT TIMESTAMP;
+    expiresT TIMESTAMP;
+  BEGIN
+    nowT := CURRENT_TIMESTAMP;
+    expiresT := nowT + '1 SECOND'::interval * $2;
+
+    IF EXISTS (SELECT lock_id FROM Lock WHERE lock_id = $1 AND expires > nowT) THEN
+      RETURN to_timestamp(0); -- Special value indicating no lock acquired.
+    END IF;
+
+    IF EXISTS (SELECT lock_id FROM Lock WHERE lock_id = $1) THEN
+      UPDATE Lock SET expires = expiresT WHERE lock_id = $1;
+      RETURN expiresT;
+    END IF;
+
+    INSERT INTO Lock (lock_id, expires) VALUES ($1, expiresT);
+    RETURN expiresT;
+  END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ReleaseLock(VARCHAR(100), TIMESTAMP) RETURNS BOOLEAN AS $$
+  BEGIN
+    IF NOT EXISTS (SELECT lock_id FROM Lock WHERE lock_id = $1 AND expires = $2) THEN
+      RETURN FALSE; -- Another process acquired an expired lock
+    END IF;
+
+    DELETE FROM Lock WHERE lock_id = $1;
+    RETURN TRUE;
+  END
+$$ LANGUAGE plpgsql;
+
+END;

--- a/migrations/000056_UpdateLocks.up.sql
+++ b/migrations/000056_UpdateLocks.up.sql
@@ -1,0 +1,58 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+CREATE INDEX lock_lock_id_expires ON Lock (lock_id, expires);
+
+CREATE OR REPLACE FUNCTION AcquireLock(VARCHAR(100), INT) RETURNS TIMESTAMP AS $$
+  DECLARE
+    nowT TIMESTAMP;
+    expiresT TIMESTAMP;
+  BEGIN
+    nowT := CURRENT_TIMESTAMP;
+    expiresT := nowT + '1 SECOND'::interval * $2;
+
+    -- Create the lock row. If it already exists, do nothing.
+    INSERT INTO Lock (lock_id, expires) VALUES ($1, to_timestamp(0))
+      ON CONFLICT (lock_id) DO NOTHING;
+
+    -- Attempt to update the lock ttl if it's expired.
+    UPDATE Lock SET expires = expiresT WHERE lock_id = $1 AND expires <= nowT;
+    IF FOUND THEN
+      -- The lock was acquired, return the new expiration time.
+      RETURN expiresT;
+    ELSE
+      -- The current lock has not yet expired, return the sentinel value
+      -- indicating the lock was not acquired.
+      RETURN to_timestamp(0);
+    END IF;
+  END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ReleaseLock(VARCHAR(100), TIMESTAMP) RETURNS BOOLEAN AS $$
+  BEGIN
+    UPDATE Lock SET expires = to_timestamp(0)
+      WHERE lock_id = $1 AND expires = $2;
+    IF FOUND THEN
+      -- Lock successfully expired.
+      RETURN TRUE;
+    ELSE
+      -- Another process already expired the lock.
+      RETURN FALSE;
+    END IF;
+  END
+$$ LANGUAGE plpgsql;
+
+END;


### PR DESCRIPTION
This updates the existing AcquireLock and ReleaseLock procedures to be strongly consistent by introducing a slight behavior change: once a lock exists, it exists forever. Releasing a lock sets the timestamp to 01-01-1970 instead of the previous behavior which deleted the row. Additionally, instead of relying on a parent transaction for isolation, the statements can operate independently from each other. This should dramatically reduce the number of serialization deadlocks we see.

I'm like 99% certain we could drop the isolation level back to READ COMMITTED after this, but I didn't want to be too invasive here.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Update locking procedure to be strongly consistent
```