### PR TITLE
Add logs-based metric for when exports are downloaded

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -302,9 +302,10 @@ resource "google_monitoring_alert_policy" "HumanDecryptedValue" {
 resource "google_logging_metric" "export_file_downloaded" {
   count = var.capture_export_file_downloads ? 1 : 0
 
-  name    = "export_file_downloaded"
-  project = var.project
-  filter  = <<EOT
+  name        = "export_file_downloaded"
+  description = "Incremented on each export file download."
+  project     = var.project
+  filter      = <<EOT
 resource.type="http_load_balancer"
 httpRequest.requestUrl=~"/index.txt$"
 httpRequest.status=200
@@ -328,7 +329,7 @@ EOT
   }
 
   label_extractors = {
-    "path"     = "REGEXP_EXTRACT(httpRequest.requestUrl, 'https?://.+/(.+)/index\\.txt')"
-    "platform" = "REGEXP_EXTRACT(httpRequest.userAgent, '(Android|Darwin)')"
+    "path"     = "REGEXP_EXTRACT(httpRequest.requestUrl, \"https?://.+/(.+)/index\\\\\\\\.txt\")"
+    "platform" = "REGEXP_EXTRACT(httpRequest.userAgent, \"(Android|Darwin)\")"
   }
 }

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -73,6 +73,13 @@ variable "alert_on_human_decrypted_value" {
   description = "Alert when a human accesses a secret. You must enable DATA_READ audit logs for Cloud KMS."
 }
 
+variable "capture_export_file_downloads" {
+  type    = bool
+  default = true
+
+  description = "Capture metrics about mobile devices downloading export files. This can be used to create alerts when values drop below acceptable thresholds."
+}
+
 terraform {
   required_version = ">= 0.14.2"
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-server/issues/1411

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add a new metric `export_file_downloaded`, which is emitted when a device downloads an export. The metric extracts the export path (for multi-tenant installations) and the platform via labels for further aggregation. This is on by default but can be disabled by setting `capture_export_file_downloads` to false. This only applies to Google Cloud.
```