### PR TITLE
Only log internal errors on publish, move others to debug level

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -388,8 +388,9 @@ func (h *PublishHandler) process(ctx context.Context, data *verifyapi.Publish, p
 			errorMessage = http.StatusText(http.StatusInternalServerError)
 			errorCode = verifyapi.ErrorInternalError
 			metric = "publish-db-write-error"
+			logger.Errorw("publish error", "error", logMessage)
 		}
-		logger.Error(logMessage)
+		logger.Debugw("publish error", "error", logMessage)
 		span.SetStatus(trace.Status{Code: trace.StatusCodeInternal, Message: logMessage})
 		return &response{
 			status: status,


### PR DESCRIPTION
There's a lot of "errors" in our logs that are actually user error (e.g. invalid report transition type). This moves user errors to debug level and only logs internal server errors.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Only log internal errors on publish, move others to debug level
```