### PR TITLE
Remove host alerts for export and federationout

### DIFF
--- a/terraform/alerting/probers.tf
+++ b/terraform/alerting/probers.tf
@@ -15,7 +15,7 @@
 resource "google_monitoring_uptime_check_config" "https" {
   project = var.project
 
-  for_each = toset(compact(concat(var.export_hosts, var.exposure_hosts, var.federationout_hosts)))
+  for_each = toset(compact(concat(var.exposure_hosts)))
 
   display_name = each.key
   timeout      = "10s"

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -17,21 +17,9 @@ variable "project" {
   description = "GCP project for key server. Required."
 }
 
-variable "export_hosts" {
-  type        = list(string)
-  description = "List of domains upon which exports should be served."
-  default     = []
-}
-
 variable "exposure_hosts" {
   type        = list(string)
   description = "List of domains upon which the exposure uploads are served."
-  default     = []
-}
-
-variable "federationout_hosts" {
-  type        = list(string)
-  description = "List of domains upon which the federationout service is served."
   default     = []
 }
 


### PR DESCRIPTION
export is just a proxy in front of GCS. There's no "health" to check since it's just a bucket. We could create a file named "health", but I'm really apprehensive to do that because we don't know how clients could behave. federationout is a grpc service. Even if we added a health endpoint, there's no way to configure an uptime check for a grpc service

Fixes https://github.com/google/exposure-notifications-server/issues/1422

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```