### PR TITLE
release key server stats 48 hours after end of UTC day even if not en…

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -108,7 +108,9 @@ type Config struct {
 	// Publish stats API config
 	// Minimum number of publish requests that need to be present to see stats for a given day.
 	// If the minimum is not met, that day is not revealed or shown in aggregates.
-	StatsUploadMinimum           int64         `env:"STATS_UPLOAD_MINIMUM, default=10"`
+	StatsUploadMinimum int64 `env:"STATS_UPLOAD_MINIMUM, default=10"`
+	// Allow release of a day's stats after this much time has passed (measured from end of day).
+	// Set to <= 0 to disable this feature.
 	StatsEmbargoPeriod           time.Duration `env:"STATS_EMBARGO_PERIOD, default=48h"`
 	StatsResponsePaddingMinBytes int64         `env:"RESPONSE_PADDING_MIN_BYTES, default=2048"`
 	StatsResponsePaddingRange    int64         `env:"RESPONSE_PADDING_RANGE, default=1024"`

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -108,9 +108,10 @@ type Config struct {
 	// Publish stats API config
 	// Minimum number of publish requests that need to be present to see stats for a given day.
 	// If the minimum is not met, that day is not revealed or shown in aggregates.
-	StatsUploadMinimum           int64 `env:"STATS_UPLOAD_MINIMUM, default=10"`
-	StatsResponsePaddingMinBytes int64 `env:"RESPONSE_PADDING_MIN_BYTES, default=2048"`
-	StatsResponsePaddingRange    int64 `env:"RESPONSE_PADDING_RANGE, default=1024"`
+	StatsUploadMinimum           int64         `env:"STATS_UPLOAD_MINIMUM, default=10"`
+	StatsEmbargoPeriod           time.Duration `env:"STATS_EMBARGO_PERIOD, default=48h"`
+	StatsResponsePaddingMinBytes int64         `env:"RESPONSE_PADDING_MIN_BYTES, default=2048"`
+	StatsResponsePaddingRange    int64         `env:"RESPONSE_PADDING_RANGE, default=1024"`
 }
 
 func (c *Config) MaintenanceMode() bool {

--- a/internal/publish/stats.go
+++ b/internal/publish/stats.go
@@ -103,7 +103,7 @@ func (s *Server) handleMetricsRequest(ctx context.Context, bearerToken string, r
 	onlyBefore := time.Now().UTC().Truncate(time.Hour)
 
 	// Combine days - this also filters things that are "too new" and days that don't meet the threshold.
-	response.Days = model.ReduceStats(stats, onlyBefore, s.config.StatsUploadMinimum)
+	response.Days = model.ReduceStats(stats, onlyBefore, s.config.StatsUploadMinimum, s.config.StatsEmbargoPeriod)
 
 	// return
 	return response, http.StatusOK


### PR DESCRIPTION
…ough entries

## Proposed Changes

* introduce new config for stats embargo period
* if stats embargo period has passed (measured from end of UTC day) and there are not enough publish requests, release the stats (that are currently held back)

**Release Note**

```release-note
NOTICE: This changes the behavior of the stats API. Introduces an embargo period for publish stats. If a health authority has low publish request, below the STATS_UPLOAD_MINIMUM, this allows you to release their stats after a certain embargo period has been met.
```