### PR TITLE
Mount middlewares in other packages

### DIFF
--- a/internal/debugger/handler_debug.go
+++ b/internal/debugger/handler_debug.go
@@ -33,11 +33,10 @@ import (
 	"google.golang.org/api/iam/v1"
 )
 
-func (s *Server) handleDebug(ctx context.Context) http.HandlerFunc {
+func (s *Server) handleDebug() http.Handler {
 	db := s.env.Database()
 	authorizedappDB := authorizedappdatabase.New(db)
 	exportDB := exportdatabase.New(db)
-	logger := logging.FromContext(ctx)
 
 	services := []string{
 		"cleanup-export",
@@ -62,8 +61,10 @@ func (s *Server) handleDebug(ctx context.Context) http.HandlerFunc {
 		SignatureInfos []*exportmodel.SignatureInfo
 	}
 
-	return func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+
+		logger := logging.FromContext(ctx).Named("handleDebug")
 
 		errCh := make(chan error, 1)
 
@@ -165,7 +166,7 @@ func (s *Server) handleDebug(ctx context.Context) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, "%s", b)
-	}
+	})
 }
 
 // queue creates a job, adding it to the given wg. Errors are pushed onto the

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -107,6 +107,7 @@ func checkResp(r *http.Response) ([]byte, error) {
 
 func TestPublishEndpoint(t *testing.T) {
 	t.Parallel()
+
 	ctx := project.TestContext(t)
 
 	tc := initConfig(t, ctx)
@@ -148,7 +149,7 @@ func TestPublishEndpoint(t *testing.T) {
 	criteria := publishdb.IterateExposuresCriteria{
 		OnlyLocalProvenance: false,
 	}
-	exposures, err := getExposures(db, criteria)
+	exposures, err := getExposures(ctx, db, criteria)
 	if err != nil {
 		t.Fatalf("Failed getting exposures: %v", err)
 	}
@@ -288,8 +289,7 @@ func TestPublishEndpoint(t *testing.T) {
 }
 
 // getExposures finds the exposures that match the given criteria.
-func getExposures(db *database.DB, criteria publishdb.IterateExposuresCriteria) ([]*publishmodel.Exposure, error) {
-	ctx := project.TestContext(t)
+func getExposures(ctx context.Context, db *database.DB, criteria publishdb.IterateExposuresCriteria) ([]*publishmodel.Exposure, error) {
 	var exposures []*publishmodel.Exposure
 	if _, err := publishdb.New(db).IterateExposures(ctx, criteria, func(m *publishmodel.Exposure) error {
 		exposures = append(exposures, m)

--- a/internal/mirror/mirror.go
+++ b/internal/mirror/mirror.go
@@ -48,12 +48,13 @@ type MirrorStatus struct {
 	Errors    []string `json:"errors,omitempty"`
 }
 
-func (s *Server) handleMirror(ctx context.Context) http.HandlerFunc {
-	logger := logging.FromContext(ctx).Named("mirror.handleMirror")
+func (s *Server) handleMirror() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
 
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := logging.WithLogger(r.Context(), logger)
-		_, span := trace.StartSpan(ctx, "(*mirror.handleMirror).ServeHTTP")
+		logger := logging.FromContext(ctx).Named("handleMirror")
+
+		ctx, span := trace.StartSpan(ctx, "(*mirror.handleMirror).ServeHTTP")
 		defer span.End()
 
 		ctx, cancelFn := context.WithTimeout(ctx, s.config.MaxRuntime)
@@ -129,7 +130,7 @@ func (s *Server) handleMirror(ctx context.Context) http.HandlerFunc {
 		}
 		w.WriteHeader(status)
 		fmt.Fprint(w, string(b))
-	}
+	})
 }
 
 // processMirror processes all files in the mirror, deleting files that have


### PR DESCRIPTION
This is all the "easy" ones that don't require a refactor

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Mount middlewares and pull from request context in debugger, e2e, exportimport, keyrotation, and mirror
```