### PR TITLE
removing version syntax to support GOPATH mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ MD_FILES = $(shell find . -name \*.md)
 # locally. There is a chance that CI detects linter errors that are not found
 # locally, but it should be rare.
 lint:
-	@command -v golangci-lint > /dev/null 2>&1 || GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.36.0
+	@command -v golangci-lint > /dev/null 2>&1 || GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint
 	golangci-lint run --config .golangci.yaml
 .PHONY: lint
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ MD_FILES = $(shell find . -name \*.md)
 # locally. There is a chance that CI detects linter errors that are not found
 # locally, but it should be rare.
 lint:
-	@command -v golangci-lint > /dev/null 2>&1 || GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint
+	@command -v golangci-lint > /dev/null 2>&1 || go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.36.0
 	golangci-lint run --config .golangci.yaml
 .PHONY: lint
 


### PR DESCRIPTION
**Release Note**

```release-note
removing version from golangci-lint to support GOPATH mode
```