### PR TITLE
Use a random prefix instead of hard-coding parent

### DIFF
--- a/pkg/keys/testing.go
+++ b/pkg/keys/testing.go
@@ -16,6 +16,8 @@ package keys
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -59,7 +61,7 @@ func TestEncryptionKey(tb testing.TB, kms KeyManager) string {
 	}
 
 	ctx := context.Background()
-	parent, err := typ.CreateEncryptionKey(ctx, "parent", "key")
+	parent, err := typ.CreateEncryptionKey(ctx, randomPrefix(tb, 8), "key")
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -82,7 +84,7 @@ func TestSigningKey(tb testing.TB, kms KeyManager) string {
 	}
 
 	ctx := context.Background()
-	parent, err := typ.CreateSigningKey(ctx, "parent", "key")
+	parent, err := typ.CreateSigningKey(ctx, randomPrefix(tb, 8), "key")
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -91,4 +93,18 @@ func TestSigningKey(tb testing.TB, kms KeyManager) string {
 	}
 
 	return parent
+}
+
+func randomPrefix(tb testing.TB, length int) string {
+	tb.Helper()
+
+	b := make([]byte, length)
+	n, err := rand.Read(b)
+	if err != nil {
+		tb.Fatalf("failed to generate random: %v", err)
+	}
+	if n < length {
+		tb.Fatalf("insufficient bytes read: %v, expected %v", n, length)
+	}
+	return hex.EncodeToString(b)[:length]
 }


### PR DESCRIPTION
This prevents collisions when the same key manager is used across multiple tests.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Use a random prefix instead of hard-coding "parent" in key manager test helper.
```