### PR TITLE
ensure stats embargo period is at least the supported minimum

### DIFF
--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -108,9 +108,11 @@ type Config struct {
 	// Publish stats API config
 	// Minimum number of publish requests that need to be present to see stats for a given day.
 	// If the minimum is not met, that day is not revealed or shown in aggregates.
+	// This value must be >= 10
 	StatsUploadMinimum int64 `env:"STATS_UPLOAD_MINIMUM, default=10"`
 	// Allow release of a day's stats after this much time has passed (measured from end of day).
 	// Set to <= 0 to disable this feature.
+	// If the value is positive, it must be >= 48h.
 	StatsEmbargoPeriod           time.Duration `env:"STATS_EMBARGO_PERIOD, default=48h"`
 	StatsResponsePaddingMinBytes int64         `env:"RESPONSE_PADDING_MIN_BYTES, default=2048"`
 	StatsResponsePaddingRange    int64         `env:"RESPONSE_PADDING_RANGE, default=1024"`
@@ -137,9 +139,9 @@ func (c *Config) Validate() error {
 			fmt.Errorf("env var `STATS_UPLOAD_MINIMUM` must be >= 10, got: %v", c.StatsUploadMinimum))
 	}
 
-	if c.StatsEmbargoPeriod < (48 * time.Hour) {
+	if ep := c.StatsEmbargoPeriod; !(ep >= (48*time.Hour) || ep <= 0) {
 		result = multierror.Append(result,
-			fmt.Errorf("env var `STATS_EMBARGO_PERIOD` must be >= 48h"))
+			fmt.Errorf("env var `STATS_EMBARGO_PERIOD` must be >= 48h or <= 0 to disable release of stats days below the threshold"))
 	}
 
 	return result.ErrorOrNil()

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -137,6 +137,11 @@ func (c *Config) Validate() error {
 			fmt.Errorf("env var `STATS_UPLOAD_MINIMUM` must be >= 10, got: %v", c.StatsUploadMinimum))
 	}
 
+	if c.StatsEmbargoPeriod < (48 * time.Hour) {
+		result = multierror.Append(result,
+			fmt.Errorf("env var `STATS_EMBARGO_PERIOD` must be >= 48h"))
+	}
+
 	return result.ErrorOrNil()
 }
 

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -502,7 +502,6 @@ func TestPublishWithBypass(t *testing.T) {
 				config.MaxSameStartIntervalKeys = 2
 				config.MaxIntervalAge = 14 * 24 * time.Hour
 				config.StatsUploadMinimum = 10
-				config.StatsEmbargoPeriod = 48 * time.Hour
 				aaProvider, err := authorizedapp.NewDatabaseProvider(ctx, testDB, config.AuthorizedAppConfig())
 				if err != nil {
 					t.Fatal(err)

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -502,6 +502,7 @@ func TestPublishWithBypass(t *testing.T) {
 				config.MaxSameStartIntervalKeys = 2
 				config.MaxIntervalAge = 14 * 24 * time.Hour
 				config.StatsUploadMinimum = 10
+				config.StatsEmbargoPeriod = 48 * time.Hour
 				aaProvider, err := authorizedapp.NewDatabaseProvider(ctx, testDB, config.AuthorizedAppConfig())
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
Fixes #1535

**Release Note**

```release-note
Adds validation for minimum value of STATS_EMBARGO_PERIOD env var.
```