### PR TITLE
Switch export to forward progress

### DIFF
--- a/docs/playbooks/alerts/ForwardProgressFailed.md
+++ b/docs/playbooks/alerts/ForwardProgressFailed.md
@@ -8,9 +8,13 @@ This alert fires when background jobs have not made forward progress in an accep
 
 - `cleanup-exposure` - Purges old exposures.
 
+- `export-batcher` - Creates batch files for export.
+
 - `export-importer-import` - Imports export files from another server.
 
 - `export-importer-schedule` - Downloads _index_ files from another server to be later imported by the `export-importer-import`
+
+- `export-worker` - Generates export files.
 
 - `jwks` - Fetches and purges public keys from a public key discovery service.
 

--- a/internal/export/metrics.go
+++ b/internal/export/metrics.go
@@ -23,62 +23,58 @@ import (
 	"go.opencensus.io/tag"
 )
 
+const metricPrefix = metrics.MetricRoot + "export"
+
 var (
-	exportMetricsPrefix = metrics.MetricRoot + "export"
-
-	mBatcherLockContention = stats.Int64(exportMetricsPrefix+"export_batcher_lock_contention",
-		"Instances of export batcher lock contention", stats.UnitDimensionless)
-	mBatcherFailure = stats.Int64(exportMetricsPrefix+"export_batcher_failure",
-		"Instances of export batcher failures", stats.UnitDimensionless)
-	mBatcherNoWork = stats.Int64(exportMetricsPrefix+"export_batcher_no_work",
-		"Instances of export batcher having no work", stats.UnitDimensionless)
-	mBatcherCreated = stats.Int64(exportMetricsPrefix+"export_batches_created",
-		"Number of export batchers created", stats.UnitDimensionless)
-	mWorkerBadKeyLength = stats.Int64(exportMetricsPrefix+"export_worker_bad_key_length",
-		"Number of dropped keys caused by bad key length", stats.UnitDimensionless)
-
-	mExportBatchCompletion = stats.Int64(exportMetricsPrefix+"export_batch_completion",
-		"Number of batches complete by output region", stats.UnitDimensionless)
-
-	ExportConfigIDTagKey  = tag.MustNewKey("export_config_id")
-	ExportRegionTagKey    = tag.MustNewKey("export_region")
+	ExportConfigIDTagKey  = tag.MustNewKey("config_id")
+	ExportRegionTagKey    = tag.MustNewKey("region")
 	ExportTravelersTagKey = tag.MustNewKey("includes_travelers")
+)
+
+var (
+	mBatcherSuccess = stats.Int64(metricPrefix+"/batcher/success", "successful batcher execution", stats.UnitDimensionless)
+	mWorkerSuccess  = stats.Int64(metricPrefix+"/worker/success", "successful worker execution", stats.UnitDimensionless)
+
+	mBatcherNoWork         = stats.Int64(metricPrefix+"/batcher_no_work", "Instances of export batcher having no work", stats.UnitDimensionless)
+	mBatcherCreated        = stats.Int64(metricPrefix+"/batches_created", "Number of export batchers created", stats.UnitDimensionless)
+	mWorkerBadKeyLength    = stats.Int64(metricPrefix+"/worker_bad_key_length", "Number of dropped keys caused by bad key length", stats.UnitDimensionless)
+	mExportBatchCompletion = stats.Int64(metricPrefix+"/batch_completion", "Number of batches complete by output region", stats.UnitDimensionless)
 )
 
 func init() {
 	observability.CollectViews([]*view.View{
 		{
-			Name:        metrics.MetricRoot + "export_batcher_lock_contention_count",
-			Description: "Total count of lock contention instances",
-			Measure:     mBatcherLockContention,
-			Aggregation: view.Sum(),
+			Name:        metricPrefix + "/batcher/success",
+			Description: "Number of batcher successes",
+			Measure:     mBatcherSuccess,
+			Aggregation: view.Count(),
 		},
 		{
-			Name:        metrics.MetricRoot + "export_batcher_failure_count",
-			Description: "Total count of export batcher failures",
-			Measure:     mBatcherFailure,
-			Aggregation: view.Sum(),
+			Name:        metricPrefix + "/worker/success",
+			Description: "Number of worker successes",
+			Measure:     mWorkerSuccess,
+			Aggregation: view.Count(),
 		},
 		{
-			Name:        metrics.MetricRoot + "export_batcher_no_work_count",
+			Name:        metrics.MetricRoot + "/batcher_no_work_count",
 			Description: "Total count for instances of export batcher having no work",
 			Measure:     mBatcherNoWork,
 			Aggregation: view.Sum(),
 		},
 		{
-			Name:        metrics.MetricRoot + "export_batches_created_count",
+			Name:        metrics.MetricRoot + "/batches_created_count",
 			Description: "Total count for number of export batches created",
 			Measure:     mBatcherCreated,
 			Aggregation: view.Sum(),
 		},
 		{
-			Name:        metrics.MetricRoot + "export_worker_bad_key_length_latest",
+			Name:        metrics.MetricRoot + "/worker_bad_key_length_latest",
 			Description: "Latest number of dropped keys caused by bad key length",
 			Measure:     mWorkerBadKeyLength,
 			Aggregation: view.LastValue(),
 		},
 		{
-			Name:        metrics.MetricRoot + "export_batch_completion",
+			Name:        metrics.MetricRoot + "/batch_completion",
 			Description: "Number of batches complete by output region",
 			Measure:     mExportBatchCompletion,
 			Aggregation: view.Sum(),

--- a/internal/export/server.go
+++ b/internal/export/server.go
@@ -21,9 +21,17 @@ import (
 	"github.com/google/exposure-notifications-server/internal/middleware"
 	"github.com/google/exposure-notifications-server/internal/serverenv"
 	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-server/pkg/render"
 	"github.com/google/exposure-notifications-server/pkg/server"
 	"github.com/gorilla/mux"
 )
+
+// Server hosts end points to manage export batches.
+type Server struct {
+	config *Config
+	env    *serverenv.ServerEnv
+	h      *render.Renderer
+}
 
 // NewServer makes a Server.
 func NewServer(cfg *Config, env *serverenv.ServerEnv) (*Server, error) {
@@ -43,13 +51,8 @@ func NewServer(cfg *Config, env *serverenv.ServerEnv) (*Server, error) {
 	return &Server{
 		config: cfg,
 		env:    env,
+		h:      render.NewRenderer(),
 	}, nil
-}
-
-// Server hosts end points to manage export batches.
-type Server struct {
-	config *Config
-	env    *serverenv.ServerEnv
 }
 
 // Routes defines and returns the routes for this server.

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -29,6 +29,7 @@ import (
 	publishdatabase "github.com/google/exposure-notifications-server/internal/publish/database"
 	"github.com/google/exposure-notifications-server/internal/storage"
 	coredb "github.com/google/exposure-notifications-server/pkg/database"
+	"github.com/hashicorp/go-multierror"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 
@@ -57,91 +58,113 @@ func (s *Server) handleDoWork() http.Handler {
 		ctx := r.Context()
 
 		logger := logging.FromContext(ctx).Named("handleDoWork")
+		logger.Debugw("starting do-work worker")
+		defer logger.Debugw("finished do-work worker")
 
-		ctx, cancel := context.WithTimeout(r.Context(), s.config.WorkerTimeout)
+		ctx, cancel := context.WithTimeout(ctx, s.config.WorkerTimeout)
 		defer cancel()
 
-		indexWrittenForConfig := make(map[int64]struct{})
+		var merr *multierror.Error
+
+		indexesWritten := make(map[int64]struct{})
+
+	OUTER:
 		for {
 			if ctx.Err() != nil {
-				msg := "Timed out processing batches. Will continue on next invocation."
-				logger.Info(msg)
-				fmt.Fprintln(w, msg)
-				return
+				logger.Warnw("deadline passed, still work to do")
+				merr = multierror.Append(merr, fmt.Errorf("deadline exceeded"))
+				break OUTER
 			}
 
 			// Check for a batch and obtain a lease for it.
 			batch, err := exportdatabase.New(db).LeaseBatch(ctx, s.config.WorkerTimeout, time.Now())
 			if err != nil {
 				logger.Errorw("failed to lease batch", "error", err)
-				continue
+				merr = multierror.Append(merr, fmt.Errorf("failed to lease batch: %w", err))
+				break OUTER
 			}
 			if batch == nil {
-				msg := "No more work to do"
-				logger.Info(msg)
-				fmt.Fprintln(w, msg)
+				logger.Debugw("no more work to do")
+				break OUTER
+			}
+
+			if err := s.processBatch(ctx, batch, indexesWritten); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to process batch %d/%d: %w", batch.BatchID, batch.ConfigID, err))
+				continue
+			}
+
+			logger.Debugw("completed batch", "batch_id", batch.BatchID, "config_id", batch.ConfigID)
+		}
+
+		if merr != nil {
+			if errs := merr.WrappedErrors(); len(errs) > 0 {
+				logger.Errorw("failed to run worker", "errors", errs)
+				s.h.RenderJSON(w, http.StatusInternalServerError, errs)
 				return
 			}
-
-			// Obtain the necessary locks for this export batch. Ensure that only
-			// one export worker is operating over a region at a time.
-			//
-			// In the event that more than one exportconfig covers the same region (and travelers), it
-			// is important that only one export worker be allowed to generate keys for that region.
-			// An exclusive lock is taken before processing the batch over the input regions.
-			//
-			// In the export lease selection, we attempt to order export batch filling such that
-			// earlier batches are filled before later batches. This helps to reduce the possibility
-			// of non-overlapping generated data.
-			locks := make([]string, 0, len(batch.EffectiveInputRegions())+1)
-			locks = append(locks, batch.EffectiveInputRegions()...)
-			if batch.IncludeTravelers {
-				locks = append(locks, travelerLockID)
-			}
-			unlockFn, err := db.MultiLock(ctx, locks, s.config.WorkerTimeout)
-			if err != nil {
-				if !errors.Is(err, coredb.ErrAlreadyLocked) {
-					logger.Errorw("failed to acquire region lock",
-						"config", batch.ConfigID,
-						"batch", batch.BatchID,
-						"regions", locks,
-						"error", err)
-				}
-				continue
-			}
-			unlock := func() {
-				if err := unlockFn(); err != nil {
-					logger.Errorw("failed to release region lock",
-						"config", batch.ConfigID,
-						"batch", batch.BatchID,
-						"regions", locks,
-						"error", err)
-				}
-			}
-
-			// We re-write the index file for empty batches for self-healing so that the
-			// index file reflects the ExportFile table in database. However, if a
-			// single worker processes a number of empty batches quickly, we want to
-			// avoid writing the same file repeatedly and hitting a rate limit. This
-			// ensures that we write the index file for an empty batch at most once
-			// per processed config each round.
-			emitIndexForEmptyBatch := false
-			if _, ok := indexWrittenForConfig[batch.ConfigID]; !ok {
-				emitIndexForEmptyBatch = true
-				indexWrittenForConfig[batch.ConfigID] = struct{}{}
-			}
-
-			// Ensure that the locks are released on either success or failure path.
-			if err = s.exportBatch(ctx, batch, emitIndexForEmptyBatch); err != nil {
-				logger.Errorw("failed to create files for batch", "error", err)
-				unlock()
-				continue
-			}
-			unlock()
-
-			fmt.Fprintf(w, "Batch %d marked completed. \n", batch.BatchID)
 		}
+
+		stats.Record(ctx, mWorkerSuccess.M(1))
+		s.h.RenderJSON(w, http.StatusOK, nil)
 	})
+}
+
+func (s *Server) processBatch(ctx context.Context, batch *model.ExportBatch, indexesWritten map[int64]struct{}) error {
+	db := s.env.Database()
+
+	// Obtain the necessary locks for this export batch. Ensure that only
+	// one export worker is operating over a region at a time.
+	//
+	// In the event that more than one exportconfig covers the same region (and travelers), it
+	// is important that only one export worker be allowed to generate keys for that region.
+	// An exclusive lock is taken before processing the batch over the input regions.
+	//
+	// In the export lease selection, we attempt to order export batch filling such that
+	// earlier batches are filled before later batches. This helps to reduce the possibility
+	// of non-overlapping generated data.
+	locks := make([]string, 0, len(batch.EffectiveInputRegions())+1)
+	locks = append(locks, batch.EffectiveInputRegions()...)
+	if batch.IncludeTravelers {
+		locks = append(locks, travelerLockID)
+	}
+
+	logger := logging.FromContext(ctx).Named("processBatch").
+		With("batch_id", batch.BatchID).
+		With("config_id", batch.ConfigID).
+		With("regions", locks)
+
+	unlock, err := db.MultiLock(ctx, locks, s.config.WorkerTimeout)
+	if err != nil {
+		if errors.Is(err, coredb.ErrAlreadyLocked) {
+			logger.Warnw("skipping (already locked)")
+			return nil
+		}
+		return fmt.Errorf("failed to obtain locks on %q: %w", locks, err)
+	}
+	defer func() {
+		if err := unlock(); err != nil {
+			logger.Errorw("failed to release lock", "error", err)
+		}
+	}()
+
+	// We re-write the index file for empty batches for self-healing so that the
+	// index file reflects the ExportFile table in database. However, if a
+	// single worker processes a number of empty batches quickly, we want to
+	// avoid writing the same file repeatedly and hitting a rate limit. This
+	// ensures that we write the index file for an empty batch at most once
+	// per processed config each round.
+	emitIndexForEmptyBatch := false
+	if _, ok := indexesWritten[batch.ConfigID]; !ok {
+		emitIndexForEmptyBatch = true
+		indexesWritten[batch.ConfigID] = struct{}{}
+	}
+
+	// Ensure that the locks are released on either success or failure path.
+	if err = s.exportBatch(ctx, batch, emitIndexForEmptyBatch); err != nil {
+		return fmt.Errorf("failed to create files for batch: %w", err)
+	}
+
+	return nil
 }
 
 type group struct {

--- a/internal/export/worker.go
+++ b/internal/export/worker.go
@@ -68,12 +68,11 @@ func (s *Server) handleDoWork() http.Handler {
 
 		indexesWritten := make(map[int64]struct{})
 
-	OUTER:
 		for {
 			if ctx.Err() != nil {
 				logger.Warnw("deadline passed, still work to do")
 				merr = multierror.Append(merr, fmt.Errorf("deadline exceeded"))
-				break OUTER
+				break
 			}
 
 			// Check for a batch and obtain a lease for it.
@@ -81,11 +80,11 @@ func (s *Server) handleDoWork() http.Handler {
 			if err != nil {
 				logger.Errorw("failed to lease batch", "error", err)
 				merr = multierror.Append(merr, fmt.Errorf("failed to lease batch: %w", err))
-				break OUTER
+				break
 			}
 			if batch == nil {
 				logger.Debugw("no more work to do")
-				break OUTER
+				break
 			}
 
 			if err := s.processBatch(ctx, batch, indexesWritten); err != nil {

--- a/internal/exportimport/handle_import.go
+++ b/internal/exportimport/handle_import.go
@@ -52,12 +52,11 @@ func (s *Server) handleImport() http.Handler {
 
 		var merr *multierror.Error
 
-	OUTER:
 		for _, cfg := range configs {
 			// Check how we're doing on max runtime.
 			if deadlinePassed(ctx) {
 				logger.Warnw("deadline passed, but there is still work to do")
-				break OUTER
+				break
 			}
 
 			if err := s.runImport(ctx, cfg); err != nil {
@@ -121,12 +120,11 @@ func (s *Server) runImport(ctx context.Context, cfg *model.ExportImport) error {
 	var merr *multierror.Error
 
 	var completedFiles, failedFiles int64
-OUTER:
 	for _, file := range openFiles {
 		// Check how we're doing on max runtime.
 		if deadlinePassed(ctx) {
 			logger.Warnw("deadline passed, but there is still work to do")
-			break OUTER
+			break
 		}
 
 		if err := s.exportImportDB.LeaseImportFile(ctx, s.config.ImportLockTime, file); err != nil {

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -28,6 +28,13 @@ locals {
       // cleanup-exposure runs every 4h, alert after 2 failures
       "cleanup-exposure" = { metric = "cleanup/exposure/success", window = "485m" },
 
+      // export-batcher runs every 5m, alert after 3 failures
+      "export-batcher" = { metric = "export/batcher/success", window = "20m" },
+
+      // export-worker runs every 1m but can take up to 5m to finish, alert
+      // after ~2 failures
+      "export-worker" = { metric = "export/worker/success", window = "10m" },
+
       // export-importer-schedule runs every 15m, alert after 2 failures
       "export-importer-schedule" = { metric = "export-importer/schedule/success", window = "35m" },
 


### PR DESCRIPTION
This also includes a slight behavior change to prevent the export worker from sitting in a hot loop if the database is unavailable.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Switch export to forward progress monitoring
```