### PR TITLE
Update data types and add more indicies

### DIFF
--- a/internal/jwks/jwks_test.go
+++ b/internal/jwks/jwks_test.go
@@ -197,7 +197,7 @@ func TestUpdateHA(t *testing.T) {
 			}
 			for _, key := range keys {
 				if err := haDB.AddHealthAuthorityKey(ctx, &test.ha, key); err != nil {
-					t.Fatalf("[%d] error adding key: %v", i, err)
+					t.Errorf("[%d] error adding key: %v", i, err)
 				}
 			}
 
@@ -216,7 +216,7 @@ func TestUpdateHA(t *testing.T) {
 				}
 				for j := range ha.Keys {
 					if key := ha.Keys[j].PublicKeyPEM; key != test.resKeys[j] {
-						t.Fatalf("[%d] wrong key[%d] %q, expected %q", i, j, key, test.resKeys[i])
+						t.Errorf("[%d] wrong key[%d] %q, expected %q", i, j, key, test.resKeys[j])
 					}
 				}
 
@@ -225,7 +225,7 @@ func TestUpdateHA(t *testing.T) {
 				var emptyTime time.Time
 				for _, j := range test.deadKeys {
 					if delTime := ha.Keys[j].From; reflect.DeepEqual(emptyTime, delTime) {
-						t.Fatalf("[%d:%d] key not deleted %v", i, j, delTime)
+						t.Errorf("[%d:%d] key not deleted %v", i, j, delTime)
 					}
 				}
 			}

