### PR TITLE
Health Check Cache

### DIFF
--- a/pkg/server/healthz.go
+++ b/pkg/server/healthz.go
@@ -28,6 +28,8 @@ import (
 // dbPingLimiter limits when we actually ping the database to at most 1/sec to
 // prevent a DOS since this is an unauthenticated endpoint.
 var dbPingLimiter = rate.NewLimiter(rate.Every(1*time.Second), 1)
+
+// healthStatus caches our status while waiting for the dbPingLimiter
 var healthStatus bool = true
 
 func HandleHealthz(db *database.DB) http.Handler {


### PR DESCRIPTION
# Fixes #

If we have a failure threshold greater than 1, this would never be marked unhealthy.
It would return one unhealthy, and then healthy until the next `dbPingLimiter.Allow` and so on.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Cache the previous state, and use it until the next `dbPingLimiter.Allow`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
cache health check status
```