### PR TITLE
capture publish request per region as a metric

### DIFF
--- a/internal/publish/metrics.go
+++ b/internal/publish/metrics.go
@@ -38,6 +38,9 @@ var (
 	mExposuresCount = stats.Int64(publishMetricsPrefix+"exposures_count",
 		"exposure count", stats.UnitDimensionless)
 
+	mPublishRequest = stats.Int64(publishMetricsPrefix+"publish_requests",
+		"publish requests", stats.UnitDimensionless)
+
 	mVerificationBypassed = stats.Int64(publishMetricsPrefix+"verification_bypassed",
 		"Instances of health authority verification being bypassed", stats.UnitDimensionless)
 	// v1 and v1alpha1
@@ -61,6 +64,13 @@ var (
 	healthAuthorityIDTag = tag.MustNewKey("healthAuthorityID")
 	missingPublicKeyTags = []tag.Key{
 		healthAuthorityIDTag,
+	}
+
+	// For publish requests counts.
+	regionTag      = tag.MustNewKey("region")
+	publishTagKeys = []tag.Key{
+		healthAuthorityIDTag,
+		regionTag,
 	}
 )
 
@@ -96,6 +106,13 @@ func init() {
 			Measure:     mExposuresCount,
 			Aggregation: view.Count(),
 			TagKeys:     exposureTagKeys,
+		},
+		{
+			Name:        metrics.MetricRoot + "publish_requests",
+			Description: "Total count of publish requests",
+			Measure:     mPublishRequest,
+			Aggregation: view.Count(),
+			TagKeys:     publishTagKeys,
 		},
 		{
 			Name:        metrics.MetricRoot + "verification_bypassed_count",

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -513,6 +513,16 @@ func (s *Server) process(ctx context.Context, data *verifyapi.Publish, platform 
 			logger.Errorw("failed to record stats", "error", err)
 		}
 	}
+	// Backwards compat from v1alpha1 API, normally there is one region.
+	for _, region := range regions {
+		tags := []tag.Mutator{
+			tag.Upsert(healthAuthorityIDTag, data.HealthAuthorityID),
+			tag.Upsert(regionTag, region),
+		}
+		if err := stats.RecordWithTags(ctx, tags, mExposuresCount.M(int64(1))); err != nil {
+			logger.Errorw("failed to record publish request stats", "error", err)
+		}
+	}
 
 	return &response{
 		status:      http.StatusOK,


### PR DESCRIPTION

**Release Note**

```release-note
Ads publish requests as a metric; tagged by health authority ID and region.
```