### PR TITLE
Only run Terraform checks once

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,7 +1,15 @@
 name: 'Terraform'
 
 on:
+  push:
+    branches:
+    - main
+    paths:
+    - 'terraform/**'
+    - '.github/workflows/terraform*'
   pull_request:
+    branches:
+    - main
     paths:
     - 'terraform/**'
     - '.github/workflows/terraform*'


### PR DESCRIPTION
This restricts Terraform to running on CI against PRs to main and the main branch

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```