### PR TITLE
Disable v1alpha1 API by default

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -24,4 +24,4 @@ docs:
         - title: Verification Protocol Design
           url: /design/verification_protocol
         - title: API Definitions
-          url: https://github.com/google/exposure-notifications-server/tree/main/pkg/api/v1alpha1
+          url: https://github.com/google/exposure-notifications-server/tree/main/pkg/api/v1

--- a/docs/getting-started/publishing-temporary-exposure-keys.md
+++ b/docs/getting-started/publishing-temporary-exposure-keys.md
@@ -26,9 +26,9 @@ an HTTP POST request to the `exposure` server.
 
 The structure of the API is defined in [pkg/api/v1/exposure_types.go](https://github.com/google/exposure-notifications-server/blob/main/pkg/api/v1/exposure_types.go),
 in the `Publish` type. Please see the documentation in the source file for details of the
-fields themselves. The 'publish' API is hosted at `/v1/publish` on the `exposure` service. The legacy version (v1alpha1) _may_ also be posted on that same service.
+fields themselves. The 'publish' API is hosted at `/v1/publish` on the `exposure` service.
 
-Access to the API depends ont he provided `healthAuthorityID` in the publish request, the
+Access to the API depends on the provided `healthAuthorityID` in the publish request, the
 the verification certificate provided in the `verificationPayload` and how things are configured
 at the server. Any region metadata assigned to TEKS will be done automatically
 at the server. If a TEK is known to be outside of the "home area," then the `traveler` field

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Key Server here:
 * [Data validation guide](tek_validation.md)
 * [Server Deployment Options](server_deployment_options.md)
 * [Reference documentation](https://pkg.go.dev/mod/github.com/google/exposure-notifications-server)
-* [API Definitions](https://github.com/google/exposure-notifications-server/tree/main/pkg/api/v1alpha1)
+* [API Definitions](https://github.com/google/exposure-notifications-server/tree/main/pkg/api/v1)
 
 ## Issues and Questions
 

--- a/docs/server_functional_requirements.md
+++ b/docs/server_functional_requirements.md
@@ -62,7 +62,7 @@ information to be shared. The information described in this section is the
 minimum required set in order to validate the uploads and to generate the
 necessary client batches for ingestion into the device for key matching.
 
-We have provides a sample API in [exposure_types.go](https://github.com/google/exposure-notifications-server/blob/main/pkg/api/v1alpha1/exposure_types.go).
+We have provides a sample API in [exposure_types.go](https://github.com/google/exposure-notifications-server/blob/main/pkg/api/v1/exposure_types.go).
 
 Minimum required fields, followed by a JSON example:
 
@@ -144,7 +144,7 @@ The following snippet is an example POST request payload in JSON format.
 }
 ```
 
-The publish request should respond with a structure described in [exposure_types.go](https://github.com/google/exposure-notifications-server/blob/main/pkg/api/v1alpha1/exposure_types.go).
+The publish request should respond with a structure described in [exposure_types.go](https://github.com/google/exposure-notifications-server/blob/main/pkg/api/v1/exposure_types.go).
 
 The revision token is a critical piece of ensuring that revised keys that ensures that a different device cannot revise a previously uploaded key. We have a reference implementation in the [revision package](https://github.com/google/exposure-notifications-server/blob/main/internal/revision/revision.go).
 
@@ -160,8 +160,8 @@ The revision token is a critical piece of ensuring that revised keys that ensure
 
 ### Requirements and recommendations
 
-* Required 
-   * An allow-list check for `healthAuthorityID` that specifies the 
+* Required
+   * An allow-list check for `healthAuthorityID` that specifies the
   verification certificate signing keys allowed and the region information
   for those keys.
   * Validation of all uploaded data, in particular that TEK data is 16 bytes in length

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -87,7 +87,7 @@ type Config struct {
 	AllowPartialRevisions bool `env:"ALLOW_PARTIAL_REVISIONS, default=false"`
 
 	// API Versions.
-	EnableV1Alpha1API bool `env:"ENABLE_V1ALPHA1_API, default=true"`
+	EnableV1Alpha1API bool `env:"ENABLE_V1ALPHA1_API, default=false"`
 
 	// If set and if a publish request has no regions (v1alpha1) and the health authority
 	// has no regions configured, then this default will be assumed.


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-server/issues/1426

**Release Note**

```release-note
**Breaking change!** This release disables the v1alpha1 API by default. If your clients depend on the v1alpha1 API, you **must** set `ENABLE_V1ALPHA1_API=true` on the `exposure` service.
```