### PR TITLE
Move DEBUG SERVER message to warning level

### DIFF
--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -563,7 +563,7 @@ type TransformPublishResult struct {
 func (t *Transformer) TransformPublish(ctx context.Context, inData *verifyapi.Publish, regions []string, claims *verification.VerifiedClaims, batchTime time.Time) (*TransformPublishResult, error) {
 	logger := logging.FromContext(ctx)
 	if t.debugReleaseSameDay {
-		logger.Errorf("DEBUG SERVER - Current day keys are not being embargoed.")
+		logger.Warnw("DEBUG SERVER - current day keys are not being embargoed!")
 	}
 
 	// Validate the number of keys that want to be published.


### PR DESCRIPTION
This message will appear on each instance start/scale. It's very difficult to find real errors in the logs. Furthermore, semantically, this is a warning.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Move DEBUG SERVER message to warning level
```