### PR TITLE
Use custom http client and customizable timeout for jwks

### DIFF
--- a/internal/jwks/config.go
+++ b/internal/jwks/config.go
@@ -31,6 +31,10 @@ type Config struct {
 
 	Port string `env:"PORT, default=8080"`
 
+	// RequestTimeout is the per-request amount of time to wait for a response
+	// before timing out.
+	RequestTimeout time.Duration `env:"REQUEST_TIMEOUT, default=5s"`
+
 	KeyCleanupTTL time.Duration `env:"HEALTH_AUTHORITY_KEY_CLEANUP_TTL, default=720h"` // 30 days
 }
 

--- a/internal/jwks/jwks.go
+++ b/internal/jwks/jwks.go
@@ -42,17 +42,23 @@ import (
 // URI.
 type Manager struct {
 	db         *database.DB
+	client     *http.Client
 	cleanupTTL time.Duration
 }
 
 // NewManager creates a new Manager.
-func NewManager(db *database.DB, cleanupTTL time.Duration) (*Manager, error) {
+func NewManager(db *database.DB, cleanupTTL, requestTimeout time.Duration) (*Manager, error) {
 	if cleanupTTL < 0 {
 		cleanupTTL *= -1
 	}
 
+	client := &http.Client{
+		Timeout: requestTimeout,
+	}
+
 	return &Manager{
 		db:         db,
+		client:     client,
 		cleanupTTL: cleanupTTL,
 	}, nil
 }
@@ -74,7 +80,7 @@ func (mgr *Manager) getKeys(ctx context.Context, ha *model.HealthAuthority) ([]b
 		return nil, fmt.Errorf("creating connection: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := mgr.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("reading connection: %w", err)
 	}

--- a/internal/jwks/jwks_test.go
+++ b/internal/jwks/jwks_test.go
@@ -139,7 +139,7 @@ func TestUpdateHA(t *testing.T) {
 			// Set up the test.
 			ctx := context.Background()
 			testDB, _ := testDatabaseInstance.NewDatabase(t)
-			mgr, err := NewManager(testDB, time.Minute)
+			mgr, err := NewManager(testDB, time.Minute, 5*time.Second)
 			if err != nil {
 				t.Fatalf("[%d] unexpected error: %v", i, err)
 			}

--- a/internal/jwks/server.go
+++ b/internal/jwks/server.go
@@ -39,7 +39,7 @@ func NewServer(cfg *Config, env *serverenv.ServerEnv) (*Server, error) {
 		return nil, fmt.Errorf("missing database in server env")
 	}
 
-	manager, err := NewManager(env.Database(), cfg.KeyCleanupTTL)
+	manager, err := NewManager(env.Database(), cfg.KeyCleanupTTL, cfg.RequestTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create manager: %w", err)
 	}


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Use a custom http client with a separate request timeout for the jwks service. Operators can customize the timeout by setting `REQUEST_TIMEOUT` on the jwks service. The default value is 5 seconds.
```

/assign @whaught 