### PR TITLE
Get Cloud SQL Proxy from new link

### DIFF
--- a/builders/migrate.dockerfile
+++ b/builders/migrate.dockerfile
@@ -15,7 +15,7 @@
 FROM alpine
 RUN apk add --no-cache bash
 
-ADD https://storage.googleapis.com/cloudsql-proxy/v1.19.1/cloud_sql_proxy.linux.amd64 /cloud-sql-proxy
+ADD https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 /cloud-sql-proxy
 COPY ./bin/migrate /migrate
 COPY ./builders/cloud-sql-exec /cloud-sql-exec
 COPY ./migrations /migrations


### PR DESCRIPTION
The old one went away :(

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Get Cloud SQL Proxy from new link in migrate
```