### PR TITLE
add self report to export-importer functionality

### DIFF
--- a/internal/exportimport/import.go
+++ b/internal/exportimport/import.go
@@ -156,6 +156,7 @@ func (s *Server) ImportExportFile(ctx context.Context, ir *ImportRequest) (*Impo
 			BackfillSymptomOnset:      s.config.BackfillDaysSinceOnset,
 			BackfillSymptomOnsetValue: int32(s.config.BackfillDaysSinceOnsetValue),
 			MaxSymptomOnsetDays:       int32(s.config.MaxMagnitudeSymptomOnsetDays),
+			AllowSelfReport:           true,
 			AllowClinical:             true,
 			AllowRevoked:              false,
 		},
@@ -178,7 +179,8 @@ func (s *Server) ImportExportFile(ctx context.Context, ir *ImportRequest) (*Impo
 
 	// Then revised keys and revise.
 	if len(tekExport.RevisedKeys) > 0 {
-		// Revoked
+		// Can transition to revoked, cannot transition to self report or clinical.
+		exKeyTransform.exportImportConfig.AllowSelfReport = false
 		exKeyTransform.exportImportConfig.AllowClinical = false
 		exKeyTransform.exportImportConfig.AllowRevoked = true
 

--- a/internal/publish/model/exposure_model.go
+++ b/internal/publish/model/exposure_model.go
@@ -101,6 +101,7 @@ type ExportImportConfig struct {
 	BackfillSymptomOnset      bool
 	BackfillSymptomOnsetValue int32
 	MaxSymptomOnsetDays       int32
+	AllowSelfReport           bool
 	AllowClinical             bool
 	AllowRevoked              bool
 }
@@ -125,6 +126,8 @@ func FromExportKey(key *export.TemporaryExposureKey, config *ExportImportConfig)
 			exp.ReportType = verifyapi.ReportTypeClinical
 		case export.TemporaryExposureKey_REVOKED:
 			exp.ReportType = verifyapi.ReportTypeNegative
+		case export.TemporaryExposureKey_SELF_REPORT:
+			exp.ReportType = verifyapi.ReportTypeSelfReport
 		case export.TemporaryExposureKey_UNKNOWN:
 			exp.ReportType = ""
 		default:
@@ -136,6 +139,9 @@ func FromExportKey(key *export.TemporaryExposureKey, config *ExportImportConfig)
 		exp.ReportType = config.DefaultReportType
 	}
 
+	if !config.AllowSelfReport && exp.ReportType == verifyapi.ReportTypeSelfReport {
+		return nil, fmt.Errorf("saw self report key when not allowed")
+	}
 	if !config.AllowRevoked && exp.ReportType == verifyapi.ReportTypeNegative {
 		return nil, fmt.Errorf("saw revoked key when not allowed")
 	}


### PR DESCRIPTION
Fixes #1595

**Release Note**

```release-note
Allow for user-report typed keys to be exported through the export-import job.
```