### PR TITLE
Make scheduler timezone configurable, default to UTC

### DIFF
--- a/terraform/service_backup.tf
+++ b/terraform/service_backup.tf
@@ -173,7 +173,7 @@ resource "google_cloud_scheduler_job" "backup-worker" {
   name             = "backup-worker"
   region           = var.cloudscheduler_location
   schedule         = "0 */4 * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.backup.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {

--- a/terraform/service_cleanup_export.tf
+++ b/terraform/service_cleanup_export.tf
@@ -166,7 +166,7 @@ resource "google_cloud_scheduler_job" "cleanup-export-worker" {
   name             = "cleanup-export-worker"
   region           = var.cloudscheduler_location
   schedule         = var.cleanup_export_worker_cron_schedule
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_cleanup_exposure.tf
+++ b/terraform/service_cleanup_exposure.tf
@@ -160,7 +160,7 @@ resource "google_cloud_scheduler_job" "cleanup-exposure-worker" {
   name             = "cleanup-exposure-worker"
   region           = var.cloudscheduler_location
   schedule         = var.cleanup_exposure_worker_cron_schedule
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_export.tf
+++ b/terraform/service_export.tf
@@ -176,7 +176,7 @@ resource "google_cloud_scheduler_job" "export-worker" {
   name             = "export-worker"
   region           = var.cloudscheduler_location
   schedule         = var.export_worker_cron_schedule
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "600s"
 
   retry_config {
@@ -203,7 +203,7 @@ resource "google_cloud_scheduler_job" "export-create-batches" {
   name             = "export-create-batches"
   region           = var.cloudscheduler_location
   schedule         = var.export_create_batches_cron_schedule
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_export_importer.tf
+++ b/terraform/service_export_importer.tf
@@ -164,7 +164,7 @@ resource "google_cloud_scheduler_job" "export-importer-worker" {
   name             = "export-importer-worker"
   region           = var.cloudscheduler_location
   schedule         = "*/5 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "600s"
 
   retry_config {
@@ -191,7 +191,7 @@ resource "google_cloud_scheduler_job" "export-importer-schedule" {
   name             = "export-importer-schedule"
   region           = var.cloudscheduler_location
   schedule         = "*/15 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_generate.tf
+++ b/terraform/service_generate.tf
@@ -163,7 +163,7 @@ locals {
 resource "google_cloud_scheduler_job" "generate-worker" {
   name             = "generate-worker"
   schedule         = var.generate_cron_schedule
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "60s"
 
   retry_config {

--- a/terraform/service_jwks.tf
+++ b/terraform/service_jwks.tf
@@ -160,7 +160,7 @@ resource "google_cloud_scheduler_job" "jwks-worker" {
   name             = "jwks-worker"
   region           = var.cloudscheduler_location
   schedule         = "*/2 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_keyrotation.tf
+++ b/terraform/service_keyrotation.tf
@@ -180,7 +180,7 @@ resource "google_cloud_scheduler_job" "key-rotation-worker" {
   name             = "key-rotation-worker"
   region           = var.cloudscheduler_location
   schedule         = "* */4 * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_mirror.tf
+++ b/terraform/service_mirror.tf
@@ -164,7 +164,7 @@ resource "google_cloud_scheduler_job" "mirror-invoke" {
   name             = "mirror-invoke"
   region           = var.cloudscheduler_location
   schedule         = "*/5 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -67,6 +67,10 @@ variable "database_backup_schedule" {
   description = "Cron schedule in which to do a full backup of the database to Cloud Storage."
 }
 
+variable "cloud_scheduler_timezone" {
+  type    = string
+  default = "Etc/UTC"
+}
 
 variable "db_failover_replica_regions" {
   type    = list(string)


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make Cloud Scheduler timezone configurable in Terraform via `var.cloud_scheduler_timezone` and update the default value to UTC time.

```