### PR TITLE
add vaccine status migrations

### DIFF
--- a/migrations/000080_VaccineStatus.down.sql
+++ b/migrations/000080_VaccineStatus.down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE Exposure
+  DROP COLUMN vaccine_status;
+
+END;

--- a/migrations/000080_VaccineStatus.up.sql
+++ b/migrations/000080_VaccineStatus.up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2021 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE Exposure
+  ADD COLUMN vaccine_status BOOL DEFAULT false;
+ALTER TABLE Exposure
+  ALTER COLUMN vaccine_status SET NOT NULL;
+
+END;


### PR DESCRIPTION

## Proposed Changes

* Add DB migrations, placeholder for vaccine status
* This is not currently in use, but is being reserved for the future

**Release Note**

```release-note
Adds placeholder database columns for possible future use of vaccine status
```