### PR TITLE
Use TestContext in tests

### DIFF
--- a/internal/authorizedapp/database/authorized_app_test.go
+++ b/internal/authorizedapp/database/authorized_app_test.go
@@ -15,12 +15,12 @@
 package database
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"strings"
 	"testing"
 
 	"github.com/google/exposure-notifications-server/internal/authorizedapp/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -28,7 +28,7 @@ import (
 func TestAuthorizedAppInsert_Errors(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	aadb := New(testDB)
 
@@ -55,7 +55,7 @@ func TestAuthorizedAppInsert_Errors(t *testing.T) {
 func TestAuthorizedAppLifecycle(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	aadb := New(testDB)
 
@@ -114,7 +114,7 @@ func TestAuthorizedAppLifecycle(t *testing.T) {
 func TestUpdateAuthorizedApp_NoRows(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	aadb := New(testDB)
 
@@ -139,7 +139,7 @@ func TestUpdateAuthorizedApp_NoRows(t *testing.T) {
 func TestUpdateAuthorizedApp_Errors(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	aadb := New(testDB)
 
@@ -174,7 +174,7 @@ func TestUpdateAuthorizedApp_Errors(t *testing.T) {
 func TestGetAuthorizedApp(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	cases := []struct {
 		name string
@@ -254,7 +254,7 @@ func TestGetAuthorizedApp(t *testing.T) {
 func TestListAuthorizedApps(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	aadb := New(testDB)
 

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -15,12 +15,12 @@
 package cleanup
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/internal/storage"
 )
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 func TestNewExposureHandler(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	testCases := []struct {
@@ -84,7 +84,7 @@ func TestNewExposureHandler(t *testing.T) {
 func TestNewExportHandler(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	noopBlobstore, _ := storage.NewNoop(ctx)
 
@@ -158,7 +158,7 @@ func TestCutoffDate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := cutoffDate(context.Background(), tc.d, tc.override)
+			got, err := cutoffDate(project.TestContext(t), tc.d, tc.override)
 			if tc.wantDur == 0 {
 				if err == nil {
 					t.Errorf("%q: got no error, wanted one", tc.d)

--- a/internal/database/lock_test.go
+++ b/internal/database/lock_test.go
@@ -15,18 +15,19 @@
 package database
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/exposure-notifications-server/internal/project"
 )
 
 func TestLock(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	const (
@@ -93,7 +94,7 @@ func TestLock(t *testing.T) {
 func TestLock_contention(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	var wg sync.WaitGroup
@@ -138,7 +139,7 @@ func TestLock_contention(t *testing.T) {
 func TestMultiLock(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	neededLocks := []string{"traveler", "US", "CA", "MX"}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -32,6 +32,7 @@ import (
 	exportapi "github.com/google/exposure-notifications-server/internal/export"
 	exportdb "github.com/google/exposure-notifications-server/internal/export/database"
 	"github.com/google/exposure-notifications-server/internal/integration"
+	"github.com/google/exposure-notifications-server/internal/project"
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	"github.com/google/exposure-notifications-server/internal/storage"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
@@ -106,7 +107,7 @@ func checkResp(r *http.Response) ([]byte, error) {
 
 func TestPublishEndpoint(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	tc := initConfig(t, ctx)
 	if tc.ExposureURL == "" {
@@ -288,7 +289,7 @@ func TestPublishEndpoint(t *testing.T) {
 
 // getExposures finds the exposures that match the given criteria.
 func getExposures(db *database.DB, criteria publishdb.IterateExposuresCriteria) ([]*publishmodel.Exposure, error) {
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	var exposures []*publishmodel.Exposure
 	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
 		exposures = append(exposures, m)

--- a/internal/export/database/export_test.go
+++ b/internal/export/database/export_test.go
@@ -15,7 +15,6 @@
 package database
 
 import (
-	"context"
 	"errors"
 	"reflect"
 	"sort"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/export/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 
@@ -34,7 +34,7 @@ import (
 func TestAddRetrieveUpdateSignatureInfo(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	want := &model.SignatureInfo{
@@ -76,7 +76,7 @@ func TestAddRetrieveUpdateSignatureInfo(t *testing.T) {
 func TestLookupSignatureInfos(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	testTime := time.Now().UTC()
@@ -126,7 +126,7 @@ func TestLookupSignatureInfos(t *testing.T) {
 func TestAddGetUpdateExportConfig(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportDB := New(testDB)
 
@@ -181,7 +181,7 @@ func TestAddGetUpdateExportConfig(t *testing.T) {
 func TestIterateExportConfigs(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	now := time.Now().Truncate(time.Microsecond)
@@ -259,7 +259,7 @@ func TestBatches(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 			now := time.Now().Truncate(time.Microsecond)
@@ -376,7 +376,7 @@ func TestBatches(t *testing.T) {
 func TestFinalizeBatch(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportDB := New(testDB)
 	now := time.Now().Truncate(time.Microsecond)
@@ -480,7 +480,7 @@ func TestFinalizeBatch(t *testing.T) {
 func TestTravelerKeys(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	now := time.Now()
 
@@ -629,7 +629,7 @@ func TestExcludeRegions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 			// Add a config.
@@ -718,7 +718,7 @@ func TestExcludeRegions(t *testing.T) {
 func TestKeysInBatch(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	now := time.Now()
 
@@ -817,7 +817,7 @@ func TestKeysInBatch(t *testing.T) {
 func TestAddExportFileSkipsDuplicates(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportDB := New(testDB)
 

--- a/internal/export/server_test.go
+++ b/internal/export/server_test.go
@@ -15,11 +15,11 @@
 package export
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/internal/storage"
 	"github.com/google/exposure-notifications-server/pkg/keys"
@@ -32,7 +32,7 @@ func TestNewServer(t *testing.T) {
 	emptyStorage := &storage.GoogleCloudStorage{}
 	emptyKMS := &keys.GoogleCloudKMS{}
 	emptyDB := &database.DB{}
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	testCases := []struct {
 		name string

--- a/internal/export/worker_test.go
+++ b/internal/export/worker_test.go
@@ -15,11 +15,11 @@
 package export
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/export/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
@@ -165,7 +165,7 @@ func TestBatchExposures(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			testDB, _ := testDatabaseInstance.NewDatabase(t)
 			testPublishDB := publishdb.New(testDB)
 
@@ -387,7 +387,7 @@ func TestBatchExposures(t *testing.T) {
 func TestVariableBatchMaxSize(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	testPublishDB := publishdb.New(testDB)
 

--- a/internal/exportimport/database/exportimport_test.go
+++ b/internal/exportimport/database/exportimport_test.go
@@ -15,7 +15,6 @@
 package database
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/exportimport/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -33,7 +33,7 @@ import (
 func TestAddGetUpdateExportConfig(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportImportDB := New(testDB)
 
@@ -119,7 +119,7 @@ func TestAddGetUpdateExportConfig(t *testing.T) {
 func TestAddImportFiles(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportImportDB := New(testDB)
 
@@ -171,7 +171,7 @@ func TestAddImportFiles(t *testing.T) {
 func TestLeaseAndCompleteImportFile(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportImportDB := New(testDB)
 
@@ -236,7 +236,7 @@ func TestLeaseAndCompleteImportFile(t *testing.T) {
 func TestImportFilePublicKey(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportImportDB := New(testDB)
 
@@ -305,7 +305,7 @@ func TestImportFilePublicKey(t *testing.T) {
 func TestRetryToClose(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportImportDB := New(testDB)
 

--- a/internal/exportimport/import_test.go
+++ b/internal/exportimport/import_test.go
@@ -15,12 +15,12 @@
 package exportimport
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
 
 	exportproto "github.com/google/exposure-notifications-server/internal/pb/export"
+	"github.com/google/exposure-notifications-server/internal/project"
 	pubmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -59,7 +59,7 @@ func (k *keyGenerator) fakeExposureKey(t testing.TB) []byte {
 func TestTransform(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	logger := logging.FromContext(ctx)
 
 	gen := &keyGenerator{}

--- a/internal/exportimport/importer_test.go
+++ b/internal/exportimport/importer_test.go
@@ -15,7 +15,6 @@
 package exportimport
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,13 +22,14 @@ import (
 
 	exportimportdb "github.com/google/exposure-notifications-server/internal/exportimport/database"
 	"github.com/google/exposure-notifications-server/internal/exportimport/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 )
 
 func TestImportingRetries(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportImportDB := exportimportdb.New(testDB)
 

--- a/internal/exportimport/scheduler_test.go
+++ b/internal/exportimport/scheduler_test.go
@@ -15,7 +15,6 @@
 package exportimport
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -23,6 +22,7 @@ import (
 
 	exportimportdb "github.com/google/exposure-notifications-server/internal/exportimport/database"
 	"github.com/google/exposure-notifications-server/internal/exportimport/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -30,7 +30,7 @@ import (
 func TestSyncFileFromIndexErrorsInExportRoot(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportImportDB := exportimportdb.New(testDB)
 
@@ -59,7 +59,7 @@ func TestSyncFileFromIndexErrorsInExportRoot(t *testing.T) {
 func TestSyncFilenameShapes(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportImportDB := exportimportdb.New(testDB)
 
@@ -239,7 +239,7 @@ func TestSyncFilenameShapes(t *testing.T) {
 func TestSyncFileFromIndex(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	exportImportDB := exportimportdb.New(testDB)
 

--- a/internal/federationin/database/federationin_test.go
+++ b/internal/federationin/database/federationin_test.go
@@ -15,7 +15,6 @@
 package database
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -23,6 +22,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/federationin/model"
 	"github.com/google/exposure-notifications-server/internal/pb/federation"
+	"github.com/google/exposure-notifications-server/internal/project"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -32,7 +32,7 @@ import (
 func TestFederationIn(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	db := New(testDB)
 

--- a/internal/federationin/federationin_test.go
+++ b/internal/federationin/federationin_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/internal/federationin/database"
 	"github.com/google/exposure-notifications-server/internal/federationin/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
@@ -408,7 +409,7 @@ func TestFederationPull(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			query := &model.FederationInQuery{
 				QueryID: queryID,
 			}

--- a/internal/federationout/database/federationout_test.go
+++ b/internal/federationout/database/federationout_test.go
@@ -15,12 +15,12 @@
 package database
 
 import (
-	"context"
 	"errors"
 	"testing"
 
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/federationin/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -29,7 +29,7 @@ import (
 func TestFederationOutAuthorization(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	want := &model.FederationOutAuthorization{

--- a/internal/federationout/federationout_test.go
+++ b/internal/federationout/federationout_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/pb/federation"
+	"github.com/google/exposure-notifications-server/internal/project"
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
@@ -506,7 +507,7 @@ func TestFetch(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			env := serverenv.New(ctx)
 			server := Server{
 				env: env,
@@ -527,7 +528,7 @@ func TestFetch(t *testing.T) {
 				revised: tc.revisedIterations,
 			}
 
-			got, err := server.fetch(context.Background(), req, fakeDB.provideInput, time.Now())
+			got, err := server.fetch(project.TestContext(t), req, fakeDB.provideInput, time.Now())
 			if err != nil {
 				t.Fatalf("fetch() returned err=%v, want err=nil", err)
 			}
@@ -544,7 +545,7 @@ func TestRawToken(t *testing.T) {
 
 	want := "Abc123"
 	md := metadata.New(map[string]string{"authorization": fmt.Sprintf("Bearer %s", want)})
-	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ctx := metadata.NewIncomingContext(project.TestContext(t), md)
 
 	got, err := rawToken(ctx)
 	if err != nil {
@@ -588,7 +589,7 @@ func TestRawTokenErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := metadata.NewIncomingContext(context.Background(), tc.mdMap)
+			ctx := metadata.NewIncomingContext(project.TestContext(t), tc.mdMap)
 			_, gotErr := rawToken(ctx)
 			if gotErr == nil {
 				t.Errorf("missing error response")

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -28,6 +28,7 @@ import (
 	exportapi "github.com/google/exposure-notifications-server/internal/export"
 	exportdb "github.com/google/exposure-notifications-server/internal/export/database"
 	"github.com/google/exposure-notifications-server/internal/pb/export"
+	"github.com/google/exposure-notifications-server/internal/project"
 	publishdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/storage"
@@ -82,7 +83,7 @@ func TestIntegration(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			env, client := NewTestServer(t)
 			db := env.Database()
 			jwtCfg, exportDir, exportRoot, appName := Seed(t, ctx, db, 2*time.Second)
@@ -135,7 +136,7 @@ func TestIntegration(t *testing.T) {
 
 			// Assert there are 3 exposures in the database
 			{
-				exposures, err := getExposures(db, criteria)
+				exposures, err := getExposures(ctx, db, criteria)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -264,7 +265,7 @@ func TestIntegration(t *testing.T) {
 
 			// Assert there are one less exposures in the database now
 			{
-				exposures, err := getExposures(db, criteria)
+				exposures, err := getExposures(ctx, db, criteria)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -314,7 +315,7 @@ func TestIntegration(t *testing.T) {
 
 			// Assert there are 5 exposures in the database
 			{
-				exposures, err := getExposures(db, criteria)
+				exposures, err := getExposures(ctx, db, criteria)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -439,8 +440,7 @@ func TestIntegration(t *testing.T) {
 }
 
 // getExposures finds the exposures that match the given criteria.
-func getExposures(db *database.DB, criteria publishdb.IterateExposuresCriteria) ([]*publishmodel.Exposure, error) {
-	ctx := context.Background()
+func getExposures(ctx context.Context, db *database.DB, criteria publishdb.IterateExposuresCriteria) ([]*publishmodel.Exposure, error) {
 	var exposures []*publishmodel.Exposure
 	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
 		exposures = append(exposures, m)

--- a/internal/keyrotation/rotate_test.go
+++ b/internal/keyrotation/rotate_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/revision"
 	revisiondb "github.com/google/exposure-notifications-server/internal/revision/database"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
@@ -34,7 +35,7 @@ import (
 func TestRotateKeys(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	kms := keys.TestKeyManager(t)
 	keyID := keys.TestEncryptionKey(t, kms)

--- a/internal/keyrotation/server_test.go
+++ b/internal/keyrotation/server_test.go
@@ -15,10 +15,10 @@
 package keyrotation
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/revision"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/pkg/keys"
@@ -27,7 +27,7 @@ import (
 func TestNewRotationHandler(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	kms := keys.TestKeyManager(t)

--- a/internal/mirror/database/mirror_test.go
+++ b/internal/mirror/database/mirror_test.go
@@ -15,10 +15,10 @@
 package database
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/exposure-notifications-server/internal/mirror/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -26,7 +26,7 @@ import (
 func TestMirror_Lifecycle(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	mirrorDB := New(testDB)
 
@@ -105,7 +105,7 @@ func TestMirror_Lifecycle(t *testing.T) {
 func TestFileLifecycle(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	mirrorDB := New(testDB)
 
@@ -182,7 +182,7 @@ func TestFileLifecycle(t *testing.T) {
 func TestFileLifecycleWithRewrite(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	mirrorDB := New(testDB)
 

--- a/internal/mirror/mirror_test.go
+++ b/internal/mirror/mirror_test.go
@@ -15,7 +15,6 @@
 package mirror
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -29,6 +28,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/database"
 	mirrordatabase "github.com/google/exposure-notifications-server/internal/mirror/database"
 	mirrormodel "github.com/google/exposure-notifications-server/internal/mirror/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/internal/storage"
 	"github.com/google/go-cmp/cmp"
@@ -47,7 +47,7 @@ func TestMain(m *testing.M) {
 func TestServer_ProcessMirror(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	zipFileContents := "data data data"
 
 	cases := []struct {
@@ -255,7 +255,7 @@ func TestServer_ProcessMirror(t *testing.T) {
 func TestServer_DownloadIndex(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	emptyDB := &database.DB{}
 	testBlobstore, err := storage.NewNoop(ctx)
 	if err != nil {

--- a/internal/mirror/server_test.go
+++ b/internal/mirror/server_test.go
@@ -15,12 +15,12 @@
 package mirror
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/internal/storage"
 )
@@ -30,7 +30,7 @@ func TestNewServer(t *testing.T) {
 
 	emptyDB := &database.DB{}
 	emptyBlobstore := &storage.Noop{}
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	testCases := []struct {
 		name string

--- a/internal/performance/export_test.go
+++ b/internal/performance/export_test.go
@@ -17,7 +17,6 @@
 package performance
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"path"
@@ -54,7 +53,7 @@ func TestExport(t *testing.T) {
 		totalBatches   = 24 * 6
 	)
 	var (
-		ctx      = context.Background()
+		ctx      = project.TestContext(t)
 		criteria = publishdb.IterateExposuresCriteria{
 			OnlyLocalProvenance: false,
 		}
@@ -64,7 +63,7 @@ func TestExport(t *testing.T) {
 		batchStartTime = time.Now().Add(time.Duration(-totalBatches-10) * exportPeriod)
 	)
 	c := testConfig{}
-	if err := envconfig.ProcessWith(context.Background(), &c, envconfig.OsLookuper()); err != nil {
+	if err := envconfig.ProcessWith(project.TestContext(t), &c, envconfig.OsLookuper()); err != nil {
 		t.Fatalf("unable to process env: %v", err)
 	}
 
@@ -75,7 +74,7 @@ func TestExport(t *testing.T) {
 	roughPerBatch := numPublishes/totalBatches + 1
 
 	makoQuickstore, cancel := setup(t)
-	defer cancel(context.Background())
+	defer cancel(project.TestContext(t))
 
 	env, client := integration.NewTestServer(t)
 	db := env.Database()

--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/pb"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
 	pgx "github.com/jackc/pgx/v4"
@@ -43,7 +44,7 @@ var (
 func TestReadExposures(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	testPublishDB := New(testDB)
 
@@ -145,7 +146,7 @@ func TestReadExposures(t *testing.T) {
 func TestExposures(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	testPublishDB := New(testDB)
 
@@ -325,7 +326,7 @@ func testExposure(tb testing.TB) *model.Exposure {
 func TestInsertAndReviseExposures_MissingRequest(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	pubDB := New(testDB)
 
@@ -339,7 +340,7 @@ func TestInsertAndReviseExposures_MissingRequest(t *testing.T) {
 func TestInsertAndReviseExposures_ConfigParadox(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	pubDB := New(testDB)
 
@@ -358,7 +359,7 @@ func TestInsertAndReviseExposures_ConfigParadox(t *testing.T) {
 func TestReviseExposures(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	pubDB := New(testDB)
 
@@ -755,7 +756,7 @@ func TestReviseExposures(t *testing.T) {
 func TestIterateExposuresCursor(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(project.TestContext(t))
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	testPublishDB := New(testDB)
 
@@ -806,7 +807,7 @@ func TestIterateExposuresCursor(t *testing.T) {
 		t.Fatalf("cursor: got %q, want %q", cursor, want)
 	}
 	// Resume from the cursor.
-	ctx = context.Background()
+	ctx = project.TestContext(t)
 	cursor, err = testPublishDB.IterateExposures(ctx, IterateExposuresCriteria{LastCursor: cursor},
 		func(e *model.Exposure) error { seen = append(seen, e); return nil })
 	if err != nil {

--- a/internal/publish/database/performance_test_utils_test.go
+++ b/internal/publish/database/performance_test_utils_test.go
@@ -14,9 +14,9 @@
 package database
 
 import (
-	"context"
 	"testing"
 
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 )
 
@@ -54,7 +54,7 @@ func TestBulkInsertExposures(t *testing.T) {
 			want: 3},
 	}
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	testPublishDB := New(testDB)
 

--- a/internal/publish/database/stats_test.go
+++ b/internal/publish/database/stats_test.go
@@ -15,10 +15,10 @@
 package database
 
 import (
-	"context"
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	hadb "github.com/google/exposure-notifications-server/internal/verification/database"
 	hamodel "github.com/google/exposure-notifications-server/internal/verification/model"
@@ -27,7 +27,7 @@ import (
 func TestDeleteStatsBefore(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	testPublishDB := New(testDB)
 
@@ -55,7 +55,7 @@ func TestDeleteStatsBefore(t *testing.T) {
 func TestUpdateStats(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	testPublishDB := New(testDB)
 
@@ -93,7 +93,7 @@ func TestUpdateStats(t *testing.T) {
 func TestReadStats(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	testPublishDB := New(testDB)
 

--- a/internal/publish/model/exposure_model_test.go
+++ b/internal/publish/model/exposure_model_test.go
@@ -15,7 +15,6 @@
 package model
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
@@ -27,6 +26,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/pb/export"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/verification"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
@@ -133,7 +133,7 @@ func TestInvalidNew(t *testing.T) {
 func TestInvalidBase64(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	transformer, err := NewTransformer(&testConfig{
 		maxExposureKeys:     1,
 		maxSameDayKeys:      1,
@@ -349,7 +349,7 @@ func TestPublishValidation(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			tf, err := NewTransformer(&testConfig{
 				maxExposureKeys:     2,
 				maxSameDayKeys:      1,
@@ -453,7 +453,7 @@ func TestStillValidKey(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			result, err := transformer.TransformPublish(ctx, &tc.source, []string{}, nil, now)
 			if err != nil {
 				t.Fatal(err)
@@ -1036,7 +1036,7 @@ func TestTransform(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewTransformer returned unexpected error: %v", err)
 	}
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	for _, tc := range cases {
 		tc := tc
@@ -1149,7 +1149,7 @@ func TestDefaultSymptomOnset(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			result, err := transformer.TransformPublish(ctx, &tc.source, []string{}, nil, now)
 			if err != nil {
 				t.Fatal(err)
@@ -1312,7 +1312,7 @@ func TestTransformOverlapping(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			transformer, err := NewTransformer(&testConfig{
 				maxExposureKeys:     10,
 				maxSameDayKeys:      tc.maxSameIntervalKeys,
@@ -1548,7 +1548,7 @@ func TestReviseKeys_FromFederation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			existing := make(map[string]*Exposure)
 			existing[tc.existing.ExposureKeyBase64()] = tc.existing
 
@@ -1627,7 +1627,7 @@ func TestReviseKeys(t *testing.T) {
 		ReportType:        verifyapi.ReportTypeConfirmed,
 	}
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	existing := make(map[string]*Exposure)
 	existing[allExposures[0].ExposureKeyBase64()] = allExposures[0]
 	existing[allExposures[1].ExposureKeyBase64()] = allExposures[1]

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -34,6 +34,7 @@ import (
 	aamodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/pb"
+	"github.com/google/exposure-notifications-server/internal/project"
 	pubdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/revision"
@@ -464,7 +465,7 @@ func TestPublishWithBypass(t *testing.T) {
 			}
 
 			t.Run(addVer+tc.Name, func(t *testing.T) {
-				ctx := context.Background()
+				ctx := project.TestContext(t)
 
 				// Database init for all modules that will be used.
 				testDB, _ := testDatabaseInstance.NewDatabase(t)
@@ -812,7 +813,7 @@ func TestKeyRevision(t *testing.T) {
 		From:    time.Now().Add(-1 * time.Minute),
 	}
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	// Database init for all modules that will be used.
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
@@ -1082,7 +1083,7 @@ func TestKeyRevision(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.Name, func(t *testing.T) {
-			ctx = context.Background()
+			ctx = project.TestContext(t)
 
 			revisionToken := ""
 			// Do the initial insert

--- a/internal/publish/stats_test.go
+++ b/internal/publish/stats_test.go
@@ -15,7 +15,6 @@
 package publish
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -27,6 +26,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/authorizedapp"
+	"github.com/google/exposure-notifications-server/internal/project"
 	pubdb "github.com/google/exposure-notifications-server/internal/publish/database"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
@@ -43,7 +43,7 @@ import (
 func TestRetrieveMetrics(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	authKey := testutil.GetSigningKey(t)
 	kms := keys.TestKeyManager(t)
@@ -199,7 +199,7 @@ func TestRetrieveMetrics(t *testing.T) {
 func TestRetrieveMetrics_AuthErrors(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	authKey := testutil.GetSigningKey(t)
 	kms := keys.TestKeyManager(t)

--- a/internal/revision/database/revision_test.go
+++ b/internal/revision/database/revision_test.go
@@ -15,11 +15,11 @@
 package database
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -28,7 +28,7 @@ import (
 func TestRevisionKey(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	kms := keys.TestKeyManager(t)
@@ -58,7 +58,7 @@ func TestRevisionKey(t *testing.T) {
 func TestMultipleRevisionKeys(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	kms := keys.TestKeyManager(t)

--- a/internal/revision/revision_test.go
+++ b/internal/revision/revision_test.go
@@ -15,13 +15,13 @@
 package revision
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/pb"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	revisiondb "github.com/google/exposure-notifications-server/internal/revision/database"
 	"github.com/google/exposure-notifications-server/pkg/keys"
@@ -161,7 +161,7 @@ func TestBuildTokenBuffer(t *testing.T) {
 func TestEncryptDecrypt(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	kms := keys.TestKeyManager(t)
@@ -252,7 +252,7 @@ func TestEncryptDecrypt(t *testing.T) {
 func TestExpandRevisionToken(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	kms := keys.TestKeyManager(t)

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -15,7 +15,6 @@
 package setup_test
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -23,6 +22,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/internal/authorizedapp"
 	"github.com/google/exposure-notifications-server/internal/database"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/internal/storage"
 	"github.com/google/exposure-notifications-server/pkg/keys"
@@ -100,7 +100,7 @@ func TestSetupWith(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		_, dbconfig := testDatabaseInstance.NewDatabase(t)
 
 		config := &testConfig{Database: dbconfig}
@@ -114,7 +114,7 @@ func TestSetupWith(t *testing.T) {
 	t.Run("database", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		_, dbconfig := testDatabaseInstance.NewDatabase(t)
 
 		config := &testConfig{Database: dbconfig}
@@ -133,7 +133,7 @@ func TestSetupWith(t *testing.T) {
 	t.Run("authorizedapp", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		_, dbconfig := testDatabaseInstance.NewDatabase(t)
 
 		config := &testConfig{Database: dbconfig}
@@ -156,7 +156,7 @@ func TestSetupWith(t *testing.T) {
 	t.Run("blobstore", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		_, dbconfig := testDatabaseInstance.NewDatabase(t)
 
 		config := &testConfig{Database: dbconfig}
@@ -179,7 +179,7 @@ func TestSetupWith(t *testing.T) {
 	t.Run("key_manager", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		_, dbconfig := testDatabaseInstance.NewDatabase(t)
 
 		config := &testConfig{Database: dbconfig}
@@ -202,7 +202,7 @@ func TestSetupWith(t *testing.T) {
 	t.Run("secret_manager", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		_, dbconfig := testDatabaseInstance.NewDatabase(t)
 
 		config := &testConfig{Database: dbconfig}
@@ -225,7 +225,7 @@ func TestSetupWith(t *testing.T) {
 	t.Run("observability_exporter", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		_, dbconfig := testDatabaseInstance.NewDatabase(t)
 
 		config := &testConfig{Database: dbconfig}

--- a/internal/storage/filesystem_storage_test.go
+++ b/internal/storage/filesystem_storage_test.go
@@ -16,11 +16,12 @@ package storage
 
 import (
 	"bytes"
-	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/exposure-notifications-server/internal/project"
 )
 
 func TestFilesystemStorage_CreateObject(t *testing.T) {
@@ -60,7 +61,7 @@ func TestFilesystemStorage_CreateObject(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 
 			storage, err := NewFilesystemStorage(ctx)
 			if err != nil {
@@ -117,7 +118,7 @@ func TestFilesystemStorage_DeleteObject(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 
 			storage, err := NewFilesystemStorage(ctx)
 			if err != nil {
@@ -169,7 +170,7 @@ func TestFilesystemStorage_GetObject(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 
 			storage, err := NewFilesystemStorage(ctx)
 			if err != nil {

--- a/internal/storage/google_cloud_storage_test.go
+++ b/internal/storage/google_cloud_storage_test.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
@@ -28,6 +27,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/exposure-notifications-server/internal/project"
 )
 
 func maybeSkipCloudStorage(tb testing.TB) {
@@ -47,7 +47,7 @@ func testGoogleCloudStorageClient(tb testing.TB) *storage.Client {
 
 	maybeSkipCloudStorage(tb)
 
-	ctx := context.Background()
+	ctx := project.TestContext(tb)
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		tb.Fatal(err)
@@ -84,7 +84,7 @@ func testGoogleCloudStorageObject(tb testing.TB, r io.Reader) string {
 
 	maybeSkipCloudStorage(tb)
 
-	ctx := context.Background()
+	ctx := project.TestContext(tb)
 	client := testGoogleCloudStorageClient(tb)
 	bucket := testGoogleCloudStorageBucket(tb)
 	name := testName(tb)
@@ -111,7 +111,7 @@ func testGoogleCloudStorageObject(tb testing.TB, r io.Reader) string {
 func TestGoogleCloudStorage_CreateObject(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	client := testGoogleCloudStorageClient(t)
 	bucket := testGoogleCloudStorageBucket(t)
 	object := testGoogleCloudStorageObject(t, strings.NewReader("contents"))
@@ -183,7 +183,7 @@ func TestGoogleCloudStorage_CreateObject(t *testing.T) {
 func TestGoogleCloudStorage_DeleteObject(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	client := testGoogleCloudStorageClient(t)
 	bucket := testGoogleCloudStorageBucket(t)
 	object := testGoogleCloudStorageObject(t, strings.NewReader("contents"))

--- a/internal/verification/authenticate_stats_test.go
+++ b/internal/verification/authenticate_stats_test.go
@@ -15,7 +15,6 @@
 package verification
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -26,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/verification/database"
 	"github.com/google/exposure-notifications-server/internal/verification/model"
 
@@ -155,7 +155,7 @@ func TestAuthenticateStatsToken(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			// Set up database. Create HealthAuthority + HAKey for the test.
 			testDB, _ := testDatabaseInstance.NewDatabase(t)
 			haDB := database.New(testDB)

--- a/internal/verification/database/health_authority_db_test.go
+++ b/internal/verification/database/health_authority_db_test.go
@@ -15,12 +15,12 @@
 package database
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/verification/model"
 	"google.golang.org/protobuf/proto"
 
@@ -38,7 +38,7 @@ IBSEEHOdgpAynz0yrHpkWL6vxjNHxRdWcImZxPgL0NVHMdY4TlsL7qaxBQ==
 func TestMissingHealthAuthority(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	haDB := New(testDB)
 
@@ -91,7 +91,7 @@ func TestAddHealthAuthorityErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			if err := haDB.AddHealthAuthority(ctx, tc.ha); err == nil {
 				t.Error("missing expected error")
 			} else if !strings.Contains(err.Error(), tc.want) {
@@ -104,7 +104,7 @@ func TestAddHealthAuthorityErrors(t *testing.T) {
 func TestAddRetrieveHealthAuthority(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	want := &model.HealthAuthority{
@@ -146,7 +146,7 @@ func TestAddRetrieveHealthAuthority(t *testing.T) {
 func TestAddRetrieveHealthAuthorityKeys(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	want := &model.HealthAuthority{
@@ -215,7 +215,7 @@ func TestAddRetrieveHealthAuthorityKeys(t *testing.T) {
 func TestListAllHealthAuthoritiesWithoutKeys(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 
 	want := []*model.HealthAuthority{

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -18,7 +18,6 @@
 package verification
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -33,6 +32,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 
 	aamodel "github.com/google/exposure-notifications-server/internal/authorizedapp/model"
+	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/verification/database"
 	"github.com/google/exposure-notifications-server/internal/verification/model"
 	"github.com/google/go-cmp/cmp"
@@ -90,7 +90,7 @@ func TestVerifyCertificate(t *testing.T) {
 	}
 
 	// Set up database. Create HealthAuthority + HAKey for the test.
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	haDB := database.New(testDB)
 

--- a/pkg/keys/filesystem_test.go
+++ b/pkg/keys/filesystem_test.go
@@ -16,7 +16,6 @@ package keys
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -26,12 +25,14 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/google/exposure-notifications-server/internal/project"
 )
 
 func TestNewFilesystem(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	t.Run("root_empty", func(t *testing.T) {
 		t.Parallel()
@@ -141,7 +142,7 @@ func TestFilesystem_NewSigner(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 
 			dir, err := ioutil.TempDir("", "")
 			if err != nil {
@@ -203,7 +204,7 @@ func TestFilesystem_EncryptDecrypt(t *testing.T) {
 			keyID:     "apple",
 			plaintext: []byte("bacon"),
 			setup: func(fs *Filesystem) error {
-				ctx := context.Background()
+				ctx := project.TestContext(t)
 				id, err := fs.CreateEncryptionKey(ctx, "", "apple")
 				if err != nil {
 					return err
@@ -219,7 +220,7 @@ func TestFilesystem_EncryptDecrypt(t *testing.T) {
 			keyID:     "apple",
 			plaintext: []byte("bacon"),
 			setup: func(fs *Filesystem) error {
-				ctx := context.Background()
+				ctx := project.TestContext(t)
 				id, err := fs.CreateEncryptionKey(ctx, "", "apple")
 				if err != nil {
 					return err
@@ -241,7 +242,7 @@ func TestFilesystem_EncryptDecrypt(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 
 			dir, err := ioutil.TempDir("", "")
 			if err != nil {
@@ -312,7 +313,7 @@ func TestFilesystem_SigningKeyVersions(t *testing.T) {
 			name:  "happy",
 			keyID: "apple",
 			setup: func(fs *Filesystem) error {
-				ctx := context.Background()
+				ctx := project.TestContext(t)
 				id, err := fs.CreateSigningKey(ctx, "", "apple")
 				if err != nil {
 					return err
@@ -328,7 +329,7 @@ func TestFilesystem_SigningKeyVersions(t *testing.T) {
 			name:  "multi",
 			keyID: "apple",
 			setup: func(fs *Filesystem) error {
-				ctx := context.Background()
+				ctx := project.TestContext(t)
 				id, err := fs.CreateSigningKey(ctx, "", "apple")
 				if err != nil {
 					return err
@@ -351,7 +352,7 @@ func TestFilesystem_SigningKeyVersions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 
 			dir, err := ioutil.TempDir("", "")
 			if err != nil {

--- a/pkg/keys/hashicorp_vault_test.go
+++ b/pkg/keys/hashicorp_vault_test.go
@@ -15,7 +15,6 @@
 package keys
 
 import (
-	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -26,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/exposure-notifications-server/internal/project"
 	vaultlog "github.com/hashicorp/go-hclog"
 	vaultapi "github.com/hashicorp/vault/api"
 	vaulttransit "github.com/hashicorp/vault/builtin/logical/transit"
@@ -66,7 +66,7 @@ func TestNewHashiCorpVaultSigner(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			_, err := NewHashiCorpVaultSigner(ctx, tc.client, tc.keyName, tc.keyVersion)
 			if err == nil {
 				t.Fatal("expected error")
@@ -125,7 +125,7 @@ func TestHashiCorpVault_SigningKeyVersions(t *testing.T) {
 			t.Parallel()
 
 			// Create a Vault server.
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
 				DisableMlock: true,
 				DisableCache: true,
@@ -196,7 +196,7 @@ func TestHashiCorpVault_CreateSigningKey(t *testing.T) {
 			t.Parallel()
 
 			// Create a Vault server.
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
 				DisableMlock: true,
 				DisableCache: true,
@@ -267,7 +267,7 @@ func TestHashiCorpVault_CreateKeyVersion(t *testing.T) {
 			t.Parallel()
 
 			// Create a Vault server.
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
 				DisableMlock: true,
 				DisableCache: true,
@@ -362,7 +362,7 @@ func TestHashiCorpVaultEncryptDecrypt(t *testing.T) {
 			t.Parallel()
 
 			// Create a Vault server.
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
 				DisableMlock: true,
 				DisableCache: true,
@@ -487,7 +487,7 @@ func TestHashiCorpVaultSigner_Public(t *testing.T) {
 			t.Parallel()
 
 			// Create a Vault server.
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
 				DisableMlock: true,
 				DisableCache: true,
@@ -544,7 +544,7 @@ func TestHashiCorpVaultSigner_Sign(t *testing.T) {
 	t.Parallel()
 
 	// Create a Vault server.
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
 		DisableMlock: true,
 		DisableCache: true,

--- a/pkg/secrets/cacher_test.go
+++ b/pkg/secrets/cacher_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/google/exposure-notifications-server/internal/project"
 )
 
 type testSecretManager struct {
@@ -32,7 +34,7 @@ func (sm *testSecretManager) GetSecretValue(ctx context.Context, name string) (s
 
 func TestCacher_GetSecretValue(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	sm := &testSecretManager{value: "first"}
 	cached, err := WrapCacher(ctx, sm, 250*time.Millisecond)

--- a/pkg/secrets/hashicorp_vault_test.go
+++ b/pkg/secrets/hashicorp_vault_test.go
@@ -15,11 +15,11 @@
 package secrets
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/google/exposure-notifications-server/internal/project"
 	vaultlog "github.com/hashicorp/go-hclog"
 	vaultkv "github.com/hashicorp/vault-plugin-secrets-kv"
 	vaultapi "github.com/hashicorp/vault/api"
@@ -156,7 +156,7 @@ func TestHashiCorpVault_GetSecretValue(t *testing.T) {
 			t.Parallel()
 
 			// Create a Vault server.
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			core, _, token := vault.TestCoreUnsealedWithConfig(t, &vault.CoreConfig{
 				DisableMlock: true,
 				DisableCache: true,

--- a/pkg/secrets/json_expander_test.go
+++ b/pkg/secrets/json_expander_test.go
@@ -15,14 +15,15 @@
 package secrets
 
 import (
-	"context"
 	"testing"
+
+	"github.com/google/exposure-notifications-server/internal/project"
 )
 
 func TestJSONExpander_GetSecretValue(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	testSM := &testSecretManager{}
 

--- a/pkg/secrets/resolver_test.go
+++ b/pkg/secrets/resolver_test.go
@@ -15,17 +15,18 @@
 package secrets
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/google/exposure-notifications-server/internal/project"
 )
 
 func TestResolver(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 
 	sm, err := NewInMemoryFromMap(ctx, map[string]string{
 		"my-secret1": "value1",
@@ -99,7 +100,7 @@ func TestResolver(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			config := &Config{SecretsDir: tc.dir}
 			result, err := Resolver(sm, config)(ctx, tc.key, tc.value)
 			if (err != nil) != tc.err {


### PR DESCRIPTION
This ensures we only see logs related to failures (instead of all logs).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```