### PR TITLE
Fixing key revision probability for generate and adding a report type confirmed override

### DIFF
--- a/internal/generate/config.go
+++ b/internal/generate/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	ChanceOfTraveler             int           `env:"CHANCE_OF_TRAVELER, default=20"`     // 0-100 are valid values
 	KeyRevisionDelay             time.Duration `env:"KEY_REVISION_DELAY, default=2h"`     // key revision will be forward dates this amount.
 	SymptomOnsetDaysAgo          uint          `env:"DEFAULT_SYMPTOM_ONSET_DAYS_AGO, default=4"`
+	ForceConfirmed               bool          `env:"FORCE_CONFIRMED, default=false"` // force report type to be confirmed for all exposures
 }
 
 func (c *Config) MaxExposureKeys() uint {

--- a/internal/generate/handle_generate.go
+++ b/internal/generate/handle_generate.go
@@ -137,7 +137,11 @@ func (s *Server) generateKeysInRegion(ctx context.Context, region string) error 
 
 		reportType := verifyapi.ReportTypeClinical
 		if !generateRevisedKeys {
-			reportType, err = util.RandomReportType()
+			if forceConfirmed := s.config.ForceConfirmed; forceConfirmed {
+				reportType = verifyapi.ReportTypeConfirmed
+			} else {
+				reportType, err = util.RandomReportType()
+			}
 			if err != nil {
 				return fmt.Errorf("failed to generate report type: %w", err)
 			}

--- a/internal/generate/handle_generate.go
+++ b/internal/generate/handle_generate.go
@@ -137,7 +137,7 @@ func (s *Server) generateKeysInRegion(ctx context.Context, region string) error 
 
 		reportType := verifyapi.ReportTypeClinical
 		if !generateRevisedKeys {
-			if forceConfirmed := s.config.ForceConfirmed; forceConfirmed {
+			if s.config.ForceConfirmed {
 				reportType = verifyapi.ReportTypeConfirmed
 			} else {
 				reportType, err = util.RandomReportType()

--- a/internal/generate/handle_generate.go
+++ b/internal/generate/handle_generate.go
@@ -133,7 +133,7 @@ func (s *Server) generateKeysInRegion(ctx context.Context, region string) error 
 		if err != nil {
 			return fmt.Errorf("failed to decide revised key status: %w", err)
 		}
-		generateRevisedKeys := val <= s.config.ChanceOfKeyRevision
+		generateRevisedKeys := val < s.config.ChanceOfKeyRevision
 
 		reportType := verifyapi.ReportTypeClinical
 		if !generateRevisedKeys {

--- a/internal/generate/handle_generate.go
+++ b/internal/generate/handle_generate.go
@@ -141,9 +141,9 @@ func (s *Server) generateKeysInRegion(ctx context.Context, region string) error 
 				reportType = verifyapi.ReportTypeConfirmed
 			} else {
 				reportType, err = util.RandomReportType()
-			}
-			if err != nil {
-				return fmt.Errorf("failed to generate report type: %w", err)
+				if err != nil {
+					return fmt.Errorf("failed to generate report type: %w", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes

* Check that the random value is < ChanceOfKeyRevision, not <= so that a chance of 0 really is 0 instead of 1/100
* Add env variable FORCE_CONFIRMED so that an exact number of exposures/keys can can be published

**Release Note**

```release-note
Fixing key revision probability for generate and adding a report type confirmed override
```