### PR TITLE
Add artificial counter to in-memory secrets write

### DIFF
--- a/pkg/secrets/in_memory.go
+++ b/pkg/secrets/in_memory.go
@@ -20,7 +20,6 @@ import (
 	"path"
 	"strconv"
 	"sync"
-	"time"
 )
 
 func init() {
@@ -34,6 +33,7 @@ var _ SecretVersionManager = (*InMemory)(nil)
 type InMemory struct {
 	mu      sync.Mutex
 	secrets map[string][]byte
+	counter int64
 }
 
 // NewInMemory creates a new in-memory secret manager.
@@ -77,8 +77,8 @@ func (sm *InMemory) CreateSecretVersion(ctx context.Context, parent string, data
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	version := strconv.FormatInt(time.Now().UnixNano(), 10)
-	k := path.Join(parent, version)
+	sm.counter++
+	k := path.Join(parent, strconv.FormatInt(sm.counter, 10))
 	sm.secrets[k] = data
 	return k, nil
 }


### PR DESCRIPTION
I have some flakey tests because, even with the mutex, its possible that two operations occur in the same unix timestamp. Since this is just for local dev/test, having a constantly incrementing number seems fine.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```