### PR TITLE
simplify error checking in unit tests

### DIFF
--- a/internal/exportimport/scheduler_test.go
+++ b/internal/exportimport/scheduler_test.go
@@ -23,6 +23,7 @@ import (
 	exportimportdb "github.com/google/exposure-notifications-server/internal/exportimport/database"
 	"github.com/google/exposure-notifications-server/internal/exportimport/model"
 	"github.com/google/exposure-notifications-server/internal/project"
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -49,11 +50,8 @@ func TestSyncFileFromIndexErrorsInExportRoot(t *testing.T) {
 	// test data ensures that URL parsing strips extra slashes.
 	index := strings.Join([]string{"a.zip", "/b.zip", "//c.zip", ""}, "\n")
 
-	if _, _, err := syncFilesFromIndex(ctx, exportImportDB, config, index); err == nil {
-		t.Fatalf("expected error")
-	} else if !strings.Contains(err.Error(), "invalid URL escape") {
-		t.Fatalf("wrong error, wanted: invalid URL escape, got: %v", err)
-	}
+	_, _, err := syncFilesFromIndex(ctx, exportImportDB, config, index)
+	errcmp.MustMatch(t, err, "invalid URL escape")
 }
 
 func TestSyncFilenameShapes(t *testing.T) {

--- a/internal/mirror/mirror_test.go
+++ b/internal/mirror/mirror_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/internal/storage"
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
 	"github.com/sethvargo/go-envconfig"
@@ -315,12 +315,7 @@ func TestServer_DownloadIndex(t *testing.T) {
 		_, err = s.downloadIndex(ctx, &mirrormodel.Mirror{
 			IndexFile: ts.URL,
 		})
-		if err == nil {
-			t.Fatal("expected error")
-		}
-		if got, want := err.Error(), "failed to download"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
-		}
+		errcmp.MustMatch(t, err, "failed to download")
 	})
 
 	// Client only reads up to configured bytes limit
@@ -343,9 +338,7 @@ func TestServer_DownloadIndex(t *testing.T) {
 		_, err = s.downloadIndex(ctx, &mirrormodel.Mirror{
 			IndexFile: ts.URL,
 		})
-		if got, want := err.Error(), "response exceeds 1 bytes"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
-		}
+		errcmp.MustMatch(t, err, "response exceeds 1 bytes")
 	})
 
 	// Client handles empty index file

--- a/internal/publish/database/exposure_test.go
+++ b/internal/publish/database/exposure_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/publish/model"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 	pgx "github.com/jackc/pgx/v4"
 
 	"github.com/google/go-cmp/cmp"
@@ -328,11 +329,8 @@ func TestInsertAndReviseExposures_MissingRequest(t *testing.T) {
 	testDB, _ := testDatabaseInstance.NewDatabase(t)
 	pubDB := New(testDB)
 
-	if _, err := pubDB.InsertAndReviseExposures(ctx, nil); err == nil {
-		t.Fatal("missing error")
-	} else if !strings.Contains(err.Error(), "missing request") {
-		t.Fatalf("wrong error, want: %v got: %v", "missing request", err.Error())
-	}
+	_, err := pubDB.InsertAndReviseExposures(ctx, nil)
+	errcmp.MustMatch(t, err, "missing request")
 }
 
 func TestInsertAndReviseExposures_ConfigParadox(t *testing.T) {
@@ -347,11 +345,8 @@ func TestInsertAndReviseExposures_ConfigParadox(t *testing.T) {
 		OnlyRevisions: true,
 	}
 
-	if _, err := pubDB.InsertAndReviseExposures(ctx, req); err == nil {
-		t.Fatal("missing error")
-	} else if !strings.Contains(err.Error(), "configuration paradox") {
-		t.Fatalf("wrong error, want: %v got: %v", "configuration paradox", err.Error())
-	}
+	_, err := pubDB.InsertAndReviseExposures(ctx, req)
+	errcmp.MustMatch(t, err, "configuration paradox")
 }
 
 func TestReviseExposures(t *testing.T) {

--- a/internal/verification/authenticate_stats_test.go
+++ b/internal/verification/authenticate_stats_test.go
@@ -21,13 +21,13 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/verification/database"
 	"github.com/google/exposure-notifications-server/internal/verification/model"
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 
 	"github.com/dgrijalva/jwt-go"
 )
