### PR TITLE
Increase metric frequency to every 15s, timeout after 10s

### DIFF
--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -65,16 +65,16 @@ type StackdriverConfig struct {
 
 	// The following options are mostly for tuning the metrics reporting
 	// behavior. You normally should not change these values.
-	// ReportingInterval: should be >=60s as stackdriver enforces 60s minimal
+	// ReportingInterval: should be >=10s as stackdriver enforces 10s minimal
 	// interval.
 	// BundleDelayThreshold / BundleCountThreshold: the stackdriver exporter
 	// uses https://google.golang.org/api/support/bundler, these two options
 	// control the max delay/count for batching the data points into one
 	// stackdriver request.
-	ReportingInterval    time.Duration `env:"STACKDRIVER_REPORTING_INTERVAL, default=2m"`
+	ReportingInterval    time.Duration `env:"STACKDRIVER_REPORTING_INTERVAL, default=15s"`
 	BundleDelayThreshold time.Duration `env:"STACKDRIVER_BUNDLE_DELAY_THRESHOLD, default=2s"`
 	BundleCountThreshold uint          `env:"STACKDRIVER_BUNDLE_COUNT_THRESHOLD, default=50"`
-	Timeout              time.Duration `env:"STACKDRIVER_TIMEOUT, default=1m"`
+	Timeout              time.Duration `env:"STACKDRIVER_TIMEOUT, default=10s"`
 
 	// The Cloud Run services are exporting many metrics that we get for free
 	// from the OpenCensus libaries. You can control whether to exclude some of


### PR DESCRIPTION
The updated documentation notes that metrics can be sent every 10s instead of every 60s.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Increase Stackdriver metric export frequency to every 15s, timeout after 10s.
```