### PR TITLE
upgrade chaff lib, cap max chaff latency at 1000ms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/kelseyhightower/run v0.0.17
 	github.com/lstoll/awskms v0.0.0-20210310122415-d1696e9c112b
-	github.com/mikehelmick/go-chaff v0.5.0
+	github.com/mikehelmick/go-chaff v0.6.0
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/rakutentech/jwk-go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1106,6 +1106,8 @@ github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WT
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mikehelmick/go-chaff v0.5.0 h1:u8lrTCbUsyVBFRHPs8Nn3i0830XAOrbcA5dbQl8tk78=
 github.com/mikehelmick/go-chaff v0.5.0/go.mod h1:mFry3zNW17oxNGmZpQV3PEOmzTNyly3nLDYawCT/iCE=
+github.com/mikehelmick/go-chaff v0.6.0 h1:RWn4tP+YI+MyCh+PsAyjr1zPFWpKX12Vzx1VXZYvcqk=
+github.com/mikehelmick/go-chaff v0.6.0/go.mod h1:mFry3zNW17oxNGmZpQV3PEOmzTNyly3nLDYawCT/iCE=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=

--- a/internal/publish/config.go
+++ b/internal/publish/config.go
@@ -116,6 +116,10 @@ type Config struct {
 	StatsEmbargoPeriod           time.Duration `env:"STATS_EMBARGO_PERIOD, default=48h"`
 	StatsResponsePaddingMinBytes int64         `env:"RESPONSE_PADDING_MIN_BYTES, default=2048"`
 	StatsResponsePaddingRange    int64         `env:"RESPONSE_PADDING_RANGE, default=1024"`
+
+	// ChaffRequestMaxLatencyMS prevents chaff request from consistently increasing latency
+	// if the server is under abnormal load.
+	ChaffRequestMaxLatencyMS uint64 `env:"CHAFF_REQUEST_MAX_LATENCY_MS, default=1000"`
 }
 
 func (c *Config) MaintenanceMode() bool {

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -114,7 +114,10 @@ func NewServer(ctx context.Context, cfg *Config, env *serverenv.ServerEnv) (*Ser
 		return nil, fmt.Errorf("config validation: %w", err)
 	}
 
-	chaffer, err := chaff.NewTracker(chaff.NewJSONResponder(chaffPublishResponse), chaff.DefaultCapacity)
+	chaffer, err := chaff.NewTracker(
+		chaff.NewJSONResponder(chaffPublishResponse),
+		chaff.DefaultCapacity,
+		chaff.WithMaxLatency(cfg.ChaffRequestMaxLatencyMS))
 	if err != nil {
 		return nil, fmt.Errorf("error making chaffer: %w", err)
 	}


### PR DESCRIPTION
**Release Note**

```release-note
Add configuration point for max chaff request latency, default of 1000ms.
```