### PR TITLE
Give admin-console signerVerify

### DIFF
--- a/terraform/service_admin_console.tf
+++ b/terraform/service_admin_console.tf
@@ -58,6 +58,12 @@ resource "google_project_iam_member" "admin-console-observability" {
   member  = "serviceAccount:${google_service_account.admin-console.email}"
 }
 
+resource "google_kms_key_ring_iam_member" "admin-console-signerverifier" {
+  key_ring_id = google_kms_key_ring.export-signing.self_link
+  role        = "roles/cloudkms.signerVerifier"
+  member      = "serviceAccount:${google_service_account.admin-console.email}"
+}
+
 resource "google_cloud_run_service" "admin-console" {
   name     = "admin-console"
   location = var.cloudrun_location


### PR DESCRIPTION
This is required for signing the "hello world" string.

Fixes https://github.com/google/exposure-notifications-server/issues/1394

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Give admin-console signerVerify permissions to sign "hello world" string during new export configuration
```