### PR TITLE
Set binauth annotation

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -321,6 +321,7 @@ locals {
     "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
   }
   default_service_annotations = {
+    "run.googleapis.com/binary-authorization" : "default"
     "run.googleapis.com/ingress" : "all"
     // This is added due to the run.googleapis.com/sandbox annotation above.
     // The sandbox anntation it added to remove the permanent diff.


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Set Binary Authorization service annotations on Cloud Run services.
```