### PR TITLE
Use more structured logging for errors

### DIFF
--- a/internal/debugger/handler_debug.go
+++ b/internal/debugger/handler_debug.go
@@ -158,7 +158,7 @@ func (s *Server) handleDebug() http.Handler {
 		// Marshall the json.
 		b, err := json.MarshalIndent(resp, "", "  ")
 		if err != nil {
-			logger.Errorf("failed to marshal json: %v", err)
+			logger.Errorw("failed to marshal json", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprint(w, http.StatusText(http.StatusInternalServerError))
 			return

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -73,7 +73,7 @@ func (s *Server) handleDoWork() http.Handler {
 			// Check for a batch and obtain a lease for it.
 			batch, err := exportdatabase.New(db).LeaseBatch(ctx, s.config.WorkerTimeout, time.Now())
 			if err != nil {
-				logger.Errorf("Failed to lease batch: %v", err)
+				logger.Errorw("failed to lease batch", "error", err)
 				continue
 			}
 			if batch == nil {
@@ -133,7 +133,7 @@ func (s *Server) handleDoWork() http.Handler {
 
 			// Ensure that the locks are released on either success or failure path.
 			if err = s.exportBatch(ctx, batch, emitIndexForEmptyBatch); err != nil {
-				logger.Errorf("Failed to create files for batch: %v.", err)
+				logger.Errorw("failed to create files for batch", "error", err)
 				unlock()
 				continue
 			}
@@ -202,7 +202,7 @@ func (s *Server) batchExposures(ctx context.Context, criteria publishdatabase.It
 	}
 
 	if droppedKeys > 0 {
-		logger.Errorf("Export found keys of invalid length, %v keys were dropped", droppedKeys)
+		logger.Errorw("export found keys of invalid length", "dropped_keys", droppedKeys)
 		stats.Record(ctx, mWorkerBadKeyLength.M(int64(droppedKeys)))
 	}
 

--- a/internal/mirror/mirror.go
+++ b/internal/mirror/mirror.go
@@ -195,7 +195,6 @@ func (s *Server) processMirror(ctx context.Context, deadline time.Time, mirror *
 			func() {
 				localFilename := filename
 				if status.MirrorFile != nil && status.MirrorFile.LocalFilename != nil {
-					// TODO(sethvargo): empty string "" check was not here before
 					val := *status.MirrorFile.LocalFilename
 					if val != "" {
 						localFilename = val

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -295,7 +295,8 @@ func (s *Server) process(ctx context.Context, data *verifyapi.Publish, platform 
 	// generous defaults. If there isn't a region set, then the TEKs
 	// won't be retrievable, so we ensure there is something set.
 	if len(regions) == 0 {
-		logger.Errorf("No regions present in request or configured for HealthAuthorityID: %v", data.HealthAuthorityID)
+		logger.Errorw("no regions present in request or configured for HealthAuthorityID",
+			"health_authority_id", data.HealthAuthorityID)
 		message := fmt.Sprintf("unknown health authority regions for %v", data.HealthAuthorityID)
 		span.SetStatus(trace.Status{Code: trace.StatusCodePermissionDenied, Message: message})
 		blame = obs.BlameClient
@@ -341,11 +342,11 @@ func (s *Server) process(ctx context.Context, data *verifyapi.Publish, platform 
 	if len(data.RevisionToken) != 0 {
 		encryptedToken, err := base64util.DecodeString(data.RevisionToken)
 		if err != nil {
-			logger.Errorf("unable to decode revision token, proceeding without: %v", err)
+			logger.Warnw("failed to decode revision token, proceeding without", "error", err)
 		} else {
 			token, err = s.tokenManager.UnmarshalRevisionToken(ctx, encryptedToken, s.tokenAAD)
 			if err != nil {
-				logger.Errorf("unable to unmarshall / decrypt revision token. Treating as if none was provided: %v", err)
+				logger.Errorw("failed to unmarshal revision token, treating as if none was provided", "error", err)
 				token = nil // just in case.
 				decryptFail = true
 			}
@@ -454,7 +455,7 @@ func (s *Server) process(ctx context.Context, data *verifyapi.Publish, platform 
 	if err != nil {
 		// In this case, an empty revision token is returned. The rest of the request
 		// was handled correctly.
-		logger.Errorf("unable to make new revision token: %v", err)
+		logger.Errorw("failed to make new revision token", "error", err)
 		newToken = make([]byte, 0)
 	}
 

--- a/internal/revision/database/revision.go
+++ b/internal/revision/database/revision.go
@@ -105,7 +105,7 @@ func (rdb *RevisionDB) DestroyKey(ctx context.Context, keyID int64) error {
 		}
 		return nil
 	}); err != nil {
-		logger.Errorf("failed to destroy revision kid: %v: %v", keyID, err)
+		logger.Errorw("failed to destroy revision key", "kid", keyID, "error", err)
 	}
 	return nil
 }
@@ -206,7 +206,8 @@ func (rdb *RevisionDB) GetAllowedRevisionKeys(ctx context.Context) (int64, []*Re
 	for _, wk := range keys {
 		unwrapped, err := rdb.decrypt(ctx, wk.WrappedCipher, wk.AAD)
 		if err != nil {
-			logger.Errorf("still allowed revision key that can't be unwrapped: kid: %v error: %v", wk.KeyID, err)
+			logger.Errorw("still allowed revision key that can't be unwrapped",
+				"kid", wk.KeyID, "error", err)
 			return 0, nil, fmt.Errorf("unable to unwrap revision key: %w", err)
 		}
 		wk.DEK = unwrapped

--- a/internal/revision/revision.go
+++ b/internal/revision/revision.go
@@ -121,14 +121,14 @@ func (tm *TokenManager) maybeRefreshCache(ctx context.Context) error {
 
 	effectiveID, allowed, err := tm.db.GetAllowedRevisionKeys(ctx)
 	if err != nil {
-		logger.Errorf("unable to read revision keys: %v", err)
+		logger.Errorw("failed to read revision keys", "error", err)
 		return fmt.Errorf("reading revision key cache: %w", err)
 	}
 
 	// To aid in system upgrade, assuming env vars are setup correctly,
 	// we autocreate the first wrapped revision key.
 	if len(allowed) == 0 {
-		logger.Errorf("no revision keys exist - creating one.")
+		logger.Info("creating revision key")
 		rk, err := tm.db.CreateRevisionKey(ctx)
 		if err != nil {
 			return fmt.Errorf("unable to bootstrap revision keys: %w", err)

--- a/tools/verify/main.go
+++ b/tools/verify/main.go
@@ -101,7 +101,7 @@ func realMain(ctx context.Context) error {
 	if ecdsa.VerifyASN1(publicKey, digest, signature) {
 		logger.Infof("SIGNATURE IS VALID")
 	} else {
-		logger.Errorf("SIGNATURE IS NOT VALID")
+		return fmt.Errorf("signature is NOT valid")
 	}
 
 	return nil


### PR DESCRIPTION
No behavior changes, just making logs more searchable.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Use more structured logging for errors
```