### PR TITLE
Switch CODEOWNERS to team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mikehelmick @sethvargo @whaught @yegle @mariliamelo
+* @google/exposure-notifications-server


### PR DESCRIPTION
This way, we can manage the team and access controls via the team instead of managing individual people.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```