### PR TITLE
Print per-package test coverage too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: go-test
-        shell: bash        
+        shell: bash
         run: make test-acc
 
       - name: go-coverage

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test-acc:
 .PHONY: test-acc
 
 test-coverage:
-	@go tool cover -func ./coverage.out | grep total
+	@go tool cover -func=./coverage.out
 .PHONY: test-coverage
 
 zapcheck:


### PR DESCRIPTION
The CI script already `grep`s and does the collapsing. This will enable us to click the arrow and see per-package coverage like on verification.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```