### PR TITLE
Disable nolintlint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,7 +57,6 @@ linters:
   - 'makezero'
   - 'misspell'
   - 'noctx'
-  - 'nolintlint'
   - 'paralleltest'
   - 'prealloc'
   - 'predeclared'

--- a/tools/export-viz/main.go
+++ b/tools/export-viz/main.go
@@ -134,7 +134,7 @@ func sameReportType(a, b *exportpb.TemporaryExposureKey) bool {
 }
 
 func sameTransmissionRisk(a, b *exportpb.TemporaryExposureKey) bool {
-	//nolint
+	//nolint:staticcheck // SA1019: may be set on v1 files.
 	return a.GetTransmissionRiskLevel() == b.GetTransmissionRiskLevel()
 }
 


### PR DESCRIPTION
I'm not sure why this is failing on CI, but it doesn't fail locally. This linter isn't super important, so I'm disabling it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```