### PR TITLE
change default scale to 10

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -294,7 +294,7 @@ variable "enable_lb_logging" {
 
 locals {
   default_revision_annotations = {
-    "autoscaling.knative.dev/maxScale" : "1",
+    "autoscaling.knative.dev/maxScale" : "10",
     "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
     "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
   }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Default maxScale to 10

Having a low max instances will cause reduced availability, a known
issue of Cloud Run:
https://cloud.google.com/run/docs/issues#low-max-instances