### PR TITLE
Return 500 instead of 404 when health authority fails to load

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -252,7 +252,7 @@ func (s *Server) process(ctx context.Context, data *verifyapi.Publish, platform 
 		blame = obs.BlameServer
 		obsResult = obs.ResultError("ERROR_LOADING_HEALTH_AUTHORITY")
 		return &response{
-			status: http.StatusNotFound,
+			status: http.StatusInternalServerError,
 			pubResponse: &verifyapi.PublishResponse{
 				ErrorMessage: message,
 				Code:         verifyapi.ErrorUnableToLoadHealthAuthority,


### PR DESCRIPTION
There's already a check above to handle the NotFound case

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Return a 500 response instead of a 404 when an error occurs while trying to find the health authority.
```