### PR TITLE
Add special "_all" key to apply to all service environments

### DIFF
--- a/terraform/service_admin_console.tf
+++ b/terraform/service_admin_console.tf
@@ -96,6 +96,7 @@ resource "google_cloud_run_service" "admin-console" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "admin-console", {}),
           )
 

--- a/terraform/service_backup.tf
+++ b/terraform/service_backup.tf
@@ -103,6 +103,7 @@ resource "google_cloud_run_service" "backup" {
             },
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "backup", {}),
           )
 

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -96,6 +96,7 @@ resource "google_cloud_run_service" "cleanup-export" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "cleanup_export", {}),
           )
 

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -90,6 +90,7 @@ resource "google_cloud_run_service" "cleanup-exposure" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "cleanup_exposure", {}),
           )
 

--- a/terraform/service_debugger.tf
+++ b/terraform/service_debugger.tf
@@ -96,6 +96,7 @@ resource "google_cloud_run_service" "debugger" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "debugger", {}),
           )
 

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -102,6 +102,7 @@ resource "google_cloud_run_service" "export" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "export", {}),
           )
 

--- a/terraform/service_export_importer.tf
+++ b/terraform/service_export_importer.tf
@@ -90,6 +90,7 @@ resource "google_cloud_run_service" "export-importer" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "export-importer", {}),
           )
 

--- a/terraform/service_exposure.tf
+++ b/terraform/service_exposure.tf
@@ -107,6 +107,7 @@ resource "google_cloud_run_service" "exposure" {
             },
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "exposure", {}),
           )
 

--- a/terraform/service_federationin.tf
+++ b/terraform/service_federationin.tf
@@ -90,6 +90,7 @@ resource "google_cloud_run_service" "federationin" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "federationin", {}),
           )
 

--- a/terraform/service_federationout.tf
+++ b/terraform/service_federationout.tf
@@ -90,6 +90,7 @@ resource "google_cloud_run_service" "federationout" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "federationout", {}),
           )
 

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -90,6 +90,7 @@ resource "google_cloud_run_service" "generate" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "generate", {}),
           )
 

--- a/terraform/service_jwks.tf
+++ b/terraform/service_jwks.tf
@@ -90,6 +90,7 @@ resource "google_cloud_run_service" "jwks" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "jwks", {}),
           )
 

--- a/terraform/service_keyrotation.tf
+++ b/terraform/service_keyrotation.tf
@@ -106,6 +106,7 @@ resource "google_cloud_run_service" "key-rotation" {
             },
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "key_rotation", {}),
           )
 

--- a/terraform/service_mirror.tf
+++ b/terraform/service_mirror.tf
@@ -90,6 +90,7 @@ resource "google_cloud_run_service" "mirror" {
             local.common_cloudrun_env_vars,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "mirror", {}),
           )
 

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -239,7 +239,7 @@ variable "service_environment" {
   type    = map(map(string))
   default = {}
 
-  description = "Per-service environment overrides."
+  description = "Per-service environment overrides. The special key \"_all\" will apply to all services. This is useful for common configuration like log-levels. A service-specific configuration overrides a value in \"_all\"."
 }
 
 variable "admin_console_hosts" {


### PR DESCRIPTION
This makes it easier (and less error-prone) to set a common configuration like `LOG_LEVEL` on all services at once.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add special "_all" key to apply to all service environments. The special key `_all` will apply to all services. This is useful for common configuration like log-levels. A service-specific configuration overrides a value in `_all`. There are no default values for `_all`, so the default behavior is unchanged.
```