### PR TITLE
Allow more time to export, increase workers

### DIFF
--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -74,7 +74,7 @@ type StackdriverConfig struct {
 	ReportingInterval    time.Duration `env:"STACKDRIVER_REPORTING_INTERVAL, default=15s"`
 	BundleDelayThreshold time.Duration `env:"STACKDRIVER_BUNDLE_DELAY_THRESHOLD, default=2s"`
 	BundleCountThreshold uint          `env:"STACKDRIVER_BUNDLE_COUNT_THRESHOLD, default=50"`
-	Timeout              time.Duration `env:"STACKDRIVER_TIMEOUT, default=10s"`
+	Timeout              time.Duration `env:"STACKDRIVER_TIMEOUT, default=15s"`
 
 	// The Cloud Run services are exporting many metrics that we get for free
 	// from the OpenCensus libaries. You can control whether to exclude some of


### PR DESCRIPTION
According to the docs, the minimum number of workers needs to be 1, and I looked in the stackdriver exporter code and do not see a default value set. I'm hoping that by bumping the timeout and increasing the number of workers, we can reduce the number of "failed to export metric" errors in logs.

All numbers were chosen arbitrarily and are up for debate.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Increase statistics export timeout to 15s and set minimum number of workers.
```