### PR TITLE
enforce that STATS_UPLOAD_MINIMUM is set to a value >= 10

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -125,6 +125,11 @@ func (c *Config) Validate() error {
 			fmt.Errorf("env var `MAX_VALID_SYMPTOM_ONSET_REPORT_DAYS` must be > 0, got: %v", c.MaxSymptomOnsetReportDays))
 	}
 
+	if c.StatsUploadMinimum < 10 {
+		result = multierror.Append(result,
+			fmt.Errorf("env var `STATS_UPLOAD_MINIMUM` must be >= 10, got: %v", c.StatsUploadMinimum))
+	}
+
 	return result.ErrorOrNil()
 }
 

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -463,6 +463,7 @@ func TestPublishWithBypass(t *testing.T) {
 				config.MaxKeysOnPublish = 20
 				config.MaxSameStartIntervalKeys = 2
 				config.MaxIntervalAge = 14 * 24 * time.Hour
+				config.StatsUploadMinimum = 10
 				aaProvider, err := authorizedapp.NewDatabaseProvider(ctx, testDB, config.AuthorizedAppConfig())
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION

## Proposed Changes

* enforce that STATS_UPLOAD_MINIMUM is set to a value >= 10


**Release Note**

```release-note
enforce that STATS_UPLOAD_MINIMUM is set to a value >= 10
```