### PR TITLE
Skip default metrics registration outside of metrics-registrar

### DIFF
--- a/pkg/observability/config.go
+++ b/pkg/observability/config.go
@@ -81,4 +81,10 @@ type StackdriverConfig struct {
 	// them using the option below.
 	// Specify them using comma separated strings in envvar.
 	ExcludedMetricPrefixes []string `env:"STACKDRIVER_EXCLUDED_METRIC_PREFIXES"`
+
+	// RegisterMetrics instructs the loader to registering metrics. This is useful
+	// if you have another process which is responsible for registering metrics or
+	// if you aren't using any custom metrics. By default, metrics are not
+	// registered.
+	RegisterMetrics bool `env:"STACKDRIVER_REGISTER_METRICS"`
 }

--- a/pkg/observability/stackdriver.go
+++ b/pkg/observability/stackdriver.go
@@ -70,6 +70,7 @@ func NewStackdriver(ctx context.Context, config *StackdriverConfig) (Stackdriver
 		NumberOfWorkers:         numWorkers,
 		BundleCountThreshold:    int(config.BundleCountThreshold),
 		MonitoredResource:       monitoredResource,
+		SkipCMD:                 !config.RegisterMetrics,
 		DefaultMonitoringLabels: &stackdriver.Labels{},
 		OnError: func(err error) {
 			logger.Errorw("failed to export metric", "error", err, "resource", monitoredResource)

--- a/terraform/service_metrics_registrar.tf
+++ b/terraform/service_metrics_registrar.tf
@@ -75,6 +75,9 @@ resource "google_cloud_run_service" "metrics-registrar" {
         dynamic "env" {
           for_each = merge(
             local.common_cloudrun_env_vars,
+            {
+              "STACKDRIVER_REGISTER_METRICS" = true
+            },
 
             // This MUST come last to allow overrides!
             lookup(var.service_environment, "_all", {}),


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```