### PR TITLE
Ensure metrics-registrar updates metric descriptors that already exist

### DIFF
--- a/terraform/service_metrics_registrar.tf
+++ b/terraform/service_metrics_registrar.tf
@@ -38,6 +38,10 @@ resource "google_project_iam_member" "metrics-registrar-observability" {
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     "roles/stackdriver.resourceMetadata.writer",
+
+    // The metrics-registrar needs permissions to delete metrics, which is only
+    // available in this role.
+    "roles/monitoring.editor",
   ])
 
   project = var.project


### PR DESCRIPTION
Same as https://github.com/google/exposure-notifications-verification-server/pull/2317

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```