### PR TITLE
add background mark and seep cache reclamation

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -75,6 +75,7 @@ func (c *Cache[T]) backgroundExpire() {
 	for {
 		select {
 		case <-c.stopChan:
+			close(c.stopChan)
 			return
 		case t := <-c.ticker.C:
 			c.mark(t.UnixNano())
@@ -88,6 +89,7 @@ func (c *Cache[T]) mark(t int64) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	for k, v := range c.data {
+		k := k
 		if t > v.expiresAt {
 			go c.purgeExpired(k, v.expiresAt)
 		}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -128,7 +128,9 @@ func TestMarkAndSweep(t *testing.T) {
 	timer := time.NewTimer(time.Millisecond * 150)
 	<-timer.C
 	// set two again so that it won't TTL
-	cache.Set("two", orderTwo)
+	if err := cache.Set("two", orderTwo); err != nil {
+		t.Fatal(err)
+	}
 
 	checkSize(t, cache, 3)
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -117,13 +117,14 @@ func TestMarkAndSweep(t *testing.T) {
 
 	cache.Set("one", orderOne)
 	cache.Set("two", orderTwo)
+	cache.Set("three", orderOne)
 
 	timer := time.NewTimer(time.Millisecond * 150)
 	<-timer.C
 	// set two again so that it won't TTL
 	cache.Set("two", orderTwo)
 
-	checkSize(t, cache, 2)
+	checkSize(t, cache, 3)
 
 	timer.Reset(time.Millisecond * 200)
 	<-timer.C

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -115,9 +115,15 @@ func TestMarkAndSweep(t *testing.T) {
 	orderOne := &order{Burgers: 1, Fries: 2}
 	orderTwo := &order{Burgers: 2, Fries: 3}
 
-	cache.Set("one", orderOne)
-	cache.Set("two", orderTwo)
-	cache.Set("three", orderOne)
+	if err := cache.Set("one", orderOne); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Set("two", orderTwo); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Set("three", orderOne); err != nil {
+		t.Fatal(err)
+	}
 
 	timer := time.NewTimer(time.Millisecond * 150)
 	<-timer.C


### PR DESCRIPTION

## Proposed Changes

* Remove expired cache entries proactively, rather than wait for them to be accessed again.

**Release Note**

```release-note
Proactive cache reclamation, should have minimal improvement in RAM usage.
```