@@ -226,16 +226,7 @@ func TestAuthenticateStatsToken(t *testing.T) {
 			}
 
 			gotID, err := verifier.AuthenticateStatsToken(ctx, jwtString)
-
-			if err != nil {
-				if tc.Error == "" {
-					t.Fatalf("unexpected error: %v", err)
-				} else if !strings.Contains(err.Error(), tc.Error) {
-					t.Fatalf("wanted error '%v', got error '%v'", tc.Error, err.Error())
-				}
-			} else if tc.Error != "" {
-				t.Fatalf("wanted error '%v', but got nil", tc.Error)
-			}
+			errcmp.MustMatch(t, err, tc.Error)
 
 			if tc.Error == "" {
 				if gotID != healthAuthority.ID {

--- a/internal/verification/database/health_authority_db_test.go
+++ b/internal/verification/database/health_authority_db_test.go
@@ -16,12 +16,12 @@ package database
 
 import (
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/project"
 	"github.com/google/exposure-notifications-server/internal/verification/model"
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/google/go-cmp/cmp"
@@ -92,11 +92,8 @@ func TestAddHealthAuthorityErrors(t *testing.T) {
 			t.Parallel()
 
 			ctx := project.TestContext(t)
-			if err := haDB.AddHealthAuthority(ctx, tc.ha); err == nil {
-				t.Error("missing expected error")
-			} else if !strings.Contains(err.Error(), tc.want) {
-				t.Errorf("wrong error: want: %q got: %q", tc.want, err.Error())
-			}
+			err := haDB.AddHealthAuthority(ctx, tc.ha)
+			errcmp.MustMatch(t, err, tc.want)
 		})
 	}
 }

--- a/internal/verification/model/health_authority_test.go
+++ b/internal/verification/model/health_authority_test.go
@@ -15,10 +15,10 @@
 package model
 
 import (
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
 )
@@ -196,13 +196,8 @@ NTG3+oqI0Q6a3kPOuAAAupr373j7O1YXrM2KAix966EPwTNlK7YCcJa0m6PKz9DT
 			}
 
 			k, err := hak.PublicKey()
-			if err != nil {
-				if tc.msg == "" {
-					t.Errorf("unexpected error: %v", err)
-				} else if !strings.Contains(err.Error(), tc.msg) {
-					t.Errorf("missing error text: want '%v', got '%v'", tc.msg, err.Error())
-				}
-			} else if k == nil {
+			errcmp.MustMatch(t, err, tc.msg)
+			if err == nil && k == nil {
 				t.Errorf("ECDSA public key is unexpectedly nil")
 			}
 		})

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -25,7 +25,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +38,7 @@ import (
 
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/api/v1alpha1"
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 	utils "github.com/google/exposure-notifications-server/pkg/verification"
 )
 
@@ -250,15 +250,7 @@ func TestVerifyCertificate(t *testing.T) {
 						t.Fatal(err)
 					}
 					verifiedClaims, err := verifier.VerifyDiagnosisCertificate(ctx, authApp, &publish)
