### PR TITLE
Update WithBuildInfo() to be more generic.

### DIFF
--- a/pkg/observability/common.go
+++ b/pkg/observability/common.go
@@ -12,26 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package middleware
+package observability
 
-import (
-	"net/http"
-
-	"github.com/google/exposure-notifications-server/internal/buildinfo"
-	"github.com/google/exposure-notifications-server/pkg/observability"
-
-	"github.com/gorilla/mux"
-)
-
-// PopulateObservability sets common observability context fields.
-func PopulateObservability() mux.MiddlewareFunc {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
-			ctx = observability.WithBuildInfo(ctx, buildinfo.KeyServer)
-
-			r = r.Clone(ctx)
-			next.ServeHTTP(w, r)
-		})
-	}
+// BuildInfo is the interface to provide build information.
+type BuildInfo interface {
+	ID() string
+	Tag() string
 }

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -23,8 +23,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/google/exposure-notifications-server/internal/buildinfo"
-
 	"contrib.go.opencensus.io/integrations/ocsql"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/plugin/ochttp"
@@ -121,10 +119,10 @@ func NewFromEnv(config *Config) (Exporter, error) {
 
 // WithBuildInfo creates a new context with the build and revision info attached
 // to the observability context.
-func WithBuildInfo(ctx context.Context) context.Context {
+func WithBuildInfo(ctx context.Context, info BuildInfo) context.Context {
 	tags := make([]tag.Mutator, 0, 5)
-	tags = append(tags, tag.Upsert(BuildIDTagKey, buildinfo.BuildID))
-	tags = append(tags, tag.Upsert(BuildTagTagKey, buildinfo.BuildTag))
+	tags = append(tags, tag.Upsert(BuildIDTagKey, info.ID()))
+	tags = append(tags, tag.Upsert(BuildTagTagKey, info.Tag()))
 
 	if knativeService != "" {
 		tags = append(tags, tag.Upsert(KnativeServiceTagKey, knativeService))


### PR DESCRIPTION
We can then share this method to be used by verification server.