### PR TITLE
Update security alerts for HumanAccessSecret and HumanDecryptedValue

### DIFF
--- a/docs/playbooks/alerts/HumanAccessedSecret.md
+++ b/docs/playbooks/alerts/HumanAccessedSecret.md
@@ -7,10 +7,10 @@ once in the period, even if multiple secrets are accessed.
 
 Go to Logs Explorer, use the following filter:
 
-```
-resource.type="audited_resource"
-resource.labels.service="secretmanager.googleapis.com"
-resource.labels.method="google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion"
+```text
+protoPayload.@type="type.googleapis.com/google.cloud.audit.AuditLog"
+protoPayload.serviceName="secretmanager.googleapis.com"
+protoPayload.methodName=~"AccessSecretVersion$"
 protoPayload.authenticationInfo.principalEmail!~"gserviceaccount.com$"
 ```
 

--- a/docs/playbooks/alerts/HumanDecryptedValue.md
+++ b/docs/playbooks/alerts/HumanDecryptedValue.md
@@ -8,9 +8,9 @@ only fires once in the period, even if multiple decryption events occur.
 Go to Logs Explorer, use the following filter:
 
 ```
-resource.type="audited_resource"
-resource.labels.service="cloudkms.googleapis.com"
-resource.labels.method:"Decrypt"
+protoPayload.@type="type.googleapis.com/google.cloud.audit.AuditLog"
+protoPayload.serviceName="cloudkms.googleapis.com"
+protoPayload.methodName="Decrypt"
 protoPayload.authenticationInfo.principalEmail!~"gserviceaccount.com$"
 ```
 

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -54,9 +54,9 @@ resource "google_logging_metric" "human_accessed_secret" {
   name    = "human_accessed_secret"
   project = var.project
   filter  = <<EOT
-resource.type="audited_resource"
-resource.labels.service="secretmanager.googleapis.com"
-resource.labels.method:"AccessSecretVersion"
+protoPayload.@type="type.googleapis.com/google.cloud.audit.AuditLog"
+protoPayload.serviceName="secretmanager.googleapis.com"
+protoPayload.methodName=~"AccessSecretVersion$"
 protoPayload.authenticationInfo.principalEmail!~"gserviceaccount.com$"
 EOT
 
@@ -80,13 +80,14 @@ EOT
     "secret" = "EXTRACT(protoPayload.resourceName)"
   }
 }
+
 resource "google_logging_metric" "human_decrypted_value" {
   name    = "human_decrypted_value"
   project = var.project
   filter  = <<EOT
-resource.type="audited_resource"
-resource.labels.service="cloudkms.googleapis.com"
-resource.labels.method:"Decrypt"
+protoPayload.@type="type.googleapis.com/google.cloud.audit.AuditLog"
+protoPayload.serviceName="cloudkms.googleapis.com"
+protoPayload.methodName="Decrypt"
 protoPayload.authenticationInfo.principalEmail!~"gserviceaccount.com$"
 EOT
 
@@ -162,7 +163,7 @@ resource "google_monitoring_alert_policy" "HumanDecryptedValue" {
       duration = "60s"
 
       query = <<-EOT
-      fetch audited_resource
+      fetch global
       | metric 'logging.googleapis.com/user/${google_logging_metric.human_decrypted_value.name}'
       | align rate(5m)
       | every 1m


### PR DESCRIPTION
The Cloud KMS audit logs were not matching as expected. This fixes that.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Update accuracy for security alerts for HumanAccessSecret and HumanDecryptedValue
```

/assign @mariliamelo 