-					if err != nil {
-						if tc.Error == "" {
-							t.Fatalf("unexpected error: %v", err)
-						} else if !strings.Contains(err.Error(), tc.Error) {
-							t.Fatalf("wanted error '%v', got error '%v'", tc.Error, err.Error())
-						}
-					} else if tc.Error != "" {
-						t.Fatalf("wanted error '%v', but got nil", tc.Error)
-					}
+					errcmp.MustMatch(t, err, tc.Error)
 
 					if tc.Error == "" {
 						if verifiedClaims == nil {

--- a/pkg/api/v1/veritifcation_types_test.go
+++ b/pkg/api/v1/veritifcation_types_test.go
@@ -15,8 +15,9 @@
 package v1
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 )
 
 func TestValidateClaims(t *testing.T) {
@@ -25,11 +26,8 @@ func TestValidateClaims(t *testing.T) {
 	c := NewVerificationClaims()
 	c.ReportType = "bogus"
 
-	if err := c.CustomClaimsValid(); err == nil {
-		t.Fatal("expected an error, got nil")
-	} else if !strings.Contains(err.Error(), "bogus") {
-		t.Fatalf("wanted an error that contained bogus, got: %v", err)
-	}
+	err := c.CustomClaimsValid()
+	errcmp.MustMatch(t, err, "bogus")
 
 	for k := range ValidReportTypes {
 		c.ReportType = k

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -17,10 +17,10 @@ package cache
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -137,11 +137,8 @@ func TestWriteThruError(t *testing.T) {
 func TestInvalidDuration(t *testing.T) {
 	t.Parallel()
 
-	if _, err := New(-1 * time.Second); err == nil {
-		t.Fatal("expected error, got nil")
-	} else if !strings.Contains(err.Error(), "duration cannot be negative") {
-		t.Fatalf("wrong error: want: `duration cannot be negative` got: %v", err.Error())
-	}
+	_, err := New(-1 * time.Second)
+	errcmp.MustMatch(t, err, "duration cannot be negative")
 }
 
 func TestConcurrentReaders(t *testing.T) {

--- a/pkg/keys/ecdsa_pem_test.go
+++ b/pkg/keys/ecdsa_pem_test.go
@@ -19,8 +19,9 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"strings"
 	"testing"
+
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 )
 
 func TestParseECDSAPublicKey_DecodeError(t *testing.T) {
@@ -45,10 +46,5 @@ func TestParseECDSAPublicKey_WrongKeyType(t *testing.T) {
 	pemPublicKey := string(pemEncodedPub)
 
 	_, err = ParseECDSAPublicKey(pemPublicKey)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if want := "x509.ParsePKIXPublicKey"; !strings.Contains(err.Error(), want) {
-		t.Fatalf("wrong error, want: %q got: %q", want, err.Error())
-	}
+	errcmp.MustMatch(t, err, "x509.ParsePKIXPublicKey")
 }

--- a/pkg/keys/filesystem_test.go
+++ b/pkg/keys/filesystem_test.go
@@ -23,10 +23,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/google/exposure-notifications-server/internal/project"
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
 )
 
 func TestNewFilesystem(t *testing.T) {
@@ -177,15 +177,8 @@ func TestFilesystem_NewSigner(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if _, err := fs.NewSigner(ctx, tc.keyID); err != nil {
-				if tc.err == "" {
-					t.Fatal(err)
-				}
-
-				if !strings.Contains(err.Error(), tc.err) {
-					t.Fatalf("expected %#v to contain %#v", err.Error(), tc.err)
-				}
-			}
+			_, err = fs.NewSigner(ctx, tc.keyID)
+			errcmp.MustMatch(t, err, tc.err)
 		})
 	}
 }
@@ -284,15 +277,7 @@ func TestFilesystem_EncryptDecrypt(t *testing.T) {
 			}
 
 			ciphertext, err := fs.Encrypt(ctx, tc.keyID, tc.plaintext, tc.aad)
-			if err != nil {
-				if tc.err == "" {
-					t.Fatal(err)
-				}
-
-				if !strings.Contains(err.Error(), tc.err) {
-					t.Fatalf("expected %#v to contain %#v", err.Error(), tc.err)
-				}
-			}
+			errcmp.MustMatch(t, err, tc.err)
 
 			if len(ciphertext) > 0 {
 				// Create another key version - this will ensure our ciphertext -> key
@@ -400,15 +385,7 @@ func TestFilesystem_SigningKeyVersions(t *testing.T) {
 			}
 
 			versions, err := fst.SigningKeyVersions(ctx, tc.keyID)
-			if err != nil {
-				if tc.err == "" {
-					t.Fatal(err)
-				}
-
-				if !strings.Contains(err.Error(), tc.err) {
-					t.Fatalf("expected %#v to contain %#v", err.Error(), tc.err)
-				}
-			}
+			errcmp.MustMatch(t, err, tc.err)
 
 			if got, want := len(versions), tc.exp; got != want {
 				t.Errorf("expected %d version to be %d", got, want)


### PR DESCRIPTION
## Proposed Changes

* use errcmp instead of a bunch of custom error checkers

**Release Note**

```release-note
NONE
```