### PR TITLE
Gracefully shutdown prometheus exporter

### DIFF
--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -17,41 +17,71 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/gorilla/mux"
 )
 
-// ServeMetricsIfPrometheus serves the opencensus metrics at /metrics when OBSERVABILITY_EXPORTER set to "prometheus"
-func ServeMetricsIfPrometheus(ctx context.Context) error {
+type MetricsDoneFunc func() error
+
+// ServeMetricsIfPrometheus serves the opencensus metrics at /metrics when
+// OBSERVABILITY_EXPORTER set to "prometheus".
+func ServeMetricsIfPrometheus(ctx context.Context) (MetricsDoneFunc, error) {
 	logger := logging.FromContext(ctx)
 
 	exporter := os.Getenv("OBSERVABILITY_EXPORTER")
-	metricsPort := os.Getenv("METRICS_PORT")
 	if strings.EqualFold(exporter, "prometheus") {
+		metricsPort := os.Getenv("METRICS_PORT")
 		if metricsPort == "" {
-			return fmt.Errorf("OBSERVABILITY_EXPORTER set to 'prometheus' but no METRICS_PORT set")
+			return nil, fmt.Errorf("OBSERVABILITY_EXPORTER set to 'prometheus' but no METRICS_PORT set")
 		}
 
 		exporter, err := prometheus.NewExporter(prometheus.Options{})
 		if err != nil {
-			return fmt.Errorf("failed to create prometheus exporter: %w", err)
+			return nil, fmt.Errorf("failed to create prometheus exporter: %w", err)
 		}
 
-		go func() {
-			r := mux.NewRouter()
-			r.Handle("/metrics", exporter)
+		r := mux.NewRouter()
+		r.Handle("/metrics", exporter)
+		srv := &http.Server{
+			Addr:              ":" + metricsPort,
+			ReadHeaderTimeout: 10 * time.Second,
+			Handler:           r,
+		}
 
-			logger.Debugf("Metrics endpoint listening on :%s", metricsPort)
-			if err := http.ListenAndServe(":"+metricsPort, r); err != nil {
-				logger.Debugf("error while serving metrics endpoint: %w", err)
+		// Start the server in the background.
+		go func() {
+			if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				logger.Errorw("failed to serve prometheus metrics", "error", err)
+				return
 			}
 		}()
+		logger.Debugw("prometheus exporter is running", "port", metricsPort)
+
+		// Create the shutdown closer.
+		metricsDone := func() error {
+			logger.Debugw("shutting down prometheus metrics exporter")
+
+			shutdownCtx, done := context.WithTimeout(context.Background(), 10*time.Second)
+			defer done()
+
+			if err := srv.Shutdown(shutdownCtx); err != nil {
+				return fmt.Errorf("failed to shutdown prometheus metrics exporter: %w", err)
+			}
+			logger.Debugw("finished shutting down prometheus metrics exporter")
+
+			return nil
+		}
+
+		return metricsDone, nil
 	}
-	return nil
+
+	return nil, nil
 }


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Gracefully shutdown the Prometheus metrics exporter when the server shuts down. This only applies if the Prometheus metrics exporter is enabled (it's off by default). This fixes a low probability issue that some metrics may be lost during shutdown.
```