### PR TITLE
Actually allow health check

### DIFF
--- a/pkg/server/healthz.go
+++ b/pkg/server/healthz.go
@@ -27,7 +27,7 @@ import (
 
 // dbPingLimiter limits when we actually ping the database to at most 1/sec to
 // prevent a DOS since this is an unauthenticated endpoint.
-var dbPingLimiter = rate.NewLimiter(rate.Every(1*time.Second), 0)
+var dbPingLimiter = rate.NewLimiter(rate.Every(1*time.Second), 1)
 
 func HandleHealthz(db *database.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-server/issues/1508

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix an issue where database checks may not run during health checks.
```