### PR TITLE
Log when o11y exporter starts and stops

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -172,11 +172,11 @@ func SetupWith(ctx context.Context, config interface{}, l envconfig.Lookuper) (*
 		logger.Info("configuring observability exporter")
 
 		oeConfig := provider.ObservabilityExporterConfig()
-		oe, err := observability.NewFromEnv(oeConfig)
+		oe, err := observability.NewFromEnv(ctx, oeConfig)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create observability provider: %w", err)
 		}
-		if err := oe.StartExporter(ctx); err != nil {
+		if err := oe.StartExporter(); err != nil {
 			return nil, fmt.Errorf("failed to start observability: %w", err)
 		}
 		exporter := serverenv.WithObservabilityExporter(oe)

--- a/pkg/observability/noop.go
+++ b/pkg/observability/noop.go
@@ -27,7 +27,7 @@ func NewNoop(_ context.Context) (Exporter, error) {
 	return &noopExporter{}, nil
 }
 
-func (g *noopExporter) StartExporter(_ context.Context) error {
+func (g *noopExporter) StartExporter() error {
 	return nil
 }
 

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -151,16 +151,12 @@ func AllViews() []*view.View {
 // used by this application.
 type Exporter interface {
 	io.Closer
-	StartExporter(ctx context.Context) error
+	StartExporter() error
 }
 
 // NewFromEnv returns the observability exporter given the provided configuration, or an error
 // if it failed to be created.
-func NewFromEnv(config *Config) (Exporter, error) {
-	// Create a separate ctx.
-	// The main ctx will be canceled when the server is shutting down. Sharing
-	// the main ctx prevent the last batch of the metrics to be uploaded.
-	ctx := context.Background()
+func NewFromEnv(ctx context.Context, config *Config) (Exporter, error) {
 	switch config.ExporterType {
 	case ExporterNoop:
 		return NewNoop(ctx)

--- a/pkg/observability/opencensus.go
+++ b/pkg/observability/opencensus.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 
 	"contrib.go.opencensus.io/exporter/ocagent"
+	"github.com/google/exposure-notifications-server/pkg/logging"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
+	"go.uber.org/zap"
 )
 
 var _ Exporter = (*opencensusExporter)(nil)
@@ -28,10 +30,13 @@ var _ Exporter = (*opencensusExporter)(nil)
 type opencensusExporter struct {
 	exporter *ocagent.Exporter
 	config   *OpenCensusConfig
+	logger   *zap.SugaredLogger
 }
 
 // NewOpenCensus creates a new metrics and trace exporter for OpenCensus.
 func NewOpenCensus(ctx context.Context, config *OpenCensusConfig) (Exporter, error) {
+	logger := logging.FromContext(ctx).Named("opencensus")
+
 	var opts []ocagent.ExporterOption
 	if config.Insecure {
 		opts = append(opts, ocagent.WithInsecure())
@@ -44,11 +49,18 @@ func NewOpenCensus(ctx context.Context, config *OpenCensusConfig) (Exporter, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to create opencensus exporter: %w", err)
 	}
-	return &opencensusExporter{oc, config}, nil
+	return &opencensusExporter{
+		exporter: oc,
+		config:   config,
+		logger:   logger,
+	}, nil
 }
 
 // StartExporter starts the exporter.
-func (e *opencensusExporter) StartExporter(_ context.Context) error {
+func (e *opencensusExporter) StartExporter() error {
+	e.logger.Debugw("starting observability exporter")
+	defer e.logger.Debugw("finished starting observability exporter")
+
 	trace.ApplyConfig(trace.Config{
 		DefaultSampler: trace.ProbabilitySampler(e.config.SampleRate),
 	})
@@ -66,6 +78,9 @@ func (e *opencensusExporter) StartExporter(_ context.Context) error {
 
 // Close halts the exporter.
 func (e *opencensusExporter) Close() error {
+	e.logger.Debugw("closing observability exporter")
+	defer e.logger.Debugw("finished closing observability exporter")
+
 	if err := e.exporter.Stop(); err != nil {
 		return fmt.Errorf("failed to stop exporter: %w", err)
 	}


### PR DESCRIPTION
This involved a slight refactor to the way the logger is passed to the exporters. I noticed that the current logger didn't have the build_id or other metadata injected. That's because it wasn't getting the correct context plumbed through. This also fixes that.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```