### PR TITLE
add metrics for future dated JWT

### DIFF
--- a/internal/publish/metrics.go
+++ b/internal/publish/metrics.go
@@ -29,6 +29,9 @@ var (
 
 	mLatencyMs = stats.Float64(publishMetricsPrefix+"requests", "publish requests", stats.UnitMilliseconds)
 
+	mJWTNotYetValid = stats.Int64(publishMetricsPrefix+"jwt_not_yet_valid",
+		"a certificate was presented with an IAT or NBF time that is in the past according to thie server", stats.UnitDimensionless)
+
 	mNoPublicKey = stats.Int64(publishMetricsPrefix+"no_public_keys",
 		"uploads where there is no public key", stats.UnitDimensionless)
 
@@ -99,6 +102,13 @@ func init() {
 			Description: "Total count of health authority verification being bypassed",
 			Measure:     mVerificationBypassed,
 			Aggregation: view.Sum(),
+		},
+		{
+			Name:        metrics.MetricRoot + "jwt_not_yet_valid",
+			Description: "Total count of instances where a verification certificate is in the future",
+			Measure:     mJWTNotYetValid,
+			Aggregation: view.Sum(),
+			TagKeys:     missingPublicKeyTags,
 		},
 		// v1 and v1alpha1
 		{

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -426,7 +426,7 @@ func TestPublishWithBypass(t *testing.T) {
 			Regions:   []string{regions.current()},
 			JWTTiming: time.Hour,
 			Code:      http.StatusUnauthorized,
-			Error:     "unable to validate diagnosis verification: Token used before issued",
+			Error:     "unable to validate diagnosis verification: not valid yet (NBF or IAT) in the future",
 		},
 		{
 			Name: "certificate expired",

--- a/internal/verification/phaverify.go
+++ b/internal/verification/phaverify.go
@@ -35,9 +35,11 @@ import (
 	"github.com/dgrijalva/jwt-go"
 )
 
-// ErrNoPublicKeys indicates no public keys were found when verifying the certificate.
-var ErrNoPublicKeys = errors.New("no active public keys for health authority")
-var ErrNotValidYet = errors.New("not valid yet (NBF or IAT) in the future")
+var (
+	// ErrNoPublicKeys indicates no public keys were found when verifying the certificate.
+	ErrNoPublicKeys = errors.New("no active public keys for health authority")
+	ErrNotValidYet  = errors.New("not valid yet (NBF or IAT) in the future")
+)
 
 // Verifier can be used to verify public health authority diagnosis verification certificates.
 type Verifier struct {

--- a/internal/verification/phaverify_test.go
+++ b/internal/verification/phaverify_test.go
@@ -75,7 +75,7 @@ func TestVerifyCertificate(t *testing.T) {
 		{
 			Name:  "future",
 			Warp:  1 * time.Hour,
-			Error: "Token used before issued",
+			Error: ErrNotValidYet.Error(),
 		},
 		{
 			Name:          "invalid hmac",


### PR DESCRIPTION
## Proposed Changes

* introduce a new metric for future JWT (NBF and/or IAT in the future)

**Release Note**


```release-note
Adds a new metric 'en-server/jwt_not_yet_valid' that will be incremented when the server processes a JWT that is future dated according to either the IAT or NBF field of a properly signed verification certificate JWT.
```