--- a/internal/verification/database/health_authority_db.go
+++ b/internal/verification/database/health_authority_db.go
@@ -301,7 +301,7 @@ func (db *HealthAuthorityDB) GetHealthAuthorityKeys(ctx context.Context, ha *mod
 			WHERE
 				health_authority_id = $1
 			ORDER BY
-				health_authority_id, version
+				version
 		`, ha.ID)
 		if err != nil {
 			return fmt.Errorf("failed to list: %w", err)

--- a/internal/verification/database/health_authority_db.go
+++ b/internal/verification/database/health_authority_db.go
@@ -300,6 +300,8 @@ func (db *HealthAuthorityDB) GetHealthAuthorityKeys(ctx context.Context, ha *mod
 				HealthAuthorityKey
 			WHERE
 				health_authority_id = $1
+			ORDER BY
+				health_authority_id, version
 		`, ha.ID)
 		if err != nil {
 			return fmt.Errorf("failed to list: %w", err)

--- a/migrations/000057_AuthorizedAppTypes.down.sql
+++ b/migrations/000057_AuthorizedAppTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER TABLE AuthorizedApp ALTER COLUMN app_package_name TYPE VARCHAR(1000);
+ALTER TABLE AuthorizedApp ALTER COLUMN allowed_regions TYPE VARCHAR(5)[];
+ALTER TABLE AuthorizedApp ALTER COLUMN allowed_health_authority_ids TYPE INT[];
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+DROP INDEX IF EXISTS authorizedapp_allowed_regions;
+DROP INDEX IF EXISTS authorizedapp_allowed_health_authority_ids;
 
 END;

--- a/migrations/000057_AuthorizedAppTypes.up.sql
+++ b/migrations/000057_AuthorizedAppTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER TABLE AuthorizedApp ALTER COLUMN app_package_name TYPE TEXT;
+ALTER TABLE AuthorizedApp ALTER COLUMN allowed_regions TYPE TEXT[];
+ALTER TABLE AuthorizedApp ALTER COLUMN allowed_health_authority_ids TYPE BIGINT[];
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+CREATE INDEX authorizedapp_allowed_regions ON AuthorizedApp(allowed_regions);
+CREATE INDEX authorizedapp_allowed_health_authority_ids ON AuthorizedApp(allowed_health_authority_ids);
 
 END;

--- a/migrations/000058_ExportBatchTypes.down.sql
+++ b/migrations/000058_ExportBatchTypes.down.sql
@@ -1,0 +1,33 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER SEQUENCE exportconfig_batch_id_seq AS INT;
+ALTER TABLE ExportConfig ALTER batch_id TYPE INT;
+ALTER TABLE ExportBatch ALTER COLUMN config_id TYPE INT;
+ALTER TABLE ExportBatch ALTER COLUMN filename_root TYPE VARCHAR(100);
+ALTER TABLE ExportBatch ALTER COLUMN output_region TYPE VARCHAR(5);
+ALTER TABLE ExportBatch ALTER COLUMN bucket_name TYPE VARCHAR(64);
+ALTER TABLE ExportBatch ALTER COLUMN signature_info_ids TYPE INT[];
+ALTER TABLE ExportBatch ALTER COLUMN input_regions TYPE VARCHAR(5)[];
+ALTER TABLE ExportBatch ALTER COLUMN exclude_regions TYPE VARCHAR(5)[];
+ALTER TABLE ExportBatch ALTER COLUMN max_records_override TYPE INT;
+
+DROP INDEX IF EXISTS exportbatch_config_id;
+DROP INDEX IF EXISTS exportbatch_status;
+DROP INDEX IF EXISTS exportbatch_start_timestamp;
+DROP INDEX IF EXISTS exportbatch_end_timestamp;
+
+END;

--- a/migrations/000058_ExportBatchTypes.up.sql
+++ b/migrations/000058_ExportBatchTypes.up.sql
@@ -1,0 +1,33 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER SEQUENCE exportbatch_batch_id_seq AS BIGINT;
+ALTER TABLE ExportBatch ALTER batch_id TYPE BIGINT;
+ALTER TABLE ExportBatch ALTER COLUMN config_id TYPE BIGINT;
+ALTER TABLE ExportBatch ALTER COLUMN filename_root TYPE TEXT;
+ALTER TABLE ExportBatch ALTER COLUMN output_region TYPE TEXT;
+ALTER TABLE ExportBatch ALTER COLUMN bucket_name TYPE TEXT;
+ALTER TABLE ExportBatch ALTER COLUMN signature_info_ids TYPE BIGINT[];
+ALTER TABLE ExportBatch ALTER COLUMN input_regions TYPE TEXT[];
+ALTER TABLE ExportBatch ALTER COLUMN exclude_regions TYPE TEXT[];
+ALTER TABLE ExportBatch ALTER COLUMN max_records_override TYPE BIGINT;
+
+CREATE INDEX exportbatch_config_id ON ExportBatch(config_id);
+CREATE INDEX exportbatch_status ON ExportBatch(status);
+CREATE INDEX exportbatch_start_timestamp ON ExportBatch(start_timestamp);
+CREATE INDEX exportbatch_end_timestamp ON ExportBatch(end_timestamp);
+
+END;

--- a/migrations/000059_ExportConfigTypes.down.sql
+++ b/migrations/000059_ExportConfigTypes.down.sql
@@ -1,0 +1,39 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+CREATE INDEX uidx_bucket_name_filename_root ON exportconfig(LOWER(bucket_name), LOWER(filename_root));
+
+ALTER SEQUENCE exportconfig_config_id_seq AS INT;
+ALTER TABLE ExportConfig ALTER config_id TYPE INT;
+ALTER TABLE ExportConfig ALTER filename_root TYPE VARCHAR(100);
+ALTER TABLE ExportConfig ALTER period_seconds TYPE INT;
+ALTER TABLE ExportConfig ALTER output_region TYPE VARCHAR(5);
+ALTER TABLE ExportConfig ALTER bucket_name TYPE VARCHAR(64);
+ALTER TABLE ExportConfig ALTER signature_info_ids TYPE INT[];
+ALTER TABLE ExportConfig ALTER input_regions TYPE VARCHAR(5)[];
+ALTER TABLE ExportConfig ALTER exclude_regions TYPE VARCHAR(5)[];
+ALTER TABLE ExportConfig ALTER max_records_override TYPE INT;
+
+DROP INDEX IF EXISTS exportconfig_filename_root ON ExportConfig(filename_root);
+DROP INDEX IF EXISTS exportconfig_from_timestamp ON ExportConfig(from_timestamp);
+DROP INDEX IF EXISTS exportconfig_thru_timestamp ON ExportConfig(thru_timestamp);
+DROP INDEX IF EXISTS exportconfig_bucket_name ON ExportConfig(bucket_name);
+DROP INDEX IF EXISTS exportconfig_signature_info_ids ON ExportConfig(signature_info_ids);
+DROP INDEX IF EXISTS exportconfig_bucket_name_filename_root ON ExportConfig(filename_root, bucket_name);
+DROP INDEX IF EXISTS exportconfig_include_travelers ON ExportConfig(include_travelers);
+DROP INDEX IF EXISTS exportconfig_only_non_travelers ON ExportConfig(only_non_travelers);
+
+END;

--- a/migrations/000059_ExportConfigTypes.up.sql
+++ b/migrations/000059_ExportConfigTypes.up.sql
@@ -1,0 +1,39 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER SEQUENCE exportconfig_config_id_seq AS BIGINT;
+ALTER TABLE ExportConfig ALTER config_id TYPE BIGINT;
+ALTER TABLE ExportConfig ALTER filename_root TYPE TEXT;
+ALTER TABLE ExportConfig ALTER period_seconds TYPE BIGINT;
+ALTER TABLE ExportConfig ALTER output_region TYPE TEXT;
+ALTER TABLE ExportConfig ALTER bucket_name TYPE TEXT;
+ALTER TABLE ExportConfig ALTER signature_info_ids TYPE BIGINT[];
+ALTER TABLE ExportConfig ALTER input_regions TYPE TEXT[];
+ALTER TABLE ExportConfig ALTER exclude_regions TYPE TEXT[];
+ALTER TABLE ExportConfig ALTER max_records_override TYPE BIGINT;
+
+CREATE INDEX exportconfig_filename_root ON ExportConfig(filename_root);
+CREATE INDEX exportconfig_from_timestamp ON ExportConfig(from_timestamp);
+CREATE INDEX exportconfig_thru_timestamp ON ExportConfig(thru_timestamp);
+CREATE INDEX exportconfig_bucket_name ON ExportConfig(bucket_name);
+CREATE INDEX exportconfig_signature_info_ids ON ExportConfig(signature_info_ids);
+CREATE UNIQUE INDEX exportconfig_bucket_name_filename_root ON ExportConfig(LOWER(filename_root), LOWER(bucket_name));
+CREATE INDEX exportconfig_include_travelers ON ExportConfig(include_travelers);
+CREATE INDEX exportconfig_only_non_travelers ON ExportConfig(only_non_travelers);
+
+DROP INDEX IF EXISTS uidx_bucket_name_filename_root;
+
+END;

--- a/migrations/000060_ExportFileTypes.down.sql
+++ b/migrations/000060_ExportFileTypes.down.sql
@@ -1,0 +1,33 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE ExportFile ALTER filename TYPE VARCHAR(100);
+ALTER TABLE ExportFile ALTER batch_id TYPE INT;
+ALTER TABLE ExportFile ALTER output_region TYPE VARCHAR(5);
+ALTER TABLE ExportFile ALTER batch_num TYPE INT;
+ALTER TABLE ExportFile ALTER batch_size TYPE INT;
+ALTER TABLE ExportFile ALTER status TYPE VARCHAR(10);
+ALTER TABLE ExportFile ALTER bucket_name TYPE VARCHAR(64);
+ALTER TABLE ExportFile ALTER input_regions TYPE VARCHAR(5)[];
+ALTER TABLE ExportFile ALTER exclude_regions TYPE VARCHAR(5)[];
+
+DROP INDEX IF EXISTS exportfile_batch_id;
+DROP INDEX IF EXISTS exportfile_status;
+DROP INDEX IF EXISTS exportfile_bucket_name;
+DROP INDEX IF EXISTS exportfile_include_travelers;
+DROP INDEX IF EXISTS exportfile_only_non_travelers;
+
+END;

--- a/migrations/000060_ExportFileTypes.up.sql
+++ b/migrations/000060_ExportFileTypes.up.sql
@@ -1,0 +1,33 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE ExportFile ALTER filename TYPE TEXT;
+ALTER TABLE ExportFile ALTER batch_id TYPE BIGINT;
+ALTER TABLE ExportFile ALTER output_region TYPE TEXT;
+ALTER TABLE ExportFile ALTER batch_num TYPE BIGINT;
+ALTER TABLE ExportFile ALTER batch_size TYPE BIGINT;
+ALTER TABLE ExportFile ALTER status TYPE TEXT;
+ALTER TABLE ExportFile ALTER bucket_name TYPE TEXT;
+ALTER TABLE ExportFile ALTER input_regions TYPE TEXT[];
+ALTER TABLE ExportFile ALTER exclude_regions TYPE TEXT[];
+
+CREATE INDEX exportfile_batch_id ON ExportFile(batch_id);
+CREATE INDEX exportfile_status ON ExportFile(status);
+CREATE INDEX exportfile_bucket_name ON ExportFile(bucket_name);
+CREATE INDEX exportfile_include_travelers ON ExportFile(include_travelers);
+CREATE INDEX exportfile_only_non_travelers ON ExportFile(only_non_travelers);
+
+END;

--- a/migrations/000061_ExportImportTypes.down.sql
+++ b/migrations/000061_ExportImportTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,16 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER SEQUENCE exportimport_id_seq AS INT;
+ALTER TABLE ExportImport ALTER id TYPE INT;
+ALTER TABLE ExportImport ALTER index_file TYPE VARCHAR(500);
+ALTER TABLE ExportImport ALTER export_root TYPE VARCHAR(500);
+ALTER TABLE ExportImport ALTER region TYPE VARCHAR(5);
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+CREATE INDEX export_import_from_timestamp ON ExportImport(from_timestamp) USING BRIN;
+CREATE INDEX export_import_thru_timestamp ON ExportImport(thru_timestamp) USING BRIN;
 
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+DROP INDEX IF EXISTS exportimport_from_timestamp;
+DROP INDEX IF EXISTS exportimport_thru_timestamp;
 
 END;

--- a/migrations/000061_ExportImportTypes.up.sql
+++ b/migrations/000061_ExportImportTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,16 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER SEQUENCE exportimport_id_seq AS BIGINT;
+ALTER TABLE ExportImport ALTER id TYPE BIGINT;
+ALTER TABLE ExportImport ALTER index_file TYPE TEXT;
+ALTER TABLE ExportImport ALTER export_root TYPE TEXT;
+ALTER TABLE ExportImport ALTER region TYPE TEXT;
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+CREATE INDEX exportimport_from_timestamp ON ExportImport(from_timestamp);
+CREATE INDEX exportimport_thru_timestamp ON ExportImport(thru_timestamp);
 
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+DROP INDEX IF EXISTS export_import_from_timestamp;
+DROP INDEX IF EXISTS export_import_thru_timestamp;
 
 END;

--- a/migrations/000062_ExposureTypes.down.sql
+++ b/migrations/000062_ExposureTypes.down.sql
@@ -36,12 +36,9 @@ CREATE INDEX exposure_revised_at_idx ON Exposure(revised_at) USING BRIN;
 
 ALTER INDEX exposure_pkey RENAME TO infection_pkey;
 
-DROP INDEX IF EXISTS exposure_app_package_name;
 DROP INDEX IF EXISTS exposure_regions;
 DROP INDEX IF EXISTS exposure_created_at;
 DROP INDEX IF EXISTS exposure_local_provenance;
-DROP INDEX IF EXISTS exposure_sync_id;
-DROP INDEX IF EXISTS exposure_health_authority_id;
 DROP INDEX IF EXISTS exposure_revised_at;
 DROP INDEX IF EXISTS exposure_traveler;
 DROP INDEX IF EXISTS exposure_sync_query_id;

--- a/migrations/000062_ExposureTypes.down.sql
+++ b/migrations/000062_ExposureTypes.down.sql
@@ -1,0 +1,52 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE Exposure ALTER exposure_key TYPE VARCHAR(30);
+ALTER TABLE Exposure ALTER app_package_name TYPE VARCHAR(100);
+ALTER TABLE Exposure ALTER transmission_risk TYPE INT;
+ALTER TABLE Exposure ALTER regions TYPE VARCHAR(5)[];
+ALTER TABLE Exposure ALTER interval_number TYPE INT;
+ALTER TABLE Exposure ALTER interval_count TYPE INT;
+ALTER TABLE Exposure ALTER sync_id TYPE INT;
+ALTER TABLE Exposure ALTER health_authority_id TYPE INT;
+ALTER TABLE Exposure ALTER report_type TYPE VARCHAR(20);
+ALTER TABLE Exposure ALTER days_since_symptom_onset TYPE INT;
+ALTER TABLE Exposure ALTER revised_report_type TYPE VARCHAR(20);
+ALTER TABLE Exposure ALTER revised_days_since_symptom_onset TYPE INT;
+ALTER TABLE Exposure ALTER sync_query_id TYPE VARCHAR(50);
+ALTER TABLE Exposure ALTER export_import_id TYPE INT;
+ALTER TABLE Exposure ALTER import_file_id TYPE INT;
+ALTER TABLE Exposure ALTER revised_import_file_id TYPE INT;
+
+CREATE INDEX exposure_created_at_idx ON Exposure(created_at) USING BRIN;
+CREATE INDEX exposure_revised_at_idx ON Exposure(revised_at) USING BRIN;
+
+ALTER INDEX exposure_pkey RENAME TO infection_pkey;
+
+DROP INDEX IF EXISTS exposure_app_package_name;
+DROP INDEX IF EXISTS exposure_regions;
+DROP INDEX IF EXISTS exposure_created_at;
+DROP INDEX IF EXISTS exposure_local_provenance;
+DROP INDEX IF EXISTS exposure_sync_id;
+DROP INDEX IF EXISTS exposure_health_authority_id;
+DROP INDEX IF EXISTS exposure_revised_at;
+DROP INDEX IF EXISTS exposure_traveler;
+DROP INDEX IF EXISTS exposure_sync_query_id;
+DROP INDEX IF EXISTS exposure_export_import_id;
+DROP INDEX IF EXISTS exposure_import_file_id;
+DROP INDEX IF EXISTS exposure_revised_import_file_id;
+
+END;

--- a/migrations/000062_ExposureTypes.up.sql
+++ b/migrations/000062_ExposureTypes.up.sql
@@ -33,12 +33,9 @@ ALTER TABLE Exposure ALTER revised_import_file_id TYPE BIGINT;
 
 ALTER INDEX infection_pkey RENAME TO exposure_pkey;
 
-CREATE INDEX exposure_app_package_name ON Exposure(app_package_name);
 CREATE INDEX exposure_regions ON Exposure(regions);
 CREATE INDEX exposure_created_at ON Exposure(created_at);
 CREATE INDEX exposure_local_provenance ON Exposure(local_provenance);
-CREATE INDEX exposure_sync_id ON Exposure(sync_id);
-CREATE INDEX exposure_health_authority_id ON Exposure(health_authority_id);
 CREATE INDEX exposure_revised_at ON Exposure(revised_at);
 CREATE INDEX exposure_traveler ON Exposure(traveler);
 CREATE INDEX exposure_sync_query_id ON Exposure(sync_query_id);

--- a/migrations/000062_ExposureTypes.up.sql
+++ b/migrations/000062_ExposureTypes.up.sql
@@ -1,0 +1,52 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE Exposure ALTER exposure_key TYPE TEXT;
+ALTER TABLE Exposure ALTER app_package_name TYPE TEXT;
+ALTER TABLE Exposure ALTER transmission_risk TYPE BIGINT;
+ALTER TABLE Exposure ALTER regions TYPE TEXT[];
+ALTER TABLE Exposure ALTER interval_number TYPE BIGINT;
+ALTER TABLE Exposure ALTER interval_count TYPE BIGINT;
+ALTER TABLE Exposure ALTER sync_id TYPE BIGINT;
+ALTER TABLE Exposure ALTER health_authority_id TYPE BIGINT;
+ALTER TABLE Exposure ALTER report_type TYPE TEXT;
+ALTER TABLE Exposure ALTER days_since_symptom_onset TYPE BIGINT;
+ALTER TABLE Exposure ALTER revised_report_type TYPE TEXT;
+ALTER TABLE Exposure ALTER revised_days_since_symptom_onset TYPE BIGINT;
+ALTER TABLE Exposure ALTER sync_query_id TYPE TEXT;
+ALTER TABLE Exposure ALTER export_import_id TYPE BIGINT;
+ALTER TABLE Exposure ALTER import_file_id TYPE BIGINT;
+ALTER TABLE Exposure ALTER revised_import_file_id TYPE BIGINT;
+
+ALTER INDEX infection_pkey RENAME TO exposure_pkey;
+
+CREATE INDEX exposure_app_package_name ON Exposure(app_package_name);
+CREATE INDEX exposure_regions ON Exposure(regions);
+CREATE INDEX exposure_created_at ON Exposure(created_at);
+CREATE INDEX exposure_local_provenance ON Exposure(local_provenance);
+CREATE INDEX exposure_sync_id ON Exposure(sync_id);
+CREATE INDEX exposure_health_authority_id ON Exposure(health_authority_id);
+CREATE INDEX exposure_revised_at ON Exposure(revised_at);
+CREATE INDEX exposure_traveler ON Exposure(traveler);
+CREATE INDEX exposure_sync_query_id ON Exposure(sync_query_id);
+CREATE INDEX exposure_export_import_id ON Exposure(export_import_id);
+CREATE INDEX exposure_import_file_id ON Exposure(import_file_id);
+CREATE INDEX exposure_revised_import_file_id ON Exposure(revised_import_file_id);
+
+DROP INDEX IF EXISTS exposure_created_at_idx;
+DROP INDEX IF EXISTS exposure_revised_at_idx;
+
+END;

--- a/migrations/000063_FederationInQueryTypes.down.sql
+++ b/migrations/000063_FederationInQueryTypes.down.sql
@@ -1,0 +1,32 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE FederationInQuery ALTER query_id TYPE VARCHAR(50);
+ALTER TABLE FederationInQuery ALTER server_addr TYPE VARCHAR(100);
+ALTER TABLE FederationInQuery ALTER include_regions TYPE VARCHAR(5)[];
+ALTER TABLE FederationInQuery ALTER exclude_regions TYPE VARCHAR(5)[];
+ALTER TABLE FederationInQuery ALTER oidc_audience TYPE VARCHAR(1000);
+ALTER TABLE FederationInQuery ALTER primary_cursor TYPE VARCHAR(100);
+ALTER TABLE FederationInQuery ALTER revised_cursor TYPE VARCHAR(100);
+
+DROP INDEX IF EXISTS federationinquery_last_timestamp;
+DROP INDEX IF EXISTS federationinquery_only_local_provenance;
+DROP INDEX IF EXISTS federationinquery_only_travelers;
+DROP INDEX IF EXISTS federationinquery_last_revised_timestamp;
+DROP INDEX IF EXISTS federationinquery_primary_cursor;
+DROP INDEX IF EXISTS federationinquery_revised_cursor;
+
+END;

--- a/migrations/000063_FederationInQueryTypes.up.sql
+++ b/migrations/000063_FederationInQueryTypes.up.sql
@@ -1,0 +1,32 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE FederationInQuery ALTER query_id TYPE TEXT;
+ALTER TABLE FederationInQuery ALTER server_addr TYPE TEXT;
+ALTER TABLE FederationInQuery ALTER include_regions TYPE TEXT[];
+ALTER TABLE FederationInQuery ALTER exclude_regions TYPE TEXT[];
+ALTER TABLE FederationInQuery ALTER oidc_audience TYPE TEXT;
+ALTER TABLE FederationInQuery ALTER primary_cursor TYPE TEXT;
+ALTER TABLE FederationInQuery ALTER revised_cursor TYPE TEXT;
+
+CREATE INDEX federationinquery_last_timestamp ON FederationInQuery(last_timestamp);
+CREATE INDEX federationinquery_only_local_provenance ON FederationInQuery(only_local_provenance);
+CREATE INDEX federationinquery_only_travelers ON FederationInQuery(only_travelers);
+CREATE INDEX federationinquery_last_revised_timestamp ON FederationInQuery(last_revised_timestamp);
+CREATE INDEX federationinquery_primary_cursor ON FederationInQuery(primary_cursor);
+CREATE INDEX federationinquery_revised_cursor ON FederationInQuery(revised_cursor);
+
+END;

--- a/migrations/000064_FederationInSyncTypes.down.sql
+++ b/migrations/000064_FederationInSyncTypes.down.sql
@@ -1,0 +1,29 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER SEQUENCE federationinsync_sync_id_seq RENAME TO federationsync_sync_id_seq;
+ALTER SEQUENCE federationsync_sync_id_seq AS INT;
+ALTER TABLE FederationInSync ALTER sync_id TYPE INT;
+ALTER TABLE FederationInSync ALTER query_id TYPE VARCHAR(50);
+ALTER TABLE FederationInSync ALTER insertions TYPE INT;
+
+DROP INDEX IF EXISTS federationinsync_query_id;
+DROP INDEX IF EXISTS federationinsync_started;
+DROP INDEX IF EXISTS federationinsync_completed;
+DROP INDEX IF EXISTS federationinsync_max_timestamp;
+DROP INDEX IF EXISTS federationinsync_max_revised_timestamp;
+
+END;

--- a/migrations/000064_FederationInSyncTypes.up.sql
+++ b/migrations/000064_FederationInSyncTypes.up.sql
@@ -1,0 +1,29 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER SEQUENCE federationsync_sync_id_seq RENAME TO federationinsync_sync_id_seq;
+ALTER SEQUENCE federationinsync_sync_id_seq AS BIGINT;
+ALTER TABLE FederationInSync ALTER sync_id TYPE BIGINT;
+ALTER TABLE FederationInSync ALTER query_id TYPE TEXT;
+ALTER TABLE FederationInSync ALTER insertions TYPE BIGINT;
+
+CREATE INDEX federationinsync_query_id ON FederationInSync(query_id);
+CREATE INDEX federationinsync_started ON FederationInSync(started);
+CREATE INDEX federationinsync_completed ON FederationInSync(completed);
+CREATE INDEX federationinsync_max_timestamp ON FederationInSync(max_timestamp);
+CREATE INDEX federationinsync_max_revised_timestamp ON FederationInSync(max_revised_timestamp);
+
+END;

--- a/migrations/000065_FederationOutAuthorizationTypes.down.sql
+++ b/migrations/000065_FederationOutAuthorizationTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER TABLE FederationOutAuthorization ALTER oidc_issuer TYPE VARCHAR(1000);
+ALTER TABLE FederationOutAuthorization ALTER oidc_subject TYPE VARCHAR(1000);
+ALTER TABLE FederationOutAuthorization ALTER oidc_audience TYPE VARCHAR(1000);
+ALTER TABLE FederationOutAuthorization ALTER note TYPE VARCHAR(100);
+ALTER TABLE FederationOutAuthorization ALTER include_regions TYPE VARCHAR(5)[];
+ALTER TABLE FederationOutAuthorization ALTER exclude_regions TYPE VARCHAR(5)[];
 
 END;

--- a/migrations/000065_FederationOutAuthorizationTypes.up.sql
+++ b/migrations/000065_FederationOutAuthorizationTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER TABLE FederationOutAuthorization ALTER oidc_issuer TYPE TEXT;
+ALTER TABLE FederationOutAuthorization ALTER oidc_subject TYPE TEXT;
+ALTER TABLE FederationOutAuthorization ALTER oidc_audience TYPE TEXT;
+ALTER TABLE FederationOutAuthorization ALTER note TYPE TEXT;
+ALTER TABLE FederationOutAuthorization ALTER include_regions TYPE TEXT[];
+ALTER TABLE FederationOutAuthorization ALTER exclude_regions TYPE TEXT[];
 
 END;

--- a/migrations/000066_HealthAuthorityTypes.down.sql
+++ b/migrations/000066_HealthAuthorityTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,12 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER SEQUENCE healthauthority_id_seq AS INT;
+ALTER TABLE HealthAuthority ALTER id TYPE INT;
+ALTER TABLE HealthAuthority ALTER iss TYPE VARCHAR(200);
+ALTER TABLE HealthAuthority ALTER aud TYPE VARCHAR(200);
+ALTER TABLE HealthAuthority ALTER name TYPE VARCHAR(200);
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER INDEX healthauthority_iss RENAME TO uniqueiss;
 
 END;

--- a/migrations/000066_HealthAuthorityTypes.up.sql
+++ b/migrations/000066_HealthAuthorityTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,12 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER SEQUENCE healthauthority_id_seq AS BIGINT;
+ALTER TABLE HealthAuthority ALTER id TYPE BIGINT;
+ALTER TABLE HealthAuthority ALTER iss TYPE TEXT;
+ALTER TABLE HealthAuthority ALTER aud TYPE TEXT;
+ALTER TABLE HealthAuthority ALTER name TYPE TEXT;
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER INDEX uniqueiss RENAME TO healthauthority_iss;
 
 END;

--- a/migrations/000067_HealthAuthorityKeyTypes.down.sql
+++ b/migrations/000067_HealthAuthorityKeyTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER TABLE HealthAuthorityKey ALTER health_authority_id TYPE INT;
+ALTER TABLE HealthAuthorityKey ALTER version TYPE VARCHAR(100);
+ALTER TABLE HealthAuthorityKey ALTER public_key TYPE VARCHAR(500);
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+DROP INDEX IF EXISTS healthauthoritykey_from_timestamp;
+DROP INDEX IF EXISTS healthauthoritykey_thru_timestamp;
 
 END;

--- a/migrations/000067_HealthAuthorityKeyTypes.up.sql
+++ b/migrations/000067_HealthAuthorityKeyTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,11 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER TABLE HealthAuthorityKey ALTER health_authority_id TYPE BIGINT;
+ALTER TABLE HealthAuthorityKey ALTER version TYPE TEXT;
+ALTER TABLE HealthAuthorityKey ALTER public_key TYPE TEXT;
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+CREATE INDEX healthauthoritykey_from_timestamp ON HealthAuthorityKey(from_timestamp);
+CREATE INDEX healthauthoritykey_thru_timestamp ON HealthAuthorityKey(thru_timestamp);
 
 END;

--- a/migrations/000068_HealthAuthorityStatsTypes.down.sql
+++ b/migrations/000068_HealthAuthorityStatsTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,6 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER TABLE HealthAuthorityStats ALTER health_authority_id TYPE INT;
 
 END;

--- a/migrations/000068_HealthAuthorityStatsTypes.up.sql
+++ b/migrations/000068_HealthAuthorityStatsTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,6 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER TABLE HealthAuthorityStats ALTER health_authority_id TYPE BIGINT;
 
 END;

--- a/migrations/000069_ImportFileTypes.down.sql
+++ b/migrations/000069_ImportFileTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER SEQUENCE importfile_id_seq AS INT;
+ALTER TABLE ImportFile ALTER id TYPE INT;
+ALTER TABLE ImportFile ALTER export_import_id TYPE INT;
+ALTER TABLE ImportFile ALTER zip_filename TYPE VARCHAR(500);
+ALTER TABLE ImportFile ALTER retries TYPE INT;
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+DROP INDEX IF EXISTS importfile_discovered_at;
+DROP INDEX IF EXISTS importfile_status;
 
 END;

--- a/migrations/000069_ImportFileTypes.up.sql
+++ b/migrations/000069_ImportFileTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER SEQUENCE importfile_id_seq AS BIGINT;
+ALTER TABLE ImportFile ALTER id TYPE BIGINT;
+ALTER TABLE ImportFile ALTER export_import_id TYPE BIGINT;
+ALTER TABLE ImportFile ALTER zip_filename TYPE TEXT;
+ALTER TABLE ImportFile ALTER retries TYPE BIGINT;
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+CREATE INDEX importfile_discovered_at ON ImportFile(discovered_at);
+CREATE INDEX importfile_status ON ImportFile(status);
 
 END;

--- a/migrations/000070_ImportFilePublicKeyTypes.down.sql
+++ b/migrations/000070_ImportFilePublicKeyTypes.down.sql
@@ -1,0 +1,28 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE ImportFilePublicKey ALTER export_import_id TYPE INT;
+ALTER TABLE ImportFilePublicKey ALTER key_id TYPE VARCHAR(50);
+ALTER TABLE ImportFilePublicKey ALTER key_version TYPE VARCHAR(50);
+ALTER TABLE ImportFilePublicKey ALTER public_key TYPE VARCHAR(500);
+
+CREATE INDEX import_file_public_key_from ON ImportFilePublicKey(from_timestamp) USING BRIN;
+CREATE INDEX import_file_public_key_thru ON ImportFilePublicKey(thru_timestamp) USING BRIN;
+
+DROP INDEX IF EXISTS importfilepublickey_from_timestamp;
+DROP INDEX IF EXISTS importfilepublickey_thru_timestamp;
+
+END;

--- a/migrations/000070_ImportFilePublicKeyTypes.up.sql
+++ b/migrations/000070_ImportFilePublicKeyTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,15 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER TABLE ImportFilePublicKey ALTER export_import_id TYPE BIGINT;
+ALTER TABLE ImportFilePublicKey ALTER key_id TYPE TEXT;
+ALTER TABLE ImportFilePublicKey ALTER key_version TYPE TEXT;
+ALTER TABLE ImportFilePublicKey ALTER public_key TYPE TEXT;
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+CREATE INDEX importfilepublickey_from_timestamp ON ImportFilePublicKey(from_timestamp);
+CREATE INDEX importfilepublickey_thru_timestamp ON ImportFilePublicKey(thru_timestamp);
 
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+DROP INDEX import_file_public_key_from;
+DROP INDEX import_file_public_key_thru;
 
 END;

--- a/migrations/000071_LockTypes.down.sql
+++ b/migrations/000071_LockTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,6 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER TABLE Lock ALTER lock_id TYPE VARCHAR(100);
 
 END;

--- a/migrations/000071_LockTypes.up.sql
+++ b/migrations/000071_LockTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,6 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER TABLE Lock ALTER lock_id TYPE TEXT;
 
 END;

--- a/migrations/000072_MirrorTypes.down.sql
+++ b/migrations/000072_MirrorTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,12 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER SEQUENCE mirror_id_seq AS INT;
+ALTER TABLE Mirror ALTER id TYPE INT;
+ALTER TABLE Mirror ALTER index_file TYPE VARCHAR(500);
+ALTER TABLE Mirror ALTER export_root TYPE VARCHAR(500);
+ALTER TABLE Mirror ALTER cloud_storage_bucket TYPE VARCHAR(200);
+ALTER TABLE Mirror ALTER filename_root TYPE VARCHAR(500);
+ALTER TABLE Mirror ALTER filename_rewrite TYPE VARCHAR(500);
 
 END;

--- a/migrations/000072_MirrorTypes.up.sql
+++ b/migrations/000072_MirrorTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,12 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER SEQUENCE mirror_id_seq AS BIGINT;
+ALTER TABLE Mirror ALTER id TYPE BIGINT;
+ALTER TABLE Mirror ALTER index_file TYPE TEXT;
+ALTER TABLE Mirror ALTER export_root TYPE TEXT;
+ALTER TABLE Mirror ALTER cloud_storage_bucket TYPE TEXT;
+ALTER TABLE Mirror ALTER filename_root TYPE TEXT;
+ALTER TABLE Mirror ALTER filename_rewrite TYPE TEXT;
 
 END;

--- a/migrations/000073_MirrorFileTypes.down.sql
+++ b/migrations/000073_MirrorFileTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,8 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER TABLE MirrorFile ALTER mirror_id TYPE INT;
+ALTER TABLE MirrorFile ALTER filename TYPE VARCHAR(200);
+ALTER TABLE MirrorFile ALTER local_filename TYPE VARCHAR(200);
 
 END;

--- a/migrations/000073_MirrorFileTypes.up.sql
+++ b/migrations/000073_MirrorFileTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,8 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER TABLE MirrorFile ALTER mirror_id TYPE BIGINT;
+ALTER TABLE MirrorFile ALTER filename TYPE TEXT;
+ALTER TABLE MirrorFile ALTER local_filename TYPE TEXT;
 
 END;

--- a/migrations/000074_RevisionKeysTypes.down.sql
+++ b/migrations/000074_RevisionKeysTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,7 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER SEQUENCE revisionkeys_kid_seq AS INT;
+ALTER TABLE RevisionKeys ALTER kid TYPE INT;
 
 END;

--- a/migrations/000074_RevisionKeysTypes.up.sql
+++ b/migrations/000074_RevisionKeysTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,7 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+ALTER SEQUENCE revisionkeys_kid_seq AS BIGINT;
+ALTER TABLE RevisionKeys ALTER kid TYPE BIGINT;
 
 END;

--- a/migrations/000075_SignatureInfoTypes.down.sql
+++ b/migrations/000075_SignatureInfoTypes.down.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,12 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER SEQUENCE signatureinfo_id_seq AS INT;
+ALTER TABLE SignatureInfo ALTER id TYPE INT;
+ALTER TABLE SignatureInfo ALTER signing_key TYPE VARCHAR(500);
+ALTER TABLE SignatureInfo ALTER signing_key_version TYPE VARCHAR(100);
+ALTER TABLE SignatureInfo ALTER signing_key_id TYPE VARCHAR(50);
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+DROP INDEX IF EXISTS signatureinfo_thru_timestamp;
 
 END;

--- a/migrations/000075_SignatureInfoTypes.up.sql
+++ b/migrations/000075_SignatureInfoTypes.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2020 Google LLC
+-- Copyright 2021 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -14,15 +14,15 @@
 
 BEGIN;
 
-UPDATE AuthorizedApp SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
+ALTER SEQUENCE signatureinfo_id_seq AS BIGINT;
+ALTER TABLE SignatureInfo ALTER id TYPE BIGINT;
+ALTER TABLE SignatureInfo ALTER signing_key TYPE TEXT;
+ALTER TABLE SignatureInfo ALTER signing_key SET DEFAULT '';
+ALTER TABLE SignatureInfo ALTER signing_key_version TYPE TEXT;
+ALTER TABLE SignatureInfo ALTER signing_key_version SET DEFAULT '';
+ALTER TABLE SignatureInfo ALTER signing_key_id TYPE TEXT;
+ALTER TABLE SignatureInfo ALTER signing_key_id SET DEFAULT '';
 
-UPDATE Exposure SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-
-UPDATE SignatureInfo SET app_package_name = LOWER(app_package_name)
-  WHERE app_package_name IS NOT NULL;
-UPDATE SignatureInfo SET bundle_id = LOWER(bundle_id)
-  WHERE bundle_id IS NOT NULL;
+CREATE INDEX signatureinfo_thru_timestamp ON SignatureInfo(thru_timestamp);
 
 END;


### PR DESCRIPTION
This updates all text data types from `VARCHAR(n)` to `TEXT`, which is actually more efficient and safer, since `VARCHAR(n)` silently truncates at `n` (it does not throw an error).

Similarly, this upgrades all integer types to BIGINT. There's no performance difference between INT and BIGINT.

Finally, this adds a bunch of missing indices, which will hopefully improve performance. The BRIN indices are also dropped in favor of GIN (default). I'm not sure why we chose BRIN, but it's not the best for timestamps.

Finally finally, I kept getting some flakes with the jwks service. It turns out that health authority keys were returned in non-deterministic ordering. I added an explicit ORDER BY clause to make it deterministic.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Update database types to their larger values (VARCHAR -> TEXT and INT -> BIGINT) and add indices to common fields to improve performance.
```

/assign @mikehelmick 