### PR TITLE
Always display signature and public key on signinfo

### DIFF
--- a/internal/admin/templates/siginfo.html
+++ b/internal/admin/templates/siginfo.html
@@ -10,13 +10,6 @@
     {{end}}
   </div>
   <div class="card-body">
-    {{if .signature}}
-      <div class="alert alert-info" role="alert">
-        <p class="mb-0">
-          The signature for the string "hello world" for this key is <code>{{.signature}}</code>.
-        </p>
-      </div>
-    {{end}}
     {{if not .new}}
       <div class="alert alert-warning" role="alert">
         <p>
@@ -30,21 +23,38 @@
           days (or a time advised by Apple and Google).
         </p>
       </div>
-
-      <div class="alert alert-info" role="alert">
-        Signature Info configurations cannot be deleted. Instead they are
-        expired by setting and end date and time.
-      </div>
     {{end}}
 
     <form method="POST" action="/siginfo/{{.siginfo.ID}}" class="floating-form">
       <div class="form-label-group">
         <input type="text" name="signing-key" id="signing-key" value="{{.siginfo.SigningKey}}"
-          placeholder="signing-key" class="form-control">
+          placeholder="signing-key" class="form-control form-control-sm text-monospace">
         <label for="signing-key">Signing key</label>
         <small class="form-text text-muted">
           The resource ID of the signing key. The exact format will be dependent
           on the Key Management System that you are using.
+        </small>
+      </div>
+
+      <div class="form-label-group">
+        <input type="text" name="signing-key-id" id="signing-key-id" value="{{.siginfo.SigningKeyID}}"
+          placeholder="Signing key ID" class="form-control form-control-sm text-monospace">
+        <label for="signing-key-id">Signing key ID</label>
+        <small class="form-text text-muted">
+          This will normally be the Mobile Country Code (<a
+          href="https://en.wikipedia.org/wiki/Mobile_country_code"
+          target="_blank">MCC</a>) for the region that your export covers.
+          This should be coordinated with Google and Apple.
+        </small>
+      </div>
+
+      <div class="form-label-group">
+        <input type="text" name="signing-key-version" id="signing-key-version" value="{{.siginfo.SigningKeyVersion}}"
+          placeholder="Signing key version" class="form-control form-control-sm text-monospace">
+        <label for="signing-key-version">Signing key version</label>
+        <small class="form-text text-muted">
+          The version of the signing key. Normally will be v1, but may change
+          with key rotation.
         </small>
       </div>
 
@@ -67,33 +77,39 @@
           For Export Configurations that reference this key #, this signature
           will be added up until this date/time. If the time is blank, the key
           will end at 00:00 UTC on the day specified. <strong>Leave blank to use
-          this key as long as it is attached to an export</strong>
+          this key as long as it is attached to an export!</strong> Signature
+          Infos cannot be deleted. Instead they are expired by setting an end
+          date and time.
         </small>
       </div>
 
-      <div class="form-label-group">
-          <input type="text" name="signing-key-id" id="signing-key-id" value="{{.siginfo.SigningKeyID}}"
-            placeholder="Signing key ID" class="form-control">
-          <label for="signing-key-id">Signing key ID</label>
+      {{if or .public .signature}}
+        <hr>
+      {{end}}
+
+      {{if .public}}
+        <div class="form-label-group">
+          <textarea id="public-key" placeholder="Public key" rows="4" readonly
+            class="form-control form-control-sm text-monospace">{{.public}}</textarea>
+          <label for="public-key">Public key</label>
           <small class="form-text text-muted">
-            This will normally be the Mobile Country Code (<a
-            href="https://en.wikipedia.org/wiki/Mobile_country_code"
-            target="_blank">MCC</a>) for the region that your export covers.
-            This should be coordinated with Google and Apple.
+            This is the public key PEM for the signing key resource ID above.
           </small>
-      </div>
+        </div>
+      {{end}}
 
-      <div class="form-label-group">
-        <input type="text" name="signing-key-version" id="signing-key-version" value="{{.siginfo.SigningKeyVersion}}"
-          placeholder="Signing key version" class="form-control">
-        <label for="signing-key-version">Signing key version</label>
-        <small class="form-text text-muted">
-          The version of the signing key. Normally will be v1, but may change
-          with key rotation.
-        </small>
-      </div>
+      {{if .signature}}
+        <div class="form-label-group">
+          <textarea id="hello-world-signature" placeholder="Signature" rows="1" readonly
+            class="form-control form-control-sm text-monospace">{{.signature}}</textarea>
+          <label for="hello-world-signature">"Hello world" signature</label>
+          <small class="form-text text-muted">
+            This is a signature for the string "hello world". This signature
+            will change if you refresh the page, but all signatures are valid.
+          </small>
+        </div>
+      {{end}}
 
-      <hr/>
       <button type="submit" class="mt-5 btn btn-block btn-primary" value="save">Save changes</button>
     </form>
   </div>


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Always display signature and public key on signinfo view page.
```