### PR TITLE
Fix regular expression escaping on path matcher

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -384,7 +384,7 @@ EOT
   }
 
   label_extractors = {
-    "path"     = "REGEXP_EXTRACT(httpRequest.requestUrl, \"https?://.+/(.+)/index\\\\\\\\.txt\")"
+    "path"     = "REGEXP_EXTRACT(httpRequest.requestUrl, \"https?://.+/(.+)/index\\\\.txt\")"
     "platform" = "REGEXP_EXTRACT(httpRequest.userAgent, \"(Android|Darwin)\")"
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,9 +26,6 @@ provider "google-beta" {
   user_project_override = true
 }
 
-# To generate passwords.
-provider "random" {}
-
 data "google_project" "project" {
   project_id = var.project
 }


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix an issue with the path matcher for the `export_file_downloaded` logs-based metric.
```