### PR TITLE
Remove debugger_hosts and set default to [] to preserve backwards compatibility

### DIFF
--- a/terraform/alerting/probers.tf
+++ b/terraform/alerting/probers.tf
@@ -15,7 +15,7 @@
 resource "google_monitoring_uptime_check_config" "https" {
   project = var.project
 
-  for_each = toset(compact(concat(var.debugger_hosts, var.export_hosts, var.exposure_hosts, var.federationout_hosts)))
+  for_each = toset(compact(concat(var.export_hosts, var.exposure_hosts, var.federationout_hosts)))
 
   display_name = each.key
   timeout      = "10s"

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -17,24 +17,22 @@ variable "project" {
   description = "GCP project for key server. Required."
 }
 
-variable "debugger_hosts" {
-  type        = list(string)
-  description = "List of domains upon which the debugger is served."
-}
-
 variable "export_hosts" {
   type        = list(string)
   description = "List of domains upon which exports should be served."
+  default     = []
 }
 
 variable "exposure_hosts" {
   type        = list(string)
   description = "List of domains upon which the exposure uploads are served."
+  default     = []
 }
 
 variable "federationout_hosts" {
   type        = list(string)
   description = "List of domains upon which the federationout service is served."
+  default     = []
 }
 
 variable "alert-notification-channel-paging" {


### PR DESCRIPTION
The debugger service should never be publicly accessible and therefore doesn't need an uptime check. It's also not included in SLO calculations. Additionally, these new variables didn't have a default value, which makes them "required". This adds a default value of `[]` to preserve the backwards compatibility of the alerting module.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mikehelmick 
/assign @mariliamelo 