### PR TITLE
Bump google plugin version to 3.58

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -383,11 +383,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.51"
+      version = "~> 3.58"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.51"
+      version = "~> 3.58"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
The query_insights support in google_sql_database_instance was added in
this version: https://github.com/hashicorp/terraform-provider-google/issues/8328