### PR TITLE
Recover from panics in main

### DIFF
--- a/cmd/admin-console/main.go
+++ b/cmd/admin-console/main.go
@@ -35,12 +35,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/cleanup-export/main.go
+++ b/cmd/cleanup-export/main.go
@@ -37,12 +37,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/cleanup-exposure/main.go
+++ b/cmd/cleanup-exposure/main.go
@@ -37,12 +37,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -35,12 +35,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/export-importer/main.go
+++ b/cmd/export-importer/main.go
@@ -35,12 +35,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -36,12 +36,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -40,13 +40,22 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
+
 func realMain(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 

--- a/cmd/federationin/main.go
+++ b/cmd/federationin/main.go
@@ -38,13 +38,22 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
+
 func realMain(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 

--- a/cmd/federationout/main.go
+++ b/cmd/federationout/main.go
@@ -42,12 +42,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -38,12 +38,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/jwks/main.go
+++ b/cmd/jwks/main.go
@@ -36,12 +36,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/key-rotation/main.go
+++ b/cmd/key-rotation/main.go
@@ -36,12 +36,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -46,12 +46,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		log.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {

--- a/cmd/mirror/main.go
+++ b/cmd/mirror/main.go
@@ -35,12 +35,20 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 
 	if err != nil {
 		logger.Fatal(err)
 	}
+	logger.Info("successful shutdown")
 }
 
 func realMain(ctx context.Context) error {


### PR DESCRIPTION
This may not be happening, but we have some sparse 500s in logs with no associated application log.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add logic to recover from panics in service entrypoints. A panic will still terminate the service with a non-zero exit code, but it will cleanup existing connections and log the panic before doing so.
```