### PR TITLE
Set project_id on monitoring service enablement

### DIFF
--- a/terraform/alerting/main.tf
+++ b/terraform/alerting/main.tf
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 resource "google_project_service" "services" {
+  project = var.project
+
   for_each = toset([
     "monitoring.googleapis.com",
   ])


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```