### PR TITLE
Try fixing coverage output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
         run: |-
           OUTPUT="$(make test-coverage)"
-          TOTAL="$(echo $OUTPUT | awk 'END{print $3}')"
+          TOTAL="$(echo $OUTPUT | awk 'END{print $NF}')"
           echo "::group::Coverage (${TOTAL})"
           echo "${OUTPUT}"
           echo "::endgroup::"


### PR DESCRIPTION
This exact code works on the verification server, unclear why it fails on the key server. Trying NF instead of column 3 in case that's it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```