### PR TITLE
Expire build caches in 7 days

### DIFF
--- a/terraform/build.tf
+++ b/terraform/build.tf
@@ -20,14 +20,14 @@ resource "google_storage_bucket" "cloudbuild-cache" {
   force_destroy               = true
   uniform_bucket_level_access = true
 
-  // Automatically expire cached objects after 14 days.
+  // Automatically expire cached objects.
   lifecycle_rule {
     action {
       type = "Delete"
     }
 
     condition {
-      age = "14"
+      age = "7"
     }
   }
 


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```