### PR TITLE
Pull logger and request_id from context in jwks service

### DIFF
--- a/internal/jwks/handle_update_all.go
+++ b/internal/jwks/handle_update_all.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jwks
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+)
+
+func (s *Server) handleUpdateAll() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		logger := logging.FromContext(ctx).Named("handleUpdateAll")
+
+		if err := s.manager.UpdateAll(ctx); err != nil {
+			logger.Errorw("failed to update all", "error", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, http.StatusText(http.StatusOK))
+	})
+}

--- a/internal/jwks/jwks_test.go
+++ b/internal/jwks/jwks_test.go
@@ -139,7 +139,7 @@ func TestUpdateHA(t *testing.T) {
 			// Set up the test.
 			ctx := context.Background()
 			testDB, _ := testDatabaseInstance.NewDatabase(t)
-			mgr, err := NewManager(ctx, testDB, time.Minute)
+			mgr, err := NewManager(testDB, time.Minute)
 			if err != nil {
 				t.Fatalf("[%d] unexpected error: %v", i, err)
 			}

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+)
+
+const (
+	// googleCloudTraceHeader is the header with trace data.
+	googleCloudTraceHeader = "X-Cloud-Trace-Context"
+
+	// googleCloudTraceKey is the key in the structured log where trace information
+	// is expected to be present.
+	googleCloudTraceKey = "logging.googleapis.com/trace"
+)
+
+// googleCloudProjectID is the project id, populated by Terraform during service
+// deployment.
+var googleCloudProjectID = os.Getenv("PROJECT_ID")
+
+// PopulateLogger populates the logger onto the context.
+func PopulateLogger(originalLogger *zap.SugaredLogger) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			logger := originalLogger
+
+			// Only override the logger if it's the default logger. This is only used
+			// for testing and is intentionally a strict object equality check because
+			// the default logger is a global default in the logger package.
+			if existing := logging.FromContext(ctx); existing == logging.DefaultLogger() {
+				logger = existing
+			}
+
+			// If there's a request ID, set that on the logger.
+			if id := RequestIDFromContext(ctx); id != "" {
+				logger = logger.With("request_id", id)
+			}
+
+			// On Google Cloud, extract the trace context and add it to the logger.
+			if v := r.Header.Get(googleCloudTraceHeader); v != "" && googleCloudProjectID != "" {
+				parts := strings.Split(v, "/")
+				if len(parts) > 0 && len(parts[0]) > 0 {
+					val := fmt.Sprintf("projects/%s/traces/%s", googleCloudProjectID, parts[0])
+					logger = logger.With(googleCloudTraceKey, val)
+				}
+			}
+
+			ctx = logging.WithLogger(ctx, logger)
+			r = r.Clone(ctx)
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,20 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package middleware defines common http middlewares.
+package middleware
+
+// contextKey is a unique type to avoid clashing with other packages that use
+// context's to pass data.
+type contextKey string

--- a/internal/middleware/observability.go
+++ b/internal/middleware/observability.go
@@ -1,0 +1,36 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-server/pkg/observability"
+
+	"github.com/gorilla/mux"
+)
+
+// WithObservability sets common observability context fields.
+func WithObservability() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			ctx = observability.WithBuildInfo(ctx)
+
+			r = r.Clone(ctx)
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/request_id.go
+++ b/internal/middleware/request_id.go
@@ -1,0 +1,71 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+// contextKeyRequestID is the unique key in the context where the request ID is
+// stored.
+const contextKeyRequestID = contextKey("request_id")
+
+// PopulateRequestID populates the request context with a random UUID if one
+// does not already exist.
+func PopulateRequestID() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			if existing := RequestIDFromContext(ctx); existing == "" {
+				u, err := uuid.NewRandom()
+				if err != nil {
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					return
+				}
+
+				ctx = withRequestID(ctx, u.String())
+				r = r.Clone(ctx)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequestIDFromContext pulls the request ID from the context, if one was set.
+// If one was not set, it returns the empty string.
+func RequestIDFromContext(ctx context.Context) string {
+	v := ctx.Value(contextKeyRequestID)
+	if v == nil {
+		return ""
+	}
+
+	t, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return t
+}
+
+// withRequestID sets the request ID on the provided context, returning a new
+// context.
+func withRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, contextKeyRequestID, id)
+}


### PR DESCRIPTION
This updates the jwks service to populate and pull critical information from the request context instead of the initial context, similar to the verifications server.

Yes, a lot of this middleware is similar to the verification server, but it's _just_ slightly different enough that it doesn't make sense to try and unify (yet).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Pull logger and request_id from context in jwks service
```