### PR TITLE
Add renderer, generate FP, and overridable FP alerts

### DIFF
--- a/internal/cleanup/metrics.go
+++ b/internal/cleanup/metrics.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package cleanup contains OpenCensus metrics and views for cleanup operations
 package cleanup
 
 import (

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -112,7 +112,7 @@ func TestServer_smoke(t *testing.T) {
 			t.Errorf("expected %#v to be %#v", got, want)
 		}
 
-		if got, want := w.Body.String(), "successfully generated exposure keys"; got != want {
+		if got, want := w.Body.String(), `{"ok":true}`; got != want {
 			t.Errorf("expected %#v to be %#v", got, want)
 		}
 	})

--- a/internal/generate/metrics.go
+++ b/internal/generate/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/generate/metrics.go
+++ b/internal/generate/metrics.go
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package cleanup implements the API handlers for running data deletion jobs.
-package cleanup
+package generate
 
 import (
-	"fmt"
-	"time"
+	"github.com/google/exposure-notifications-server/internal/metrics"
+	"github.com/google/exposure-notifications-server/pkg/observability"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
 )
 
-const minTTL = 10 * 24 * time.Hour
+const metricPrefix = metrics.MetricRoot + "generate"
 
-func cutoffDate(d time.Duration, override bool) (time.Time, error) {
-	if d >= minTTL || override {
-		return time.Now().UTC().Add(-d), nil
-	}
+var mSuccess = stats.Int64(metricPrefix+"/success", "successful execution", stats.UnitDimensionless)
 
-	return time.Time{}, fmt.Errorf("cleanup ttl %s is less than configured minimum ttl of %s", d, minTTL)
+func init() {
+	observability.CollectViews([]*view.View{
+		{
+			Name:        metricPrefix + "/success",
+			Description: "Number of successes",
+			Measure:     mSuccess,
+			Aggregation: view.Count(),
+		},
+	}...)
 }

--- a/internal/generate/server.go
+++ b/internal/generate/server.go
@@ -23,6 +23,7 @@ import (
 	publishmodel "github.com/google/exposure-notifications-server/internal/publish/model"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-server/pkg/render"
 	"github.com/google/exposure-notifications-server/pkg/server"
 	"github.com/gorilla/mux"
 )
@@ -32,6 +33,7 @@ type Server struct {
 	env         *serverenv.ServerEnv
 	transformer *publishmodel.Transformer
 	database    *publishdb.PublishDB
+	h           *render.Renderer
 }
 
 func NewServer(cfg *Config, env *serverenv.ServerEnv) (*Server, error) {
@@ -49,6 +51,7 @@ func NewServer(cfg *Config, env *serverenv.ServerEnv) (*Server, error) {
 		transformer: transformer,
 		config:      cfg,
 		database:    publishdb.New(env.Database()),
+		h:           render.NewRenderer(),
 	}, nil
 }
 

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -1,0 +1,102 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// RenderJSON renders the interface as JSON. It attempts to gracefully handle
+// any rendering errors to avoid partial responses sent to the response by
+// writing to a buffer first, then flushing the buffer to the response.
+//
+// If the provided data is nil and the response code is a 200, the result will
+// be `{"ok":true}`. If the code is not a 200, the response will be of the
+// format `{"error":"<val>"}` where val is the JSON-escaped http.StatusText for
+// the provided code.
+//
+// If rendering fails, a generic 500 JSON response is returned. In dev mode, the
+// error is included in the payload. If flushing the buffer to the response
+// fails, an error is logged, but no recovery is attempted.
+//
+// The buffers are fetched via a sync.Pool to reduce allocations and improve
+// performance.
+func (r *Renderer) RenderJSON(w http.ResponseWriter, code int, data interface{}) {
+	// Avoid marshaling nil data.
+	if data == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+
+		// Return an OK response.
+		if code >= 200 && code < 300 {
+			fmt.Fprint(w, jsonOKResp)
+			return
+		}
+
+		fmt.Fprintf(w, jsonErrTmpl, http.StatusText(code))
+		return
+	}
+
+	// Special-case handle multi-error.
+	if typ, ok := data.(*multierror.Error); ok {
+		errs := typ.WrappedErrors()
+		msgs := make([]string, 0, len(errs))
+		for _, err := range errs {
+			msgs = append(msgs, err.Error())
+		}
+
+		data = map[string][]string{
+			"errors": msgs,
+		}
+	}
+
+	// If the provided value was an error, marshall accordingly.
+	if typ, ok := data.(error); ok {
+		data = map[string]string{
+			"error": typ.Error(),
+		}
+	}
+
+	// Acquire a renderer
+	b := r.pool.Get().(*bytes.Buffer)
+	b.Reset()
+	defer r.pool.Put(b)
+
+	// Render into the renderer
+	if err := json.NewEncoder(b).Encode(data); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, jsonErrTmpl, http.StatusText(http.StatusInternalServerError))
+		return
+	}
+
+	// Rendering worked, flush to the response
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_, _ = b.WriteTo(w)
+}
+
+// jsonErrTmpl is the template to use when returning a JSON error. It is
+// rendered using Printf, not json.Encode, so values must be escaped by the
+// caller.
+const jsonErrTmpl = `{"error":"%s"}`
+
+// jsonOKResp is the return value for empty data responses.
+const jsonOKResp = `{"ok":true}`

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package cleanup implements the API handlers for running data deletion jobs.
-package cleanup
+// Package render defines rendering functionality.
+package render
 
 import (
-	"fmt"
-	"time"
+	"bytes"
+	"sync"
 )
 
