### PR TITLE
include platform tag in publish controller logs

### DIFF
--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -219,7 +219,8 @@ func (s *Server) process(ctx context.Context, data *verifyapi.Publish, platform 
 	defer obs.RecordLatency(ctx, time.Now(), mLatencyMs, &blame, &obsResult)
 
 	logger := logging.FromContext(ctx).Named("process").
-		With("health_authority_id", data.HealthAuthorityID)
+		With("health_authority_id", data.HealthAuthorityID).
+		With("platform", platform)
 
 	logger.Info("publish API request")
 


### PR DESCRIPTION

## Proposed Changes

* Add platform to publish logs so that issues can be debugged easier and isolate issues to one client platform is possible.

**Release Note**

```release-note
Include client platform as a tag in logs from the publish service: android, ios, or unkown.
```