### PR TITLE
add metrics for missing public key and more logging

### DIFF
--- a/internal/publish/metrics.go
+++ b/internal/publish/metrics.go
@@ -29,6 +29,9 @@ var (
 
 	mLatencyMs = stats.Float64(publishMetricsPrefix+"requests", "publish requests", stats.UnitMilliseconds)
 
+	mNoPublicKeys = stats.Int64(publishMetricsPrefix+"no_pub_keys",
+		"uploads where there is no public key", stats.UnitDimensionless)
+
 	mExposuresCount = stats.Int64(publishMetricsPrefix+"exposures_count",
 		"exposure count", stats.UnitDimensionless)
 
@@ -50,6 +53,11 @@ var (
 		observability.BuildIDTagKey,
 		observability.BuildTagTagKey,
 		exposureTypeTag,
+	}
+
+	healthAuthorityIDTag = tag.MustNewKey("healthAuthorityID")
+	missingPublicKeyTags = []tag.Key{
+		healthAuthorityIDTag,
 	}
 )
 
@@ -98,6 +106,13 @@ func init() {
 			Description: "Total count of response padding failures",
 			Measure:     mPaddingFailed,
 			Aggregation: view.Sum(),
+		},
+		{
+			Name:        metrics.MetricRoot + "no_public_key",
+			Description: "Publish request with no public key",
+			Measure:     mNoPublicKeys,
+			Aggregation: view.Count(),
+			TagKeys:     missingPublicKeyTags,
 		},
 	}...)
 }

--- a/internal/publish/metrics.go
+++ b/internal/publish/metrics.go
@@ -29,7 +29,7 @@ var (
 
 	mLatencyMs = stats.Float64(publishMetricsPrefix+"requests", "publish requests", stats.UnitMilliseconds)
 
-	mNoPublicKeys = stats.Int64(publishMetricsPrefix+"no_pub_keys",
+	mNoPublicKey = stats.Int64(publishMetricsPrefix+"no_public_keys",
 		"uploads where there is no public key", stats.UnitDimensionless)
 
 	mExposuresCount = stats.Int64(publishMetricsPrefix+"exposures_count",
@@ -110,7 +110,7 @@ func init() {
 		{
 			Name:        metrics.MetricRoot + "no_public_key",
 			Description: "Publish request with no public key",
-			Measure:     mNoPublicKeys,
+			Measure:     mNoPublicKey,
 			Aggregation: view.Count(),
 			TagKeys:     missingPublicKeyTags,
 		},

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -321,7 +321,8 @@ func (s *Server) process(ctx context.Context, data *verifyapi.Publish, platform 
 			if errors.Is(err, verification.ErrNoPublicKeys) {
 				// This only happens if the health authority ID exists in the database.
 				logger.Warnw("received publish request for health authority with no public keys", "healthAuthorityID", data.HealthAuthorityID)
-				if err := stats.RecordWithTags(ctx, []tag.Mutator{tag.Upsert(healthAuthorityIDTag, data.HealthAuthorityID)}, mNoPublicKeys.M(1)); err != nil {
+				tags := []tag.Mutator{tag.Upsert(healthAuthorityIDTag, data.HealthAuthorityID)}
+				if err := stats.RecordWithTags(ctx, tags, mNoPublicKey.M(1)); err != nil {
 					logger.Errorw("failed to record stats for missing public key", "error", err, "healthAuthorityID", data.HealthAuthorityID)
 				}
 			}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -260,7 +260,7 @@ func (s *Server) process(ctx context.Context, data *verifyapi.Publish, platform 
 		}
 	}
 
-	// In the v1 API - regions aren't passed. They may be passed from v1Apha1
+	// In the v1 API - regions aren't passed. They may be passed from v1alpha1
 	var regions []string
 	if bridge != nil && len(bridge.AdditionalRegions) > 0 {
 		regions = bridge.AdditionalRegions
@@ -318,6 +318,14 @@ func (s *Server) process(ctx context.Context, data *verifyapi.Publish, platform 
 			logger.Warnf("bypassing health authority certificate verification health authority: %v", appConfig.AppPackageName)
 			stats.Record(ctx, mVerificationBypassed.M(1))
 		} else {
+			if errors.Is(err, verification.ErrNoPublicKeys) {
+				// This only happens if the health authority ID exists in the database.
+				logger.Warnw("received publish request for health authority with no public keys", "healthAuthorityID", data.HealthAuthorityID)
+				if err := stats.RecordWithTags(ctx, []tag.Mutator{tag.Upsert(healthAuthorityIDTag, data.HealthAuthorityID)}, mNoPublicKeys.M(1)); err != nil {
+					logger.Errorw("failed to record stats for missing public key", "error", err, "healthAuthorityID", data.HealthAuthorityID)
+				}
+			}
+
 			message := fmt.Sprintf("unable to validate diagnosis verification: %v", err)
 			if s.config.DebugLogBadCertificates {
 				logger.Errorw(message, "error", err, "jwt", data.VerificationPayload)

--- a/internal/verification/phaverify.go
+++ b/internal/verification/phaverify.go
@@ -35,6 +35,9 @@ import (
 	"github.com/dgrijalva/jwt-go"
 )
 
+// ErrNoPublicKeys indicates no public keys were found when verifying the certificate.
+var ErrNoPublicKeys = errors.New("no active public keys for health authority")
+
 // Verifier can be used to verify public health authority diagnosis verification certificates.
 type Verifier struct {
 	db      *database.HealthAuthorityDB
@@ -123,7 +126,7 @@ func (v *Verifier) VerifyDiagnosisCertificate(ctx context.Context, authApp *aamo
 				return hak.PublicKey()
 			}
 		}
-		return nil, fmt.Errorf("key not found: iss: %v, kid: %v", claims.Issuer, kid)
+		return nil, ErrNoPublicKeys
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

## Proposed Changes

* add metrics for when a HA exists, but has no public keys
* specifically log this type of issue

**Release Note**

```release-note
Add metrics for when a healthAuthorityID exists, but has no public keys
```