-const minTTL = 10 * 24 * time.Hour
+// Renderer is a structure that knows how to perform safe HTTP rendering.
+type Renderer struct {
+	pool *sync.Pool
+}
 
-func cutoffDate(d time.Duration, override bool) (time.Time, error) {
-	if d >= minTTL || override {
-		return time.Now().UTC().Add(-d), nil
+// NewRenderer returns an instantiated renderer.
+func NewRenderer() *Renderer {
+	return &Renderer{
+		pool: &sync.Pool{
+			New: func() interface{} {
+				return bytes.NewBuffer(make([]byte, 0, 1024))
+			},
+		},
 	}
-
-	return time.Time{}, fmt.Errorf("cleanup ttl %s is less than configured minimum ttl of %s", d, minTTL)
 }

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -16,6 +16,17 @@
 locals {
   playbook_prefix = "https://github.com/google/exposure-notifications-server/blob/main/docs/playbooks/alerts"
   custom_prefix   = "custom.googleapis.com/opencensus/en-server"
+
+  forward_progress_indicators = merge(
+    {
+      // cleanup-export runs every 4h, alert after 2 failures
+      "cleanup-export" = { metric = "cleanup/export/success", window = "485m" },
+
+      // cleanup-exposure runs every 4h, alert after 2 failures
+      "cleanup-exposure" = { metric = "cleanup/exposure/success", window = "485m" },
+    },
+    var.forward_progress_indicators,
+  )
 }
 
 resource "google_monitoring_alert_policy" "CloudSchedulerJobFailed" {
@@ -65,7 +76,7 @@ resource "google_monitoring_alert_policy" "CloudSchedulerJobFailed" {
 }
 
 resource "google_monitoring_alert_policy" "ForwardProgressFailed" {
-  for_each = var.forward_progress_indicators
+  for_each = local.forward_progress_indicators
 
   project      = var.project
   display_name = "ForwardProgressFailed-${each.key}"

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -86,13 +86,8 @@ variable "forward_progress_indicators" {
     window = string
   }))
 
-  default = {
-    // cleanup-export runs every 4h, alert after 2 failures
-    "cleanup-export" = { metric = "cleanup/export/success", window = "485m" },
-
-    // cleanup-exposure runs every 4h, alert after 2 failures
-    "cleanup-exposure" = { metric = "cleanup/exposure/success", window = "485m" },
-  }
+  description = "Map of overrides for forward progress indicators. These are merged with the default variables."
+  default     = {}
 }
 
 terraform {


### PR DESCRIPTION
The renderer is similar to the verification server, but restricted to JSON. The generate service publishes a success metric (but there's no default alert). The default alerts are hard-coded as a local variable and can overridden using the variable.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add renderer, forward-progress alerts for generate service, and overridable alerts for forward-progress.
```