### PR TITLE
using PathPrefix as a path catch-all so that v1alpha API works properly

### DIFF
--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -84,7 +84,7 @@ func realMain(ctx context.Context) error {
 
 	// Serving of v1alpha1 is on by default, but can be disabled through env var.
 	if config.EnableV1Alpha1API {
-		r.Handle("/", handler.HandleV1Alpha1())
+		r.PathPrefix("/").Handler(handler.HandleV1Alpha1())
 	}
 
 	srv, err := server.New(config.Port)


### PR DESCRIPTION
Fixes #1348

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Switch catch-all path to use gorilla/mux PathPrefix func to fix v1alpha handling

**Release Note**

```release-note
fixing exposure service handling of "/" path to fix v1alpha API
```