### PR TITLE
Drop usage of serializable transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/hashicorp/vault-plugin-secrets-kv v0.7.0
 	github.com/hashicorp/vault/api v1.0.5-0.20201001211907-38d91b749c77
 	github.com/hashicorp/vault/sdk v0.1.14-0.20201214222404-d8fffe05d2f4
-	github.com/jackc/pgconn v1.8.0
 	github.com/jackc/pgx/v4 v4.10.0
 	github.com/kelseyhightower/run v0.0.17
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/internal/authorizedapp/database/authorized_app.go
+++ b/internal/authorizedapp/database/authorized_app.go
@@ -46,7 +46,7 @@ func (aa *AuthorizedAppDB) InsertAuthorizedApp(ctx context.Context, m *model.Aut
 		return fmt.Errorf("AuthorizedApp invalid: %v", strings.Join(errors, ", "))
 	}
 
-	return aa.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return aa.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO
 				AuthorizedApp
@@ -67,7 +67,7 @@ func (aa *AuthorizedAppDB) InsertAuthorizedApp(ctx context.Context, m *model.Aut
 
 // UpdateAuthorizedApp updates the properties of an authorized app, including possibly renaming it.
 func (aa *AuthorizedAppDB) UpdateAuthorizedApp(ctx context.Context, priorKey string, m *model.AuthorizedApp) error {
-	return aa.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return aa.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE AuthorizedApp
 			SET
@@ -92,7 +92,7 @@ func (aa *AuthorizedAppDB) UpdateAuthorizedApp(ctx context.Context, priorKey str
 // DeleteAuthorizedApp removes an authorized app from the database.
 func (aa *AuthorizedAppDB) DeleteAuthorizedApp(ctx context.Context, name string) error {
 	var count int64
-	err := aa.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	if err := aa.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			DELETE FROM
 				AuthorizedApp
@@ -104,8 +104,7 @@ func (aa *AuthorizedAppDB) DeleteAuthorizedApp(ctx context.Context, name string)
 		}
 		count = result.RowsAffected()
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 	if count == 0 {

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -226,7 +226,7 @@ func TestPublishEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	if err := db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 		UPDATE
 			ExportBatch

--- a/internal/exportimport/database/exportimport.go
+++ b/internal/exportimport/database/exportimport.go
@@ -162,7 +162,7 @@ func (db *ExportImportDB) AddConfig(ctx context.Context, ei *model.ExportImport)
 		return err
 	}
 
-	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO
 			ExportImport
@@ -186,7 +186,7 @@ func (db *ExportImportDB) UpdateConfig(ctx context.Context, c *model.ExportImpor
 	}
 
 	from := db.db.NullableTime(c.From)
-	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE
 				ExportImport

--- a/internal/federationout/database/federationout.go
+++ b/internal/federationout/database/federationout.go
@@ -37,7 +37,7 @@ func New(db *database.DB) *FederationOutDB {
 
 // AddFederationOutAuthorization adds or updates a FederationOutAuthorization record.
 func (db *FederationOutDB) AddFederationOutAuthorization(ctx context.Context, auth *model.FederationOutAuthorization) error {
-	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		q := `
 			INSERT INTO
 				FederationOutAuthorization

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -367,7 +367,7 @@ func TestIntegration(t *testing.T) {
 			}
 
 			// Mark the export in the past to force a cleanup
-			if err := db.SerializableTx(ctx, func(tx pgx.Tx) error {
+			if err := db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 				result, err := tx.Exec(ctx, `
 				UPDATE
 					ExportBatch

--- a/internal/mirror/database/mirror.go
+++ b/internal/mirror/database/mirror.go
@@ -35,7 +35,7 @@ func New(db *database.DB) *MirrorDB {
 }
 
 func (db *MirrorDB) AddMirror(ctx context.Context, m *model.Mirror) error {
-	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO
 				Mirror (index_file, export_root, cloud_storage_bucket, filename_root, filename_rewrite)
@@ -54,7 +54,7 @@ func (db *MirrorDB) AddMirror(ctx context.Context, m *model.Mirror) error {
 // UpdateMirror updates the given mirror struct in the database. It must already
 // exist in the database, keyed off of ID.
 func (db *MirrorDB) UpdateMirror(ctx context.Context, m *model.Mirror) error {
-	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE
 				Mirror
@@ -82,7 +82,7 @@ func (db *MirrorDB) UpdateMirror(ctx context.Context, m *model.Mirror) error {
 }
 
 func (db *MirrorDB) DeleteMirror(ctx context.Context, m *model.Mirror) error {
-	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			DELETE FROM
 				MirrorFile

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -109,7 +109,7 @@ func TestExport(t *testing.T) {
 	if err := client.ExportBatches(); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	if err := db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 					UPDATE
 						ExportBatch
@@ -225,7 +225,7 @@ func TestExport(t *testing.T) {
 	// Next, measure cleanup performance
 
 	// Mark the export in the past to force a cleanup
-	if err := db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	if err := db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE
 				ExportBatch

--- a/internal/revision/database/revision.go
+++ b/internal/revision/database/revision.go
@@ -88,7 +88,7 @@ func (rdb *RevisionDB) DestroyKey(ctx context.Context, keyID int64) error {
 	logger := logging.FromContext(ctx)
 	logger.Warnf("destroying key material for revision key ID %v", keyID)
 
-	if err := rdb.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	if err := rdb.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE
 				RevisionKeys

--- a/internal/verification/database/health_authority_db.go
+++ b/internal/verification/database/health_authority_db.go
@@ -54,7 +54,7 @@ func (db *HealthAuthorityDB) AddHealthAuthority(ctx context.Context, ha *model.H
 		return err
 	}
 
-	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
 			INSERT INTO
 				HealthAuthority
@@ -79,7 +79,7 @@ func (db *HealthAuthorityDB) UpdateHealthAuthority(ctx context.Context, ha *mode
 		return err
 	}
 
-	return db.db.SerializableTx(ctx, func(tx pgx.Tx) error {
+	return db.db.InTx(ctx, pgx.ReadCommitted, func(tx pgx.Tx) error {
 		result, err := tx.Exec(ctx, `
 			UPDATE HealthAuthority
 			SET


### PR DESCRIPTION
I audited all uses, and none of them should be serializable; ReadCommitted is more than fine. I also removed the helper to discourage accidental future use.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Drop usage of serializable transactions
```

/assign @mikehelmick 