### PR TITLE
Upgrade to Go 1.16

### DIFF
--- a/.github/workflows/codereview.yaml
+++ b/.github/workflows/codereview.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.36.0
+          version: v1.37
           only-new-issues: true
 
   reviewdog:

--- a/.github/workflows/codereview.yaml
+++ b/.github/workflows/codereview.yaml
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15'
+          go-version: '1.16'
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/codereview.yaml
+++ b/.github/workflows/codereview.yaml
@@ -14,10 +14,24 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: lint
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.37
+          skip-go-installation: true
           only-new-issues: true
 
   reviewdog:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Each binary will have its `main.go` file in a `/cmd/[bin-name]` folder.
 
 To run the server, you must install the following dependencies:
 
-1.  [Go 1.15.2 or newer](https://golang.org/dl/).
+1.  [Go 1.16 or newer](https://golang.org/dl/).
 
 1.  [Docker][docker].
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ MD_FILES = $(shell find . -name \*.md)
 # locally. There is a chance that CI detects linter errors that are not found
 # locally, but it should be rare.
 lint:
-	@command -v golangci-lint > /dev/null 2>&1 || GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.36.0
+	@command -v golangci-lint > /dev/null 2>&1 || GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.37.1
 	golangci-lint run --config .golangci.yaml
 .PHONY: lint
 

--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -48,7 +48,7 @@ steps:
   - '-allow-failure'
 
 - id: 'download-modules'
-  name: 'golang:1.15.2'
+  name: 'golang:1.16'
   args:
   - 'go'
   - 'install'
@@ -75,7 +75,7 @@ steps:
   - 'bin'
 
 - id: 'build'
-  name: 'golang:1.15.2'
+  name: 'golang:1.16'
   args:
   - 'go'
   - 'build'

--- a/cmd/admin-console/main.go
+++ b/cmd/admin-console/main.go
@@ -18,17 +18,18 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/admin"
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/cleanup-export/main.go
+++ b/cmd/cleanup-export/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/cleanup"
@@ -26,11 +28,10 @@ import (
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
 	"github.com/gorilla/mux"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/cleanup-exposure/main.go
+++ b/cmd/cleanup-exposure/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/cleanup"
@@ -26,11 +28,10 @@ import (
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
 	"github.com/gorilla/mux"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/debugger/main.go
+++ b/cmd/debugger/main.go
@@ -18,17 +18,18 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/debugger"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/export-importer/main.go
+++ b/cmd/export-importer/main.go
@@ -18,17 +18,18 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/exportimport"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/export/main.go
+++ b/cmd/export/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/export"
@@ -25,11 +27,10 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/exposure/main.go
+++ b/cmd/exposure/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/publish"
@@ -25,11 +27,10 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/federationin/main.go
+++ b/cmd/federationin/main.go
@@ -19,17 +19,18 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/federationin"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/federationout/main.go
+++ b/cmd/federationout/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -31,11 +33,10 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -19,6 +19,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/generate"
@@ -26,11 +28,10 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/jwks/main.go
+++ b/cmd/jwks/main.go
@@ -19,17 +19,18 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/jwks"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/key-rotation/main.go
+++ b/cmd/key-rotation/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/keyrotation"
@@ -25,11 +27,10 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	_ "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -28,7 +30,6 @@ import (
 	"github.com/google/exposure-notifications-server/internal/database"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/logging"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 var (
@@ -39,7 +40,7 @@ var (
 func main() {
 	flag.Parse()
 
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/cmd/mirror/main.go
+++ b/cmd/mirror/main.go
@@ -18,17 +18,18 @@ package main
 import (
 	"context"
 	"fmt"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/internal/mirror"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/server"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).

--- a/docker/presubmit-test.dockerfile
+++ b/docker/presubmit-test.dockerfile
@@ -19,12 +19,6 @@ FROM golang:1.16
 # Install sudo
 RUN apt-get update -yqq && apt-get install -yqq sudo unzip
 
-# Install terraform
-RUN wget -q https://releases.hashicorp.com/terraform/0.14.2/terraform_0.14.2_linux_amd64.zip \
-  && unzip terraform_0.14.2_linux_amd64.zip \
-  && mv terraform /usr/bin \
-  && rm terraform_0.14.2_linux_amd64.zip
-
 # Install jq
 RUN curl -o /usr/bin/jq http://stedolan.github.io/jq/download/linux64/jq \
   && chmod +x /usr/bin/jq

--- a/docker/presubmit-test.dockerfile
+++ b/docker/presubmit-test.dockerfile
@@ -14,7 +14,7 @@
 
 # This image is used to run ./scripts/presubmit.sh on CI
 
-FROM golang:1.15.2
+FROM golang:1.16
 
 # Install sudo
 RUN apt-get update -yqq && apt-get install -yqq sudo unzip

--- a/docker/protoc.dockerfile
+++ b/docker/protoc.dockerfile
@@ -14,7 +14,7 @@
 
 # protoc is a base container with protoc and protoc-gen-go installed.
 
-FROM golang:1.15.2 AS builder
+FROM golang:1.16 AS builder
 
 ENV PROTOC_VERSION "3.11.4"
 ENV PROTOC_GEN_GO_VERSION "1.4.1"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/exposure-notifications-server
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go v0.76.0

--- a/internal/debugger/handler_debug.go
+++ b/internal/debugger/handler_debug.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -219,7 +219,7 @@ func cloudRunEnv(ctx context.Context, name string) (map[string]string, error) {
 	defer serviceResp.Body.Close()
 
 	if serviceResp.StatusCode != 200 {
-		b, _ := ioutil.ReadAll(serviceResp.Body)
+		b, _ := io.ReadAll(serviceResp.Body)
 		return nil, fmt.Errorf("failed to lookup service: %d: %s", serviceResp.StatusCode, b)
 	}
 
@@ -242,7 +242,7 @@ func cloudRunEnv(ctx context.Context, name string) (map[string]string, error) {
 	defer revisionResp.Body.Close()
 
 	if revisionResp.StatusCode != 200 {
-		b, _ := ioutil.ReadAll(revisionResp.Body)
+		b, _ := io.ReadAll(revisionResp.Body)
 		return nil, fmt.Errorf("failed to lookup revision: %d: %s", revisionResp.StatusCode, b)
 	}
 

--- a/internal/export/exportfile.go
+++ b/internal/export/exportfile.go
@@ -21,7 +21,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sort"
 
 	"github.com/google/exposure-notifications-server/internal/export/model"
@@ -118,7 +118,7 @@ func unmarshalContent(file *zip.File) (*export.TemporaryExposureKeyExport, []byt
 	}
 	defer f.Close()
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -272,7 +272,7 @@ func unmarshalSignatureContent(file *zip.File) (*export.TEKSignatureList, error)
 	}
 	defer f.Close()
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/exportimport/import.go
+++ b/internal/exportimport/import.go
@@ -20,7 +20,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -89,7 +89,7 @@ func (s *Server) ImportExportFile(ctx context.Context, ir *ImportRequest) (*Impo
 	}
 
 	defer resp.Body.Close()
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading file: %w", err)
 	}

--- a/internal/exportimport/scheduler.go
+++ b/internal/exportimport/scheduler.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -92,7 +92,7 @@ func (s *Server) handleSchedule() http.Handler {
 			}
 
 			defer resp.Body.Close()
-			bytes, err := ioutil.ReadAll(resp.Body)
+			bytes, err := io.ReadAll(resp.Body)
 			if err != nil {
 				anyErrors = true
 				logger.Errorw("unable to read index file", "file", config.IndexFile, "error", err)

--- a/internal/federationin/federationin.go
+++ b/internal/federationin/federationin.go
@@ -21,8 +21,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -133,7 +133,7 @@ func (s *Server) handleSync() http.Handler {
 		}
 
 		if s.config.TLSCertFile != "" {
-			b, err := ioutil.ReadFile(s.config.TLSCertFile)
+			b, err := os.ReadFile(s.config.TLSCertFile)
 			if err != nil {
 				internalErrorf(ctx, w, "Failed to read cert file %q: %v", s.config.TLSCertFile, err)
 				return

--- a/internal/integration/client.go
+++ b/internal/integration/client.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -185,7 +185,7 @@ func (c *client) do(req *http.Request, out interface{}) (*http.Response, error) 
 
 	errPrefix := fmt.Sprintf("%s %s - %d", strings.ToUpper(req.Method), req.URL.String(), resp.StatusCode)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed to read body: %w", errPrefix, err)
 	}

--- a/internal/jsonutil/unmarshal_test.go
+++ b/internal/jsonutil/unmarshal_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -50,7 +50,7 @@ func TestBodyTooLarge(t *testing.T) {
 func TestInvalidHeader(t *testing.T) {
 	t.Parallel()
 
-	body := ioutil.NopCloser(bytes.NewReader([]byte("")))
+	body := io.NopCloser(bytes.NewReader([]byte("")))
 	r := httptest.NewRequest("POST", "/", body)
 	r.Header.Set("content-type", "application/text")
 
@@ -153,7 +153,7 @@ func TestValidPublishMessage(t *testing.T) {
     "VerificationPayload": "1234-ABCD-EFGH-5678"}`
 	json = fmt.Sprintf(json, intervalNumber, intervalNumber, intervalNumber)
 
-	body := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+	body := io.NopCloser(bytes.NewReader([]byte(json)))
 	r := httptest.NewRequest("POST", "/", body)
 	r.Header.Set("content-type", "application/json")
 
@@ -186,7 +186,7 @@ func TestValidPublishMessage(t *testing.T) {
 func unmarshalTestHelper(t *testing.T, payloads []string, errors []string, expCode int) {
 	t.Helper()
 	for i, testStr := range payloads {
-		body := ioutil.NopCloser(bytes.NewReader([]byte(testStr)))
+		body := io.NopCloser(bytes.NewReader([]byte(testStr)))
 		r := httptest.NewRequest("POST", "/", body)
 		r.Header.Set("content-type", "application/json; charset=utf-8")
 

--- a/internal/jwks/jwks.go
+++ b/internal/jwks/jwks.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"sort"
@@ -94,7 +94,7 @@ func (mgr *Manager) getKeys(ctx context.Context, ha *model.HealthAuthority) ([]b
 	}
 
 	var bytes []byte
-	bytes, err = ioutil.ReadAll(resp.Body)
+	bytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading: %w", err)
 	}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -570,7 +570,7 @@ func TestPublishWithBypass(t *testing.T) {
 
 				// For non success status, check that they body contains the expected message
 				defer resp.Body.Close()
-				respBytes, err := ioutil.ReadAll(resp.Body)
+				respBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1084,7 +1084,7 @@ func TestKeyRevision(t *testing.T) {
 
 				// For non success status, check that they body contains the expected message
 				defer resp.Body.Close()
-				respBytes, err := ioutil.ReadAll(resp.Body)
+				respBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -1148,7 +1148,7 @@ func TestKeyRevision(t *testing.T) {
 
 				// For non success status, check that they body contains the expected message
 				defer resp.Body.Close()
-				respBytes, err := ioutil.ReadAll(resp.Body)
+				respBytes, err := io.ReadAll(resp.Body)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/internal/publish/stats_test.go
+++ b/internal/publish/stats_test.go
@@ -18,7 +18,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -152,7 +152,7 @@ func TestRetrieveMetrics(t *testing.T) {
 	resp := rr.Result()
 
 	defer resp.Body.Close()
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +304,7 @@ func TestRetrieveMetrics_AuthErrors(t *testing.T) {
 			resp := rr.Result()
 
 			defer resp.Body.Close()
-			respBytes, err := ioutil.ReadAll(resp.Body)
+			respBytes, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -15,7 +15,6 @@
 package setup_test
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -91,7 +90,7 @@ func (t *testConfig) ObservabilityExporterConfig() *observability.Config {
 func TestSetupWith(t *testing.T) {
 	t.Parallel()
 
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/aws_s3.go
+++ b/internal/storage/aws_s3.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -107,7 +107,7 @@ func (s *AWSS3) GetObject(ctx context.Context, bucket, key string) ([]byte, erro
 	}
 	defer o.Body.Close()
 
-	b, err := ioutil.ReadAll(o.Body)
+	b, err := io.ReadAll(o.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read object: %w", err)
 	}

--- a/internal/storage/filesystem_storage.go
+++ b/internal/storage/filesystem_storage.go
@@ -18,7 +18,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -45,7 +44,7 @@ func NewFilesystemStorage(ctx context.Context, _ *Config) (Blobstore, error) {
 // contentType is ignored for this storage implementation.
 func (s *FilesystemStorage) CreateObject(ctx context.Context, folder, filename string, contents []byte, cacheable bool, contentType string) error {
 	pth := filepath.Join(folder, filename)
-	if err := ioutil.WriteFile(pth, contents, 0o600); err != nil {
+	if err := os.WriteFile(pth, contents, 0o600); err != nil {
 		return fmt.Errorf("failed to create object: %w", err)
 	}
 	return nil
@@ -65,7 +64,7 @@ func (s *FilesystemStorage) DeleteObject(ctx context.Context, folder, filename s
 // exist, it returns ErrNotFound.
 func (s *FilesystemStorage) GetObject(ctx context.Context, folder, filename string) ([]byte, error) {
 	pth := filepath.Join(folder, filename)
-	b, err := ioutil.ReadFile(pth)
+	b, err := os.ReadFile(pth)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, ErrNotFound

--- a/internal/storage/filesystem_storage_test.go
+++ b/internal/storage/filesystem_storage_test.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +26,7 @@ import (
 func TestFilesystemStorage_CreateObject(t *testing.T) {
 	t.Parallel()
 
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +73,7 @@ func TestFilesystemStorage_CreateObject(t *testing.T) {
 			}
 
 			if !tc.err {
-				contents, err := ioutil.ReadFile(filepath.Join(tc.folder, tc.filepath))
+				contents, err := os.ReadFile(filepath.Join(tc.folder, tc.filepath))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -90,7 +89,7 @@ func TestFilesystemStorage_CreateObject(t *testing.T) {
 func TestFilesystemStorage_DeleteObject(t *testing.T) {
 	t.Parallel()
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +134,7 @@ func TestFilesystemStorage_DeleteObject(t *testing.T) {
 func TestFilesystemStorage_GetObject(t *testing.T) {
 	t.Parallel()
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/google_cloud_storage_test.go
+++ b/internal/storage/google_cloud_storage_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -170,7 +169,7 @@ func TestGoogleCloudStorage_CreateObject(t *testing.T) {
 				}
 				defer r.Close()
 
-				contents, err := ioutil.ReadAll(r)
+				contents, err := io.ReadAll(r)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/keys/filesystem_test.go
+++ b/pkg/keys/filesystem_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -76,7 +75,7 @@ func TestNewFilesystem(t *testing.T) {
 	t.Run("root_absolute", func(t *testing.T) {
 		t.Parallel()
 
-		tmp, err := ioutil.TempDir("", "")
+		tmp, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -127,7 +126,7 @@ func TestFilesystem_NewSigner(t *testing.T) {
 			keyID: "banana",
 			setup: func(dir string) error {
 				pth := filepath.Join(dir, "banana")
-				return ioutil.WriteFile(pth, []byte("dafd"), 0o600)
+				return os.WriteFile(pth, []byte("dafd"), 0o600)
 			},
 			err: "failed to parse signing key",
 		},
@@ -145,7 +144,7 @@ func TestFilesystem_NewSigner(t *testing.T) {
 				}
 
 				pth := filepath.Join(dir, "apple")
-				return ioutil.WriteFile(pth, b, 0o600)
+				return os.WriteFile(pth, b, 0o600)
 			},
 		},
 	}
@@ -158,7 +157,7 @@ func TestFilesystem_NewSigner(t *testing.T) {
 
 			ctx := project.TestContext(t)
 
-			dir, err := ioutil.TempDir("", "")
+			dir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -253,7 +252,7 @@ func TestFilesystem_EncryptDecrypt(t *testing.T) {
 
 			ctx := project.TestContext(t)
 
-			dir, err := ioutil.TempDir("", "")
+			dir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -361,7 +360,7 @@ func TestFilesystem_SigningKeyVersions(t *testing.T) {
 
 			ctx := project.TestContext(t)
 
-			dir, err := ioutil.TempDir("", "")
+			dir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/keys/testing.go
+++ b/pkg/keys/testing.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -29,7 +28,7 @@ func TestKeyManager(tb testing.TB) KeyManager {
 
 	ctx := context.Background()
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/pkg/secrets/resolver.go
+++ b/pkg/secrets/resolver.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -109,7 +108,7 @@ func (r *secretResolver) resolve(ctx context.Context, envName, secretRef string)
 
 		secretFileName := r.filenameForSecret(envName + "." + secretRef)
 		secretFilePath := filepath.Join(r.dir, secretFileName)
-		if err := ioutil.WriteFile(secretFilePath, []byte(secretVal), 0o600); err != nil {
+		if err := os.WriteFile(secretFilePath, []byte(secretVal), 0o600); err != nil {
 			return "", fmt.Errorf("failed to write secret file for %q: %w", envName, err)
 		}
 

--- a/pkg/secrets/resolver_test.go
+++ b/pkg/secrets/resolver_test.go
@@ -15,7 +15,6 @@
 package secrets
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -36,7 +35,7 @@ func TestResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/export-analyzer/main.go
+++ b/tools/export-analyzer/main.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -104,7 +103,7 @@ type analysis struct {
 }
 
 func analyzeOne(pth string, includeSig, includeExport bool) (*analysis, error) {
-	blob, err := ioutil.ReadFile(pth)
+	blob, err := os.ReadFile(pth)
 	if err != nil {
 		return nil, fmt.Errorf("can't read export file: %w", err)
 	}

--- a/tools/export-generate/main.go
+++ b/tools/export-generate/main.go
@@ -24,9 +24,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
+	"os"
 	"time"
 
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
@@ -96,7 +96,7 @@ func main() {
 	var exposureKeys []publishmodel.Exposure
 	if *tekFile != "" {
 		log.Printf("Using TEKs provided in: %s", *tekFile)
-		file, err := ioutil.ReadFile(*tekFile)
+		file, err := os.ReadFile(*tekFile)
 		if err != nil {
 			log.Fatalf("unable to read file: %v", err)
 		}
@@ -211,14 +211,14 @@ func (e *exportFileWriter) writeFile() {
 	}
 	fileName := fmt.Sprintf(e.exportBatch.FilenameRoot+"%d-records-%d-of-%d"+filenameSuffix, e.totalKeys, e.curBatch, e.numBatches)
 	log.Printf("Creating %v", fileName)
-	err = ioutil.WriteFile(fileName, data, 0o600)
+	err = os.WriteFile(fileName, data, 0o600)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
 func getSigningKey(fileName string) (*ecdsa.PrivateKey, error) {
-	keyBytes, _ := ioutil.ReadFile(fileName)
+	keyBytes, _ := os.ReadFile(fileName)
 	return ParseECPrivateKeyFromPEM(keyBytes)
 }
 

--- a/tools/export-viz/main.go
+++ b/tools/export-viz/main.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -50,7 +49,7 @@ func realMain() error {
 		return fmt.Errorf("--file is required")
 	}
 
-	blob, err := ioutil.ReadFile(*filePath)
+	blob, err := os.ReadFile(*filePath)
 	if err != nil {
 		return fmt.Errorf("can't read export file: %w", err)
 	}

--- a/tools/exposure-client/main.go
+++ b/tools/exposure-client/main.go
@@ -23,16 +23,16 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/util"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 var (
@@ -44,7 +44,7 @@ var (
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().
 		With("build_id", buildinfo.BuildID).
@@ -122,7 +122,7 @@ func sendRequest(ctx context.Context, data io.Reader) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read body: %w", err)
 	}

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -22,8 +22,10 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"os/signal"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"time"
 
 	authorizedappdatabase "github.com/google/exposure-notifications-server/internal/authorizedapp/database"
@@ -35,12 +37,10 @@ import (
 	verificationmodel "github.com/google/exposure-notifications-server/internal/verification/model"
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/logging"
-
-	"github.com/sethvargo/go-signalcontext"
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().Named("tools.seed")
 	logger = logger.With("build_id", buildinfo.BuildID)

--- a/tools/sign/main.go
+++ b/tools/sign/main.go
@@ -24,6 +24,8 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
@@ -31,13 +33,12 @@ import (
 	"github.com/google/exposure-notifications-server/internal/export/database"
 	"github.com/google/exposure-notifications-server/internal/setup"
 	"github.com/google/exposure-notifications-server/pkg/logging"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 var messageToSign = flag.String("message", "hello world", "string message to sign")
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().Named("tools.sign")
 	logger = logger.With("build_id", buildinfo.BuildID)

--- a/tools/unwrap-signature/main.go
+++ b/tools/unwrap-signature/main.go
@@ -18,8 +18,8 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/google/exposure-notifications-server/internal/pb/export"
 	"google.golang.org/protobuf/proto"
@@ -40,7 +40,7 @@ func main() {
 		log.Fatalf("no out file passed in, --out")
 	}
 
-	inData, err := ioutil.ReadFile(*inFile)
+	inData, err := os.ReadFile(*inFile)
 	if err != nil {
 		log.Fatalf("unable to read input file: %v", err)
 	}
@@ -53,7 +53,7 @@ func main() {
 	log.Printf("Data: \n%v", teksl)
 	sig := teksl.Signatures[0].Signature
 
-	err = ioutil.WriteFile(*outFile, sig, 0o600)
+	err = os.WriteFile(*outFile, sig, 0o600)
 	if err != nil {
 		log.Fatalf("unable to write output file: %v", err)
 	}

--- a/tools/verify/main.go
+++ b/tools/verify/main.go
@@ -22,14 +22,15 @@ import (
 	"encoding/base64"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/google/exposure-notifications-server/internal/buildinfo"
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/logging"
-	"github.com/sethvargo/go-signalcontext"
 )
 
 var (
@@ -40,7 +41,7 @@ var (
 )
 
 func main() {
-	ctx, done := signalcontext.OnInterrupt()
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 
 	logger := logging.NewLoggerFromEnv().Named("tools.verify")
 	logger = logger.With("build_id", buildinfo.BuildID)
@@ -74,7 +75,7 @@ func realMain(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("--signature must be base64 encoded, error: %w", err)
 	}
-	pemBytes, err := ioutil.ReadFile(*pemFileFlag)
+	pemBytes, err := os.ReadFile(*pemFileFlag)
 	if err != nil {
 		return fmt.Errorf("--pem-file could not be read: %w", err)
 	}


### PR DESCRIPTION
- Replace signalcontext with stdlib
- Replace ioutil with stdlib

Part of https://github.com/google/exposure-notifications-server/issues/1386, but I didn't include the `embed` things.

Needs to merge before https://github.com/google/exposure-notifications-verification-server/pull/1865 to make Prow happy.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Upgrade to Go 1.16
```